### PR TITLE
Added constants WANT_OUTPUT and NO_OUTPUT into godinterface

### DIFF
--- a/AppController/lib/godinterface.rb
+++ b/AppController/lib/godinterface.rb
@@ -1,6 +1,16 @@
 #!/usr/bin/ruby -w
 
 
+# A constant that we use to indicate that we want the output produced
+# by remotely executed SSH commands.
+WANT_OUTPUT = true
+
+
+# A constant that we use to indicate that we do not want the output 
+# produced by remotely executed SSH commands.
+NO_OUTPUT = false
+
+
 # Most daemons within AppScale aren't fault-tolerant, so to make them
 # fault-tolerant, we use the open source process monitor god. This
 # module hides away having to write god config files, deploying it, and


### PR DESCRIPTION
It looks like a recent merge into appscale/testing removed these constants, which god needed to execute. Not having them would crash the AppController repeatedly.
