### PR TITLE
IaaS Manager Sources credentials properly

### DIFF
--- a/InfrastructureManager/lib/helperfunctions.rb
+++ b/InfrastructureManager/lib/helperfunctions.rb
@@ -258,9 +258,8 @@ module HelperFunctions
     ENV['EC2_JVM_ARGS'] = nil
 
     creds.each_pair { |k, v|
-      next unless k =~ /\ACLOUD#{cloud_num}/
-      env_key = k.scan(/\ACLOUD#{cloud_num}_(.*)\Z/).flatten.to_s
-      ENV[env_key] = v
+      Kernel.puts("Setting #{k} to #{v} in our environment.")
+      ENV[k] = v
     }
 
     # note that key and cert vars are set wrong - they refer to


### PR DESCRIPTION
Fixed IaaS manager to not check for credentials in the format `CLOUDX_CRED_NAME`, which was how we handled credentials in multiple clouds before we broke the InfrastructureManager out into its own service. Now just setting all credentials that are sent over.
