### PR TITLE
Removed status info on MapReduce

### DIFF
--- a/AppLoadBalancer/app/helpers/status_helper.rb
+++ b/AppLoadBalancer/app/helpers/status_helper.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'usertools'
 
-SERVICE_NAMES = %w{ blobstore datastore datastore_write images memcache taskqueue urlfetch users xmpp mapreduce ec2 neptune}
+SERVICE_NAMES = %w{ blobstore datastore datastore_write images memcache taskqueue urlfetch users xmpp ec2 neptune}
 
 module StatusHelper
   include ApplicationHelper

--- a/AppServer/demos/therepo/repo.py
+++ b/AppServer/demos/therepo/repo.py
@@ -26,7 +26,6 @@ from google.appengine.api import users
 from google.appengine.api import xmpp
 
 from google.appengine.api.appscale import ec2
-from google.appengine.api.appscale import mapreduce
 from google.appengine.api.appscale import neptune
 
 import logging
@@ -292,16 +291,6 @@ class HealthChecker(webapp.RequestHandler):
       except Exception, e:
         health['xmpp'] = FAILED
         logging.error("xmpp API FAILED %s"%(str(e)))
-
-    if capability == "all" or capability == "mapreduce":
-      try:
-        if mapreduce.can_run_jobs():
-          health['mapreduce'] = RUNNING
-        else:
-          health['mapreduce'] = FAILED
-      except Exception, e:
-        health['mapreduce'] = FAILED
-        logging.error("mapreduce API FAILED %s"%(str(e)))
 
     if capability == "all" or capability == "ec2":
       try:


### PR DESCRIPTION
Because our default database, cassandra, does not support MapReduce currently, it looks like AppScale is broken when it first starts up, when in fact its just not supported. This commit removes MR status.
