### PR TITLE
Moved dist-packages up in os.path 

### DIFF
--- a/AppServer/dev_appserver.py
+++ b/AppServer/dev_appserver.py
@@ -93,11 +93,11 @@ EXTRA_PATHS = [
   os.path.join(DIR_PATH, 'lib', 'yaml', 'lib'),
   os.path.join(DIR_PATH, 'lib', 'simplejson'),
   os.path.join(DIR_PATH, 'lib', 'google.appengine._internal.graphy'),
+  '/usr/lib/python2.6/dist-packages/',
   '/usr/share/pyshared',
   '/usr/local/lib/python2.7/site-packages',
   '/usr/local/lib/python2.6/dist-packages/xmpppy-0.5.0rc1-py2.6.egg',
   '/usr/local/lib/python2.6/dist-packages/lxml-3.1.1-py2.6-linux-x86_64.egg',
-  '/usr/lib/python2.6/dist-packages/',
 ]
 
 API_SERVER_EXTRA_PATHS = [


### PR DESCRIPTION
Ensures that the correct version of pycrypto is imported (instead of the one in pyshared).
