### PR TITLE
Having cron not go through the apploadbalancer

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2988,7 +2988,7 @@ HOSTS
         maybe_start_taskqueue_worker(app)
 
         if my_node.is_shadow?
-          CronHelper.update_cron(my_public, app_language, app)
+          CronHelper.update_cron(my_public, @nginx_port, app_language, app)
           start_xmpp_for_app(app, app_language)
         end
         app_number = @nginx_port - Nginx::START_PORT

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -11,7 +11,7 @@ module CronHelper
   NTP_SYNC_CRON = "*/5 * * * * /root/appscale/ntp.sh"
   NO_EMAIL_CRON = 'MAILTO=\"\"'
   
-  def self.update_cron(ip, lang, app)
+  def self.update_cron(ip, port, lang, app)
     Djinn.log_debug("saw a cron request with args [#{ip}][#{lang}][#{app}]") 
 
     if lang == "python" or lang == "python27" or lang == "go"
@@ -26,7 +26,7 @@ module CronHelper
         url = item["url"].scan(/\A(\/[\/\d\w]+)/).flatten.to_s
         schedule = item["schedule"]
         timezone = item["timezone"] # will add support later for this
-        cron_scheds = convert_schedule_to_cron(schedule, url, ip, app)
+        cron_scheds = convert_schedule_to_cron(schedule, url, ip, port, app)
         cron_scheds.each { |line|
         #  cron_info = <<CRON
         #  Description: #{description}
@@ -52,7 +52,7 @@ module CronHelper
         url = get_from_xml(item, "url").scan(/\A(\/[\/\d\w]+)/).flatten.to_s
         schedule = get_from_xml(item, "schedule")
         timezone = get_from_xml(item, "timezone") # will add support later for this
-        cron_scheds = convert_schedule_to_cron(schedule, url, ip, app)
+        cron_scheds = convert_schedule_to_cron(schedule, url, ip, port, app)
         cron_scheds.each { |line|
         #  cron_info = <<CRON
         #  Description: #{description}
@@ -156,7 +156,7 @@ module CronHelper
     return cron_lines
   end
 
-  def self.convert_schedule_to_cron(schedule, url, ip, app)
+  def self.convert_schedule_to_cron(schedule, url, ip, port, app)
     cron_lines = []
     simple_format = schedule.scan(/\Aevery (\d+) (hours|mins|minutes)\Z/)
 
@@ -174,7 +174,7 @@ module CronHelper
     end
 
     cron_lines.each { |cron|
-      cron << " curl -k -L http://#{ip}/apps/#{app}#{url} 2>&1 >> /var/apps/#{app}/log/cron.log"
+      cron << " curl -k -L http://#{ip}:#{port}#{url} 2>&1 >> /var/apps/#{app}/log/cron.log"
     }
   end
 


### PR DESCRIPTION
The AppLoadBalancer wasn't preserving the URL to send requests to, so having requests sent directly to nginx/haproxy instead.
