### PR TITLE
nginx config files written incorrectly in full proxy deployment

### DIFF
--- a/AppController/lib/nginx.rb
+++ b/AppController/lib/nginx.rb
@@ -80,13 +80,13 @@ module Nginx
   end
 
   # Creates a Nginx config file for the provided app name
-  def self.write_app_config(app_name, app_number, my_public_ip, proxy_port, static_handlers, login_ip)
+  def self.write_app_config(app_name, app_number, my_public_ip, my_private_ip, proxy_port, static_handlers, login_ip)
     static_locations = static_handlers.map { |handler| HelperFunctions.generate_location_config(handler) }.join
     listen_port = Nginx.app_listen_port(app_number)
     config = <<CONFIG
 # Any requests that arent static files get sent to haproxy
 upstream gae_#{app_name} {
-    server #{my_public_ip}:#{proxy_port};
+    server #{my_private_ip}:#{proxy_port};
 }
 
 server {

--- a/AppController/lib/repo.rb
+++ b/AppController/lib/repo.rb
@@ -70,7 +70,7 @@ class Repo
 
     static_handlers = HelperFunctions.parse_static_data(app)
     proxy_port = HAProxy.app_listen_port(app_number)
-    Nginx.write_app_config(app, app_number, @@ip, proxy_port, static_handlers, login_ip)
+    Nginx.write_app_config(app, app_number, @@ip, @@private_ip, proxy_port, static_handlers, login_ip)
     HAProxy.write_app_config(app, app_number, num_servers, @@private_ip)
     Collectd.write_app_config(app)
 


### PR DESCRIPTION
Resulted in a syntax error was being thrown. Two files updated to use the correct number of args when calling methods that write nginx config files.
