### PR TITLE
First pass at enabling Remote API Shell

### DIFF
--- a/AppServer/google/appengine/ext/webapp/__init__.py
+++ b/AppServer/google/appengine/ext/webapp/__init__.py
@@ -158,8 +158,11 @@ def _django_setup():
   import django.conf
   try:
 
-
-    getattr(django.conf.settings, 'FAKE_ATTR', None)
+    raise ImportError
+    # TODO(cgb): Right now the below line raises a
+    # django.core.exceptions.ImproperlyConfigured exception. Need to investigate
+    # why and address accordingly.
+    #getattr(django.conf.settings, 'FAKE_ATTR', None)
   except (ImportError, EnvironmentError), e:
 
 

--- a/AppServer/google/appengine/tools/dev_appserver_login.py
+++ b/AppServer/google/appengine/tools/dev_appserver_login.py
@@ -117,6 +117,27 @@ def ClearUserInfoCookie(cookie_name=COOKIE_NAME):
   set_cookie[cookie_name]['max-age'] = '0'
   return '%s\r\n' % set_cookie
 
+def CreateCookieData(email, admin):
+  """ Creates cookie payload data.
+
+  Args:
+    email, admin: Parameters to incorporate into the cookie.
+
+  Returns:
+    String containing the cookie payload.
+  """
+  nickname = email.split("@")[0]
+
+  if admin:
+    app_list = os.environ['APPLICATION_ID']
+  else:
+    app_list = ''
+
+  secret = os.environ['COOKIE_SECRET']
+
+  hashed = sha.new(email+nickname+app_list+secret).hexdigest()
+  return urllib.quote_plus("{0}:{1}:{2}:{3}".format(email, nickname, app_list, hashed))
+
 def LoginRedirect(login_url,
                   hostname,
                   port,


### PR DESCRIPTION
This pull enables users to use the Remote API Shell with their Google App Engine apps. One caveat on this first pass is that it requires users to set the COOKIE_SECRET and APPLICATION_ID environment variables before invoking the Remote API Shell. A second pass probably should get these values from the hosted app itself.
