### PR TITLE
Remove an app's crontab when there are no jobs

### DIFF
--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -37,6 +37,10 @@ module CronHelper
 
       begin
         yaml_file = YAML.load_file(cron_file)
+        unless yaml_file:
+          clear_app_crontab(app)
+          return
+        end
       rescue ArgumentError
         Djinn.log_error("Was not able to update cron for app #{app}")
         return

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -109,7 +109,7 @@ CRON
 
   # Erases all cron jobs for all applications.
   def self.clear_app_crontabs
-    Djinn.log_run('rm /etc/cron.d/appscale-*')
+    Djinn.log_run('rm -f /etc/cron.d/appscale-*')
   end
 
 
@@ -118,7 +118,7 @@ CRON
   # Args:
   #   app: A String that names the appid of this application.
   def self.clear_app_crontab(app)
-    Djinn.log_run("rm /etc/cron.d/appscale-#{app}")
+    Djinn.log_run("rm -f /etc/cron.d/appscale-#{app}")
   end
 
 

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -37,14 +37,19 @@ module CronHelper
 
       begin
         yaml_file = YAML.load_file(cron_file)
-        return if not yaml_file
-      rescue ArgumentError, Errno::ENOENT
+      rescue ArgumentError
         Djinn.log_error("Was not able to update cron for app #{app}")
+        return
+      rescue Errno::ENOENT
+        clear_app_crontab(app)
         return
       end
 
       cron_routes = yaml_file["cron"]
-      return if cron_routes.nil?
+      if cron_routes.nil?
+        clear_app_crontab(app)
+        return
+      end
 
       cron_routes.each { |item|
         next if item['url'].nil?


### PR DESCRIPTION
Previously, if an app's cron.yaml were removed or emptied (and the app redeployed), the app's crontab would remain.