### PR TITLE
Having the ejabberd authentication script connect to the userappserver

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2827,7 +2827,7 @@ HOSTS
     my_public = my_node.public_ip
     Ejabberd.stop
     Djinn.log_run("rm -f /var/lib/ejabberd/*")
-    Ejabberd.write_auth_script(my_public, @@secret)
+    Ejabberd.write_auth_script(my_public, get_db_master.private_ip, @@secret)
     Ejabberd.write_config_file(my_public)
     Ejabberd.start
   end

--- a/AppController/lib/ejabberd.rb
+++ b/AppController/lib/ejabberd.rb
@@ -75,7 +75,7 @@ module Ejabberd
     }
   end
 
-  def self.write_auth_script(login_ip, secret)
+  def self.write_auth_script(login_ip, uaserver_ip, secret)
     auth_script = <<SCRIPT
 #!/usr/bin/python
 
@@ -95,10 +95,11 @@ logging.info("extauth script started, waiting for ejabberd requests")
 # db initialization
 
 login_ip = "#{login_ip}"
+uaserver_ip = "#{uaserver_ip}"
 secret = "#{secret}"
 
-login_address = "https://" + login_ip + ":4343"
-server = SOAPpy.SOAPProxy(login_address)
+uaserver_address = "https://" + uaserver_ip + ":4343"
+server = SOAPpy.SOAPProxy(uaserver_address)
 
 # helper functions
 


### PR DESCRIPTION
We were previously assuming that the UserAppServer was at the login address, which isn't true in advanced deployments.
