### PR TITLE
Using HelperFunctions.shell instead of backticks so that we can mock it

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2858,15 +2858,15 @@ class Djinn
     ip = dest_node.private_ip
     options = "-e 'ssh -i #{ssh_key}' -arv --filter '- *.pyc'"
 
-    `rsync #{options} #{controller}/* root@#{ip}:#{controller}`
-    `rsync #{options} #{server}/* root@#{ip}:#{server}`
-    `rsync #{options} #{loadbalancer}/* root@#{ip}:#{loadbalancer}`
-    `rsync #{options} --exclude='logs/*' --exclude='hadoop-*' --exclude='hbase/hbase-*' --exclude='voldemort/voldemort/*' --exclude='cassandra/cassandra/*' #{appdb}/* root@#{ip}:#{appdb}`
-    `rsync #{options} #{neptune}/* root@#{ip}:#{neptune}`
-    `rsync #{options} #{loki}/* root@#{ip}:#{loki}`
-    `rsync #{options} #{app_manager}/* root@#{ip}:#{app_manager}`
-    `rsync #{options} #{iaas_manager}/* root@#{ip}:#{iaas_manager}`
-    `rsync #{options} #{xmpp_receiver}/* root@#{ip}:#{xmpp_receiver}`
+    HelperFunctions.shell("rsync #{options} #{controller}/* root@#{ip}:#{controller}")
+    HelperFunctions.shell("rsync #{options} #{server}/* root@#{ip}:#{server}")
+    HelperFunctions.shell("rsync #{options} #{loadbalancer}/* root@#{ip}:#{loadbalancer}")
+    HelperFunctions.shell("rsync #{options} --exclude='logs/*' --exclude='hadoop-*' --exclude='hbase/hbase-*' --exclude='voldemort/voldemort/*' --exclude='cassandra/cassandra/*' #{appdb}/* root@#{ip}:#{appdb}")
+    HelperFunctions.shell("rsync #{options} #{neptune}/* root@#{ip}:#{neptune}")
+    HelperFunctions.shell("rsync #{options} #{loki}/* root@#{ip}:#{loki}")
+    HelperFunctions.shell("rsync #{options} #{app_manager}/* root@#{ip}:#{app_manager}")
+    HelperFunctions.shell("rsync #{options} #{iaas_manager}/* root@#{ip}:#{iaas_manager}")
+    HelperFunctions.shell("rsync #{options} #{xmpp_receiver}/* root@#{ip}:#{xmpp_receiver}")
   end
 
   def setup_config_files()

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -892,8 +892,8 @@ class TestDjinn < Test::Unit::TestCase
       with(/\Assh.* root@1.2.3.5 'ls #{HelperFunctions::APPSCALE_CONFIG_DIR}/).and_return("0\n")
 
     # mock out our attempts to rsync over to the new boxes
-    flexmock(Djinn).should_receive(:log_run).with(/\Arsync.* root@1.2.3.4/).and_return()
-    flexmock(Djinn).should_receive(:log_run).with(/\Arsync.* root@1.2.3.5/).and_return()
+    flexmock(HelperFunctions).should_receive(:shell).with(/\Arsync.* root@1.2.3.4/).and_return()
+    flexmock(HelperFunctions).should_receive(:shell).with(/\Arsync.* root@1.2.3.5/).and_return()
 
     # when the appcontroller asks those boxes where APPSCALE_HOME is,
     # let's assume they say it's in /usr/appscale


### PR DESCRIPTION
Fixing broken unit tests
