### PR TITLE
Making sure that zookeeper owns all folders in the zookeeper directory

### DIFF
--- a/AppController/lib/zookeeper_helper.rb
+++ b/AppController/lib/zookeeper_helper.rb
@@ -58,7 +58,7 @@ def start_zookeeper
     Djinn.log_run("rm -rfv #{DATA_LOCATION}")
   end
   Djinn.log_run("mkdir -pv #{DATA_LOCATION}")
-  Djinn.log_run("chown -v zookeeper:zookeeper #{DATA_LOCATION}")
+  Djinn.log_run("chown -Rv zookeeper:zookeeper #{DATA_LOCATION}")
 
   # myid is needed for multi node configuration.
   Djinn.log_run("ln -sfv /etc/zookeeper/conf/myid #{DATA_LOCATION}")


### PR DESCRIPTION
Previously, ZooKeeper would own the /opt/appscale/zookeeper directory, but may not necessarily own files in that directory, causing ZooKeeper to crash when it starts up (since it cannot read or write its saved state).
