### PR TITLE
Retry when starting other AppControllers

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2837,6 +2837,7 @@ HOSTS
       end
     rescue Timeout::Error
       Djinn.log_debug("Couldn't start the AppController at #{ip}. Retrying.")
+      retry
     end
     
     Djinn.log_debug("Sending data to #{ip}")


### PR DESCRIPTION
Prior to this pull request, Jovan was running into problems where the first AppController would hang trying to start other AppControllers in the system. This pull request fixes that problem by putting a 60 second timeout on that process, and retrying if the timeout is reached.
