### PR TITLE
RPC Tweaks

### DIFF
--- a/AppServer/google/appengine/tools/appengine_rpc.py
+++ b/AppServer/google/appengine/tools/appengine_rpc.py
@@ -423,7 +423,8 @@ class AbstractRpcServer(object):
       A str of the URL for the AppScale Dashboard's authentication page
     """
     host = self._GetAppScaleDashboardHost()
-    return "%s://%s:1443/%s" % (self.scheme + "s", host,
+    scheme = self.scheme if self.scheme.endswith('s') else self.scheme + 's'
+    return "%s://%s:1443/%s" % (scheme, host,
       self._APPSCALE_AUTH_PAGE)
 
   def _RunCommand(self, command):


### PR DESCRIPTION
I made a couple of changes to `appengine_rpc.py` to make it work for me:
- My password had some characters that didn't play well with the curl command construction, this adds quotes to make sure they aren't interpreted when the command is invoked
- The URL construction was adding an additional `s` to the scheme, so I tweaked the scheme construction to ensure that it never results in a scheme of `httpss`
