### PR TITLE
Fixed XMPP in Python 2.7

### DIFF
--- a/AppServer/google/appengine/api/xmpp/xmpp_service_real.py
+++ b/AppServer/google/appengine/api/xmpp/xmpp_service_real.py
@@ -99,7 +99,7 @@ class XmppService(apiproxy_stub.APIProxyStub):
 
     my_jid = xmpppy.protocol.JID(xmpp_username)
     client = xmpppy.Client(my_jid.getDomain(), debug=[])
-    client.connect()
+    client.connect(secure=False)
     client.auth(my_jid.getNode(), self.uasecret, resource=my_jid.getResource())
 
     for jid in request.jid_list():


### PR DESCRIPTION
Prior to this pull request, using the XMPP library in Python 2.7 didn't work, and would throw this stack trace:

```
ERROR    2013-02-19 17:46:30,348 threading.py:564] Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/local/Python-2.7.3/Lib/threading.py", line 551, in __bootstrap_inner
    self.run()
  File "/usr/local/Python-2.7.3/Lib/threading.py", line 504, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/root/appscale/AppServer/google/appengine/api/apiproxy_stub.py", line 125, in MakeSyncCall
    method(request, response)
  File "/root/appscale/AppServer/google/appengine/api/xmpp/xmpp_service_real.py", line 102, in _Dynamic_SendMessage
    client.connect()
  File "/usr/share/pyshared/xmpp/client.py", line 205, in connect
  File "/usr/share/pyshared/xmpp/dispatcher.py", line 303, in dispatch
  File "/usr/share/pyshared/xmpp/transports.py", line 330, in StartTLSHandler
  File "/usr/share/pyshared/xmpp/transports.py", line 308, in _startSSL
  File "/usr/local/Python-2.7.3/Lib/socket.py", line 64, in ssl
    return _realssl.sslwrap_simple(sock, keyfile, certfile)
AttributeError: 'module' object has no attribute 'sslwrap_simple'
```

The problem appears to be related to how the Python 2.5 and Python 2.7 AppServers use the xmpppy library, which in turn uses distinct SSL libraries. As SSL was the problem, this pull request doesn't use it, getting around the problem. Tested and working with Hawkeye on Python 2.5 and Python 2.7.
