### PR TITLE
Prevent malicious overwriting of x-forwarded-proto and ssl

### DIFF
--- a/AppController/lib/nginx.rb
+++ b/AppController/lib/nginx.rb
@@ -293,8 +293,8 @@ CONFIG
     location / {
       proxy_set_header  X-Real-IP  $remote_addr;
       proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header  X-Forwarded-Ssl on;
-      proxy_set_header  X-Forwarded-Proto https;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_set_header  X-Forwarded-Ssl $ssl;
       proxy_set_header Host $http_host;
       proxy_redirect off;
       proxy_pass http://gae_ssl_#{app_name};
@@ -313,6 +313,8 @@ DEFAULT_CONFIG
     location / {
       proxy_set_header  X-Real-IP  $remote_addr;
       proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_set_header  X-Forwarded-Ssl $ssl;
       proxy_set_header Host $http_host;
       proxy_redirect off;
       proxy_pass http://gae_#{app_name};
@@ -336,6 +338,11 @@ upstream gae_ssl_#{app_name} {
 
 upstream gae_#{app_name}_blobstore {
     server #{my_private_ip}:#{BLOBSERVER_PORT};
+}
+
+map $scheme $ssl {
+    default off;
+    https on;
 }
 
 server {


### PR DESCRIPTION
We have made an improvement over our last pull request about the X-Forward-Proto and -Ssl. 
With the previous nginx configuration it was possible that a malicious user can send the headers himself and force the app thinking that the connection was made via https where in fact it was not. This is now prevented by always setting the header in nginx, and thus overwriting any user sent headers.
Further we improved how the scheme and ssl flag is set resulting in a cleaner configuration.
