### PR TITLE
Add X-Forwarded-Ssl and X-Forwarded-Proto for better SSL support

### DIFF
--- a/AppController/lib/nginx.rb
+++ b/AppController/lib/nginx.rb
@@ -293,6 +293,8 @@ CONFIG
     location / {
       proxy_set_header  X-Real-IP  $remote_addr;
       proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Ssl on;
+      proxy_set_header  X-Forwarded-Proto https;
       proxy_set_header Host $http_host;
       proxy_redirect off;
       proxy_pass http://gae_ssl_#{app_name};


### PR DESCRIPTION
Currently it is not possible for an app to detect if it is accessed via HTTP or HTTPS. 
In order to get this working, we added the [quite common](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Common_non-standard_request_headers) X-Forwarded-Ssl and X-Forwarded-Proto headers to the nginx configuration for the app
