### PR TITLE
removing port files when taking down appscale

### DIFF
--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -21,6 +21,7 @@ module TerminateHelper
     `rm -f /var/appscale/*.pid`
     `rm -f /usr/local/nginx/conf/sites-enabled/*.conf`
     `rm -f /etc/monit/conf.d/*.cfg`
+    `rm -f /etc/appscale/port-*.txt`
 
     # TODO(cgb): It may be wise to save the apps for when AppScale starts up
     # later.


### PR DESCRIPTION
This prevents future deployments from reading in stale values.
