### PR TITLE
Using private IPs instead of public for memcached and ejabberd

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2528,11 +2528,11 @@ HOSTS
 
   def start_ejabberd()
     @state = "Starting up XMPP server"
-    my_public = my_node.public_ip
+    my_private = my_node.private_ip
     Ejabberd.stop
     Djinn.log_run("rm -f /var/lib/ejabberd/*")
-    Ejabberd.write_auth_script(my_public, @@secret)
-    Ejabberd.write_config_file(my_public)
+    Ejabberd.write_auth_script(my_private, @@secret)
+    Ejabberd.write_config_file(my_private)
     Ejabberd.start
   end
 

--- a/AppController/lib/ejabberd.rb
+++ b/AppController/lib/ejabberd.rb
@@ -64,7 +64,7 @@ module Ejabberd
     return if nodes.nil?
     nodes.each { |node|
       next if node.is_login? # don't copy the file to itself
-      ip = node.public_ip
+      ip = node.private_ip
       ssh_key = node.ssh_key
       HelperFunctions.scp_file(ONLINE_USERS_FILE, ONLINE_USERS_FILE, ip, ssh_key)
     }
@@ -226,7 +226,7 @@ SCRIPT
     Djinn.log_run("chmod +x #{AUTH_SCRIPT_LOCATION}")
   end
 
-  def self.write_config_file(my_public_ip)
+  def self.write_config_file(my_private_ip)
     config = <<CONFIG
 %%%
 %%%     Debian ejabberd configuration file
@@ -241,10 +241,10 @@ SCRIPT
 %% Options which are set by Debconf and managed by ucf
 
 %% Admin user
-{acl, admin, {user, "admin", "#{my_public_ip}"}}.
+{acl, admin, {user, "admin", "#{my_private_ip}"}}.
 
 %% Hostname
-{hosts, ["#{my_public_ip}"]}.
+{hosts, ["#{my_private_ip}"]}.
 
 {loglevel, 4}.
 


### PR DESCRIPTION
Fixes problems we run into on Euca3 where, because the private IP doesn't get resolved to the public IP, memcached and ejabberd cannot be accessed by AppScale services. Fixed this by explicitly using the private IP address in these scenarios.
