### PR TITLE
Remove app via appcontroller fix

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -691,7 +691,7 @@ class Djinn
         HAProxy.remove_app(app_name)
         Nginx.reload
         Collectd.restart
-        ZKInterface.remove_app_entry(app_name)
+        ZKInterface.remove_app_entry(app_name, my_node.serialize)
 
         # If this node has any information about AppServers for this app,
         # clear that information out.

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -152,8 +152,8 @@ class ZKInterface
   end
 
 
-  def self.remove_app_entry(appname)
-    appname_path = ROOT_APP_PATH + "/#{appname}"
+  def self.remove_app_entry(appname, ip)
+    appname_path = ROOT_APP_PATH + "/#{appname}/#{ip}"
     self.delete(appname_path)
   end
 


### PR DESCRIPTION
Fixed issue #77, which was that `appscale-remove-app` doesn't work because of how the AppController removes app information from ZooKeeper. Basically the AppController was trying to delete `/apps/guestbook` from ZooKeeper when it should have been trying to delete `/apps/guestbook/my-ip-address`, and since `guestbook` is a folder, it couldn't be deleted without recursively deleting everything in it first.

Changed how we remove app info to just remove our IP address from that folder (as every node should remove their own info when they receive the stop signal for that app).
