### PR TITLE
Generating kind stats now works in advanced deployments

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1090,7 +1090,7 @@ class Djinn
     end
 
     Thread.new {
-      run_groomer_command = "cd /root/appscale/AppDB && python groomer.py"
+      run_groomer_command = "python /root/appscale/AppDB/groomer.py"
       if my_node.is_db_master?
         Djinn.log_run(run_groomer_command)
       else


### PR DESCRIPTION
Removed ampersands from groomer commands since the function it calls expects only one command to be passed in, and thus the ampersand would be incorrectly parsed.
