### PR TITLE
Validating that APIChecker data is a Hash before using it

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2541,6 +2541,12 @@ class Djinn
     begin
       response = Net::HTTP.get_response(URI.parse(apichecker_url))
       data = JSON.load(response.body)
+
+      if data.class != Hash
+        Djinn.log_error("API status received from host at #{apichecker_url} " +
+          "was not a Hash, but was a #{data.class.name} containing: #{data}")
+        return
+      end
     rescue Exception => e
       Djinn.log_error("Couldn't get API status from host at #{apichecker_url}")
 


### PR DESCRIPTION
Fixes an issue where the AppController assumes that this data is a Hash, and attempts to iterate through it accordingly. Typically this is true, but if a node has died, it may receive nil instead, causing the AppController to crash.
