### PR TITLE
Manually specifying --appservers now properly disables autoscaling

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2943,7 +2943,7 @@ HOSTS
       return
     end
 
-    if @creds["autoscale"]
+    if @creds["autoscale"] == "true"
       Djinn.log_debug("Examining AppServers to autoscale them")
       perform_scaling_for_appservers()
     else


### PR DESCRIPTION
Properly checking if autoscaling should be used based on --autoscaling flag from tools, fixing issue #43. The problem was that we were checking for the boolean true for --autoscaling, instead of the literal string "true", which is what the tools were actually sending over.
