### PR TITLE
Terminate script kills RabbitMQ / Ejabberd

### DIFF
--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -132,7 +132,9 @@ end
  "ndb_mgmd", "ndbd", "mysqld",
  "rabbitmq",
  "thin", "god", "djinn", "xmpp_receiver", 
- "InfrastructureManager", "Neptune"
+ "InfrastructureManager", "Neptune",
+ # RabbitMQ, ejabberd
+ "epmd", "beam", "ejabberd_auth.py"
 ].each do |program|
   `ps ax | grep #{program} | grep -v grep | awk '{ print $1 }' | xargs -d '\n' kill -9`
 end


### PR DESCRIPTION
Ran into issue #291, where the terminate script wouldn't kill epmd, beam, and other Erlang processes. This causes RabbitMQ to fail to start on subsequent runs. Altered the terminate script to kill those processes, since there was no reason for them to hang around.
