### PR TITLE
Make sure future_builtins is whitelisted.

### DIFF
--- a/AppServer/google/appengine/tools/devappserver2/python/sandbox.py
+++ b/AppServer/google/appengine/tools/devappserver2/python/sandbox.py
@@ -805,7 +805,7 @@ _WHITE_LIST_C_MODULES = [
     '_weakref',
     'zipimport',
     'zlib',
-    'future_builtins' ,
+    'future_builtins',
 ]
 
 


### PR DESCRIPTION
This is a second part of the future_builtins patch did earlier. The
module needs to be whitelisted.
