### PR TITLE
Fix RabbitMQ restart issues in Virtual Cluster mode, update startup sequence..

### DIFF
--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -115,8 +115,9 @@ module TaskQueue
     # start the server, reset it to join the head node
     hostname = `hostname`.chomp()
     start_cmds = ["/usr/sbin/rabbitmq-server -detached -setcookie #{HelperFunctions.get_secret()}",
-                  "/usr/sbin/rabbitmqctl cluster rabbit@#{hostname}",
-                  "/usr/sbin/rabbitmqctl start_app"]
+                   "/usr/sbin/rabbitmqctl stop_app",
+                   "/usr/sbin/rabbitmqctl cluster rabbit@#{hostname}",
+                   "/usr/sbin/rabbitmqctl start_app"]
     full_cmd = "#{start_cmds.join('; ')}"
     stop_cmd = "/usr/sbin/rabbitmqctl stop"
     match_cmd = "sname rabbit"


### PR DESCRIPTION
Rabbit MQ failed to restart in 4 node Virtual Cluster mode on EC2. Updated startup sequence as suggested by Graziano in the following thread

https://groups.google.com/forum/#!topic/appscale_community/SXl34vp7-nE
