### PR TITLE
Type check

### DIFF
--- a/AppDB/cassandra/cassandra_interface.py
+++ b/AppDB/cassandra/cassandra_interface.py
@@ -223,7 +223,8 @@ class DatastoreProxy(AppDBInterface):
     if not isinstance(end_key, str): raise TypeError("Expected a str")
     if not isinstance(limit, int) and not isinstance(limit, long): 
       raise TypeError("Expected an int or long")
-    if not isinstance(offset, int): raise TypeError("Expected an int")
+    if not isinstance(offset, int) and not isinstance(offset, long): 
+      raise TypeError("Expected an int or long")
     
     # We add extra rows in case we exclude the start/end keys
     # This makes sure the limit is upheld correctly

--- a/AppDB/hbase/hbase_interface.py
+++ b/AppDB/hbase/hbase_interface.py
@@ -218,7 +218,8 @@ class DatastoreProxy(AppDBInterface):
     if not isinstance(end_key, str): raise TypeError("Expected str")
     if not isinstance(limit, int) and not isinstance(limit, long): 
       raise TypeError("Expected int or long")
-    if not isinstance(offset, int): raise TypeError
+    if not isinstance(offset, int) and not isinstance(offset, long): 
+      raise TypeError("Expected an int or long")
 
     results = []
 

--- a/AppDB/hypertable/hypertable_interface.py
+++ b/AppDB/hypertable/hypertable_interface.py
@@ -273,7 +273,8 @@ class DatastoreProxy(AppDBInterface):
     if not isinstance(end_key, str): raise TypeError("Expected str")
     if not isinstance(limit, int) and not isinstance(limit, long): 
       raise TypeError("Expected int or long")
-    if not isinstance(offset, int): raise TypeError("Expected int")
+    if not isinstance(offset, int) and not isinstance(offset, long): 
+      raise TypeError("Expected an int or long")
    
     start_key = self.__encode(start_key) 
     end_key = self.__encode(end_key) 


### PR DESCRIPTION
Fixing an issue where the underlying DB interfaces received a long where we only expected an int for the offset argument. This check makes sure it is either a long or an int, like the limit argument which does the same.
