### PR TITLE
Renamed xmpp receiver watch name 

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3587,7 +3587,8 @@ HOSTS
     if Ejabberd.does_app_need_receive?(app, app_language)
       start_cmd = "#{PYTHON27} #{APPSCALE_HOME}/XMPPReceiver/xmpp_receiver.py #{app} #{login_ip} #{@@secret}"
       stop_cmd = "ps ax | grep '#{start_cmd}' | grep -v grep | awk '{print $1}' | xargs -d '\n' kill -9"
-      GodInterface.start(app, start_cmd, stop_cmd, 9999)
+      watch_name = "xmpp-#{app}"
+      GodInterface.start(watch_name, start_cmd, stop_cmd, 9999)
       Djinn.log_debug("App #{app} does need xmpp receive functionality")
     else
       Djinn.log_debug("App #{app} does not need xmpp receive functionality")
@@ -3597,14 +3598,14 @@ HOSTS
   # Stop the xmpp receiver for an applicaiton.
   # 
   # Args:
-  #   xmpp_watch_name: The application ID, which is what we set the god watch
-  #     name as for the XMPP receiver.
-  def stop_xmpp_for_app(xmpp_watch_name)
-    Djinn.log_debug("Shutting down xmpp receiver with watch name: #{xmpp_watch_name}")
-    GodInterface.remove(xmpp_watch_name)
-    stop_cmd = "ps ax | grep 'xmpp_receiver.py #{xmpp_watch_name}' | grep -v grep | awk '{print $1}' | xargs -d '\n' kill -9"
+  #   app: The application ID whose XMPPReceiver we should shut down.
+  def stop_xmpp_for_app(app)
+    Djinn.log_debug("Shutting down xmpp receiver for app: #{app}")
+    watch_name = "xmpp-#{app}"
+    GodInterface.remove(watch_name)
+    stop_cmd = "ps ax | grep 'xmpp_receiver.py #{app}' | grep -v grep | awk '{print $1}' | xargs -d '\n' kill -9"
     Djinn.log_run(stop_cmd)
-    Djinn.log_debug("Done shutting down xmpp receiver with watch name: #{xmpp_watch_name}")
+    Djinn.log_debug("Done shutting down xmpp receiver for app: #{app}")
   end
 
   def self.neptune_parse_creds(storage, job_data)


### PR DESCRIPTION
Done so that we don't confuse it with the app's god watch name (as they were previously named the same thing).
