### PR TITLE
Use app-specific crontabs instead of root crontab

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1174,6 +1174,7 @@ class Djinn
     Djinn.log_info("Shutting down app named [#{app_name}]")
     result = ""
     Djinn.log_run("rm -rf /var/apps/#{app_name}")
+    CronHelper.clear_app_crontab(app_name)
 
     # app shutdown process can take more than 30 seconds
     # so run it in a new thread to avoid 'execution expired'

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1909,7 +1909,7 @@ class Djinn
     Nginx.clear_sites_enabled()
     HAProxy.clear_sites_enabled()
     Djinn.log_run("echo '' > /root/.ssh/known_hosts") # empty it out but leave the file there
-    CronHelper.clear_crontab()
+    CronHelper.clear_app_crontabs
   end
 
 

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -103,10 +103,12 @@ CRON
   end
 
 
-  # Erases all cron jobs on this machine.
-  def self.clear_crontab()
-    Djinn.log_run("crontab -r")
-    self.add_line_to_crontab(NO_EMAIL_CRON)
+  # Erases all cron jobs for all applications.
+  #
+  # Args:
+  #   app: A String that names the appid of this application.
+  def self.clear_app_crontabs
+    Djinn.log_run('rm /etc/cron.d/appscale-*')
   end
 
 

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -110,6 +110,15 @@ CRON
   end
 
 
+  # Erases all cron jobs for application.
+  #
+  # Args:
+  #   app: A String that names the appid of this application.
+  def self.clear_app_crontab(app)
+    Djinn.log_run("rm /etc/cron.d/appscale-#{app}")
+  end
+
+
   private
 
 

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -301,7 +301,10 @@ CRON
 
     secret_hash = Digest::SHA1.hexdigest("#{app}/#{HelperFunctions.get_secret}")
     cron_lines.each { |cron|
-      cron << " curl -H \"X-Appengine-Cron:true\" -H \"X-AppEngine-Fake-Is-Admin:#{secret_hash}\" -k -L http://#{ip}:#{port}#{url} 2>&1 >> /var/apps/#{app}/log/cron.log"
+      cron << " root curl -H \"X-Appengine-Cron:true\" "\
+              "-H \"X-AppEngine-Fake-Is-Admin:#{secret_hash}\" -k "\
+              "-L http://#{ip}:#{port}#{url} "\
+              "2>&1 >> /var/apps/#{app}/log/cron.log"
     }
   end
 

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -29,7 +29,8 @@ module CronHelper
   #   app: A String that names the appid of this application, used to find the
   #     cron configuration file on the local filesystem.
   def self.update_cron(ip, port, lang, app)
-    Djinn.log_debug("saw a cron request with args [#{ip}][#{lang}][#{app}]") 
+    Djinn.log_debug("saw a cron request with args [#{ip}][#{lang}][#{app}]")
+    app_crontab = NO_EMAIL_CRON + "\n"
 
     if lang == "python27" or lang == "go" or lang == "php"
       cron_file = "/var/apps/#{app}/app/cron.yaml"
@@ -45,7 +46,6 @@ module CronHelper
       cron_routes = yaml_file["cron"]
       return if cron_routes.nil?
 
-      app_crontab = NO_EMAIL_CRON + "\n"
       cron_routes.each { |item|
         next if item['url'].nil?
         description = item["description"]
@@ -67,7 +67,6 @@ CRON
           app_crontab << line + "\n"
         }
       }
-      write_app_crontab(app_crontab, app)
 
     elsif lang == "java"
       cron_file = "/var/apps/#{app}/app/war/WEB-INF/cron.xml"
@@ -75,7 +74,6 @@ CRON
       cron_xml = Document.new(File.new(cron_file)).root
       return if cron_xml.nil?
 
-      app_crontab = NO_EMAIL_CRON + "\n"
       cron_xml.each_element('//cron') { |item|
         description = get_from_xml(item, "description")
         # since url gets put at end of curl, need to ensure it
@@ -96,10 +94,11 @@ CRON
           app_crontab << line + "\n"
         }
       }
-      write_app_crontab(app_crontab, app)
     else
       Djinn.log_error("ERROR: lang was neither python27, go, php, nor java but was [#{lang}] (cron)")
     end
+
+    write_app_crontab(app_crontab, app)
   end
 
 

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -103,9 +103,6 @@ CRON
 
 
   # Erases all cron jobs for all applications.
-  #
-  # Args:
-  #   app: A String that names the appid of this application.
   def self.clear_app_crontabs
     Djinn.log_run('rm /etc/cron.d/appscale-*')
   end


### PR DESCRIPTION
This fixes the issue where updating an app's cron.yaml file would not remove the obsolete cron job.