### PR TITLE
Correctly starting AppScale if more than one eth device is present

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1834,20 +1834,21 @@ class Djinn
   # speaking, we assume that our node is identifiable by private IP.
   def find_me_in_locations()
     @my_index = nil
-    Djinn.log_debug("Searching for node index for #{HelperFunctions.local_ip}")
+    all_local_ips = HelperFunctions.get_all_local_ips()
+    Djinn.log_debug("Seeing which node has a private IP that matches " +
+      "our private IPs, which are: #{all_local_ips.join(', ')}")
     Djinn.log_debug("@nodes is #{@nodes.join(', ')}")
     @nodes.each_index { |index|
       Djinn.log_debug("Am I #{@nodes[index].private_ip}?")
-      if @nodes[index].private_ip == HelperFunctions.local_ip
+      if all_local_ips.include?(@nodes[index].private_ip)
         Djinn.log_debug("Yes!")
         @my_index = index
-        break
+        HelperFunctions.set_local_ip(@nodes[index].private_ip)
+        return
       end
       Djinn.log_debug("No...")
     }
-    if @my_index.nil?
-      Djinn.log_debug("I am lost, could not find my node") 
-    end
+    Djinn.log_debug("I am lost, could not find my node") 
   end
 
 

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -12,6 +12,7 @@ class TestDjinn < Test::Unit::TestCase
   def setup
     kernel = flexmock(Kernel)
     kernel.should_receive(:puts).and_return()
+    kernel.should_receive(:shell).with("").and_return()
     kernel.should_receive(:sleep).and_return()
 
     djinn_class = flexmock(Djinn)
@@ -159,11 +160,11 @@ class TestDjinn < Test::Unit::TestCase
 
     credentials = ['table', 'cassandra', 'hostname', 'public_ip', 'ips', '', 
       'keyname', 'appscale']
-    one_node_info = ['public_ip:private_ip:some_role:instance_id:cloud1']
+    one_node_info = ['public_ip:1.2.3.4:some_role:instance_id:cloud1']
     app_names = []
 
-    flexmock(HelperFunctions).should_receive(:local_ip).
-      and_return("private_ip")
+    flexmock(HelperFunctions).should_receive(:shell).with("ifconfig").
+      and_return("inet addr:1.2.3.4")
 
     expected = "OK"
     actual = djinn.set_parameters(one_node_info, credentials, app_names,


### PR DESCRIPTION
Fixes issue #143, by querying the operating system for all IPs bound to the given VM. It then checks to see if each IP in the node map matches any IP bound to this VM (except 127.0.0.1), and if so, sets that IP in HelperFunctions and uses it from then onward.
