### PR TITLE
Terminate AppServer when process is over soft memory cap

### DIFF
--- a/AppServer/google/appengine/tools/dev_appserver.py
+++ b/AppServer/google/appengine/tools/dev_appserver.py
@@ -239,7 +239,7 @@ DEVEL_FAKE_IS_ADMIN_RAW_HEADER = 'X-AppEngine-Fake-Is-Admin'
 SOFT_CAP_MEM = 150000
 
 # Max number for randomly killing the dev_appserver when over the soft 
-# memory cap
+# memory cap.
 MAX_RANDOM_TARGET = 25
 
 class Error(Exception):


### PR DESCRIPTION
Currently the Python AppServer in AppScale (adapted from the SDK Google gives out) leaks memory. To reproduce this, run the guestbook application and post to it. From this point on, even if a user only performs read operations, the AppServer will leak memory.

This pull request terminates the Python AppServer if it uses more memory than a preset threshold. Investigation using the objgraph python library shows that there is a dictionary growing by 2 (could also be two dictionaries growing 1 each) and a list growing by 1. Which list and which dictionary requires further investigation.
