### PR TITLE
TaskQueue reconnect and exception handling

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2834,7 +2834,7 @@ HOSTS
         static_handlers = HelperFunctions.parse_static_data(app)
         proxy_port = HAProxy.app_listen_port(app_number)
         login_ip = get_login.public_ip
-        success = Nginx.write_app_config(app, app_number, my_public, 
+        success = Nginx.write_app_config(app, app_number, my_public, my_private,
           proxy_port, static_handlers, login_ip)
         if not success
           Djinn.log_debug("ERROR: Failure to create valid nginx config file for application #{app}.")
@@ -3445,7 +3445,8 @@ HOSTS
 
     static_handlers = HelperFunctions.parse_static_data(app)
     proxy_port = HAProxy.app_listen_port(app_number)
-    Nginx.write_app_config(app, app_number, my_public, proxy_port, static_handlers, login_ip)
+    Nginx.write_app_config(app, app_number, my_public, my_private, 
+                           proxy_port, static_handlers, login_ip)
     HAProxy.write_app_config(app, app_number, num_servers, my_private)
     Collectd.write_app_config(app)
 

--- a/AppServer/google/appengine/api/taskqueue/taskqueue_rabbitmq.py
+++ b/AppServer/google/appengine/api/taskqueue/taskqueue_rabbitmq.py
@@ -52,6 +52,7 @@ from google.appengine.api import datastore
 from google.appengine.api import datastore_errors
 import pika
 
+#TODO document these globals
 DEFAULT_RATE = '5.00/s'
 
 DEFAULT_RATE_FLOAT = 5.0
@@ -73,7 +74,7 @@ MAX_RETRIES = 10
 # Max wait in seconds
 MAX_WAIT = 60 
 
-# Max time for exponential backoff for RabbitMQ reconnect
+# Max for time for exponential backoff for RabbitMQ reconnect
 MAX_RECONNECT_TIME = 1024
 
 BUILT_IN_HEADERS = set(['x-appengine-queuename',
@@ -497,8 +498,11 @@ class _BackgroundTaskScheduler(object):
         logging.error("RabbitMQ Unknown exception %s"%str(e))
       logging.info("Reconnecting in " + str(reconnect_time) + " seconds")
       time.sleep(reconnect_time) 
+
       if reconnect_time <= MAX_RECONNECT_TIME:
         reconnect_time *= 2
+      else:
+        reconnect_time = MAX_RECONNECT_TIME
 
 class TaskQueueServiceStub(apiproxy_stub.APIProxyStub):
   """Python only task queue service stub.


### PR DESCRIPTION
Added fixes to the Python AppServer so that it doesn't crash if the Task Queue API implementation (currently RabbitMQ) isn't available, and increased logging for those scenarios.
