### PR TITLE
deleting apps by keys, instead of with the actual model

### DIFF
--- a/AppDashboard/lib/app_dashboard_data.py
+++ b/AppDashboard/lib/app_dashboard_data.py
@@ -522,7 +522,7 @@ class AppDashboardData():
         apps_to_delete = []
         for app in all_apps:
           if app.name in app_names_to_delete:
-            apps_to_delete.append(app)
+            apps_to_delete.append(app.key)
         ndb.delete_multi(apps_to_delete)
 
       # Add in new apps that are now running.


### PR DESCRIPTION
Deleting with `ndb.delete_multi` takes a list of keys, not a list of models, hence why this did not previously work.
