### PR TITLE
Fix bootstrap.sh version detection

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -101,8 +101,8 @@ echo
 sleep 5
 apt-get install -y git
 if [ -d appscale ]; then
-        APPSCALE_MAJOR="$(sed -n 's/.*\([0-9]\)\.\([0-9][0-9]\)\.[0-9]/\1/gp' appscale/VERSION)"
-        APPSCALE_MINOR="$(sed -n 's/.*\([0-9]\)\.\([0-9][0-9]\)\.[0-9]/\2/gp' appscale/VERSION)"
+        APPSCALE_MAJOR="$(sed -n 's/.*\([0-9]\)\+\.\([0-9]\)\+\.[0-9]/\1/gp' appscale/VERSION)"
+        APPSCALE_MINOR="$(sed -n 's/.*\([0-9]\)\+\.\([0-9]\)\+\.[0-9]/\2/gp' appscale/VERSION)"
         if [ -z "$APPSCALE_MAJOR" -o -z "$APPSCALE_MINOR" ]; then
                 echo "Cannot determine version of AppScale!"
                 exit 1


### PR DESCRIPTION
Running `bootstrap.sh` on a system with appscale 2.0.0 already installed currently results in an error message proclaiming:

> Cannot determine version of AppScale!

This is caused by 2.0.0's minor version number having only one digit.  This patches the regex to support version components with any number of digits.
