### PR TITLE
Monitoring app engine apps when we start them

### DIFF
--- a/lib/monit_interface.py
+++ b/lib/monit_interface.py
@@ -71,6 +71,7 @@ def start(watch):
     return False
 
   logging.info("Starting watch {0}".format(watch))
+  run_with_retry([MONIT, 'monitor', '-g', watch])
   return run_with_retry([MONIT, 'start', '-g', watch])
 
 def stop(watch, is_group=True):


### PR DESCRIPTION
Fixes problems where removing an app then uploading it would result in 503s, since removing apps unmonitors them.
