### PR TITLE
Erasing votes to scale up or down after we retrieve them

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4155,6 +4155,7 @@ HOSTS
     nodes_needed = []
     @apps_loaded.each { |appid|
       scaling_requests = ZKInterface.get_scaling_requests_for_app(appid)
+      ZKInterface.clear_scaling_requests_for_app(appid)
       scale_up_requests = scaling_requests.select { |item| item == "scale_up" }
       num_of_scale_up_requests = scale_up_requests.length
 

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -606,6 +606,17 @@ class ZKInterface
   end
 
 
+  # Erases all requests to scale AppServers up or down for the named
+  # application.
+  #
+  # Args:
+  #   appid: A String that names the application whose scaling requests we
+  #     wish to erase.
+  def self.clear_scaling_requests_for_app(appid)
+    self.recursive_delete("#{SCALING_DECISION_PATH}/#{appid}")
+  end
+
+
   # Writes a node in ZooKeeper indicating that the named application needs
   # additional AppServers running to serve the amount of traffic currently
   # accessing the caller's machine.


### PR DESCRIPTION
This prevents the AppController from repeatedly finding the same votes to scale up (which would cause the AppController to continuously scale up, even if no more scaling is needed).
