### PR TITLE
Deleting cookies via the same IP they are set with

### DIFF
--- a/AppLoadBalancer/app/controllers/application_controller.rb
+++ b/AppLoadBalancer/app/controllers/application_controller.rb
@@ -43,14 +43,14 @@ class ApplicationController < ActionController::Base
     if tokens.length != 4
       # guard against user-crafted cookies
       Rails.logger.info "saw a malformed cookie: [#{cookie_val}] - clearing it out"
-      cookies[:dev_appserver_login] = { :value => nil, :domain => UserTools.local_ip, :expires => Time.at(0) }
+      cookies[:dev_appserver_login] = { :value => nil, :domain => UserTools.public_ip, :expires => Time.at(0) }
     end
     email, nick, admin, hash = tokens
 
     my_hash = UserTools.get_appengine_hash(email, nick, admin)
     if my_hash != hash
       reset_session
-      cookies[:dev_appserver_login] = { :value => nil, :domain => UserTools.local_ip, :expires => Time.at(0) }      
+      cookies[:dev_appserver_login] = { :value => nil, :domain => UserTools.public_ip, :expires => Time.at(0) }
     end
   end
 

--- a/AppLoadBalancer/app/controllers/users_controller.rb
+++ b/AppLoadBalancer/app/controllers/users_controller.rb
@@ -105,7 +105,7 @@ class UsersController < ApplicationController
   def logout
     create_token(get_remote_ip, "invalid") # clear the token out
     reset_session
-    cookies[:dev_appserver_login] = { :value => nil, :domain => UserTools.local_ip, :expires => Time.at(0) }
+    cookies[:dev_appserver_login] = { :value => nil, :domain => UserTools.public_ip, :expires => Time.at(0) }
     Rails.logger.info("params is #{params.inspect}, continue URL is #{params[:continue]}")
     if params[:continue]
       Rails.logger.info("about to redirect to #{params[:continue]}")


### PR DESCRIPTION
Cookies were being created with the public IP address and deleted via the private IP address. If these IPs are the same, this is not an issue, but in VirtualBox and EC2 (and certain types of Euca deployments), this is not true and thus can the cookie won't be deleted. Remedied this problem by always deleting via the public IP address.

This fixes issue #79. Tested on VirtualBox. To test, spawn a one node deployment on VirtualBox (with more than one eth device) or EC2 and upload the guestbook application. Log in as the admin user and log out. Then post to the guestbook app. Before this fix, you would still see your posts under your admin user account. After this fix, you see the posts performed anonymously.
