### PR TITLE
Improve ZooKeeper performance

### DIFF
--- a/AppController/lib/zookeeper_helper.rb
+++ b/AppController/lib/zookeeper_helper.rb
@@ -19,6 +19,8 @@ dataDir=#{DATA_LOCATION}
 clientPort=2181
 leaderServes=yes
 maxClientsCnxns=0
+forceSync=no
+skipACL=yes
 EOF
   myid = ""
 


### PR DESCRIPTION
Not using ACLs, since we write everything as world-readable anyways, and not syncing to disk, since we write to ephemeral disks
