### PR TITLE
AppController validates AppScale version on other VMs

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1834,20 +1834,21 @@ class Djinn
   # speaking, we assume that our node is identifiable by private IP.
   def find_me_in_locations()
     @my_index = nil
-    Djinn.log_debug("Searching for node index for #{HelperFunctions.local_ip}")
+    all_local_ips = HelperFunctions.get_all_local_ips()
+    Djinn.log_debug("Seeing which node has a private IP that matches " +
+      "our private IPs, which are: #{all_local_ips.join(', ')}")
     Djinn.log_debug("@nodes is #{@nodes.join(', ')}")
     @nodes.each_index { |index|
       Djinn.log_debug("Am I #{@nodes[index].private_ip}?")
-      if @nodes[index].private_ip == HelperFunctions.local_ip
+      if all_local_ips.include?(@nodes[index].private_ip)
         Djinn.log_debug("Yes!")
         @my_index = index
-        break
+        HelperFunctions.set_local_ip(@nodes[index].private_ip)
+        return
       end
       Djinn.log_debug("No...")
     }
-    if @my_index.nil?
-      Djinn.log_debug("I am lost, could not find my node") 
-    end
+    Djinn.log_debug("I am lost, could not find my node") 
   end
 
 

--- a/AppController/lib/helperfunctions.rb
+++ b/AppController/lib/helperfunctions.rb
@@ -85,6 +85,10 @@ module HelperFunctions
   DONT_USE_SSL = false
 
 
+  # The IPv4 address that corresponds to the reserved localhost IP.
+  LOCALHOST_IP = "127.0.0.1"
+
+
   # A class variable that is used to locally cache our own IP address, so that
   # we don't keep asking the system for it.
   @@my_local_ip = nil
@@ -326,6 +330,43 @@ module HelperFunctions
     self.shell("tar --file #{tar_path} --force-local -C #{tar_dir} -zx") if untar
   end
 
+
+  # Queries the operating system to determine which IP addresses are
+  # bound to this virtual machine.
+  # Args:
+  #   remove_lo: A boolean that indicates whether or not the lo
+  #     device's IP should be removed from the results. By default,
+  #     we remove it, since it is on all virtual machines and thus
+  #     not useful towards uniquely identifying a particular machine.
+  # Returns:
+  #   An Array of Strings, each of which is an IP address bound to
+  #     this virtual machine.
+  def self.get_all_local_ips(remove_lo=true)
+    ifconfig = HelperFunctions.shell("ifconfig")
+    Kernel.puts("ifconfig returned the following: [#{ifconfig}]")
+    bound_addrs = ifconfig.scan(/inet addr:(\d+.\d+.\d+.\d+)/).flatten
+
+    Kernel.puts("ifconfig reports bound IP addresses as " +
+      "[#{bound_addrs.join(', ')}]")
+    if remove_lo
+      bound_addrs.delete(LOCALHOST_IP)
+    end
+    return bound_addrs
+  end
+
+  
+  # Sets the locally cached IP address to the provided value. Callers
+  # should use this if they believe the IP address on this machine
+  # is not the first IP returned by 'ifconfig', which can occur if
+  # the IP to reach this machine on is eth1, eth2, etc.
+  # Args:
+  #   ip: The IP address that other AppScale nodes can reach this
+  #     machine via.
+  def self.set_local_ip(ip)
+    @@my_local_ip = ip
+  end
+
+
   # Returns the IP address associated with this machine. To get around
   # issues where a VM may forget its IP address
   # (https://github.com/AppScale/appscale/issues/84), we locally cache it
@@ -340,23 +381,15 @@ module HelperFunctions
       return @@my_local_ip
     end
 
-    ifconfig = HelperFunctions.shell("ifconfig")
-    Kernel.puts("ifconfig returned the following: [#{ifconfig}]")
-    bound_addrs = ifconfig.scan(/inet addr:(\d+.\d+.\d+.\d+)/).flatten
+    bound_addrs = self.get_all_local_ips()
+    if bound_addrs.length.zero?
+      raise Exception.new("Couldn't get our local IP address")
+    end
 
-    Kernel.puts("ifconfig reports bound IP addresses as " +
-      "[#{bound_addrs.join(', ')}]")
-    bound_addrs.each { |addr|
-      if addr == "127.0.0.1"
-        next
-      end
-
-      Kernel.puts("Returning #{addr} as our local IP address")
-      @@my_local_ip = addr
-      return addr
-    }
-
-    raise Exception.new("Couldn't get our local IP address")
+    addr = bound_addrs[0]
+    Kernel.puts("Returning #{addr} as our local IP address")
+    @@my_local_ip = addr
+    return addr
   end
 
   # In cloudy deployments, the recommended way to determine a machine's true

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -12,6 +12,7 @@ class TestDjinn < Test::Unit::TestCase
   def setup
     kernel = flexmock(Kernel)
     kernel.should_receive(:puts).and_return()
+    kernel.should_receive(:shell).with("").and_return()
     kernel.should_receive(:sleep).and_return()
 
     djinn_class = flexmock(Djinn)
@@ -159,11 +160,11 @@ class TestDjinn < Test::Unit::TestCase
 
     credentials = ['table', 'cassandra', 'hostname', 'public_ip', 'ips', '', 
       'keyname', 'appscale']
-    one_node_info = ['public_ip:private_ip:some_role:instance_id:cloud1']
+    one_node_info = ['public_ip:1.2.3.4:some_role:instance_id:cloud1']
     app_names = []
 
-    flexmock(HelperFunctions).should_receive(:local_ip).
-      and_return("private_ip")
+    flexmock(HelperFunctions).should_receive(:shell).with("ifconfig").
+      and_return("inet addr:1.2.3.4")
 
     expected = "OK"
     actual = djinn.set_parameters(one_node_info, credentials, app_names,


### PR DESCRIPTION
Added logic to have the head AppController make sure the version of AppScale on its own machine matches the version found on all other AppControllers, throwing an AppScaleException if the versions don't match.
