### PR TITLE
Update Cicero client to cleaned up API

### DIFF
--- a/Neptune/lib/job_types/cicero_helper.rb
+++ b/Neptune/lib/job_types/cicero_helper.rb
@@ -338,9 +338,9 @@ class NeptuneManager
       NeptuneManager.log("Response class is [#{response.class}]")
       NeptuneManager.log("Response is [#{response.inspect}]")
 
-      state = response['state']
+      status = response['status']
       #start_time = response['start_time']
-      if state == "finished"
+      if status == "finished"
         NeptuneManager.log("Task with id [#{task_id}] has finished")
         break
       end
@@ -351,9 +351,9 @@ class NeptuneManager
       #end
 
       NeptuneManager.log("Current state of job with task id [#{task_id}], " +
-        "is #{state}, waiting for it to become 'finished'")
+        "is #{status}, waiting for it to become 'finished'")
       #NeptuneManager.log("Current state of job with task id [#{task_id}], started" +
-      #  " at #{start_time}, is '#{state}', waiting for it to become 'finished'")
+      #  " at #{start_time}, is '#{status}', waiting for it to become 'finished'")
       sleep(RETRY_TIME)
     }
 


### PR DESCRIPTION
Most things didn't change, except that in the task status data, "state" became "status". Instead of modifying the client, we could also revert the template code to use "state".

See [the Java implentation](https://github.com/ariofrio/oration/tree/089b96868c687f08fb57b0f522e2a42581a2a555/templates/appengine/java/src/main/java), more specifically, [ComputeServlet](https://github.com/ariofrio/oration/blob/089b96868c687f08fb57b0f522e2a42581a2a555/templates/appengine/java/src/main/java/ComputeServlet.java#L48).
