### PR TITLE
Upgrading to AppEngine Java to 1.8.1

### DIFF
--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -2,7 +2,7 @@
 <project name="AppServer_Java" default="install">
   <property name="src" location="src" />
   <property name="build" location="build" />
-  <property name="gae_version" value="1.8.0" />
+  <property name="gae_version" value="1.8.1" />
   <property name="gae_url" value="http://googleappengine.googlecode.com/files/appengine-java-sdk-${gae_version}.zip" />
   <property name="gae_org" location="appengine-java-sdk-${gae_version}" />
   <property name="gae_dist" location="appengine-java-sdk-repacked" />

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRGetLogRequest.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRGetLogRequest.java
@@ -32,9 +32,10 @@ public class MRGetLogRequest extends ProtocolMessage<MRGetLogRequest> implements
 	}
 	
 	@Override
-	public void clear() {
+	public MRGetLogRequest clear() {
 		System.out.println("stub in MRGetLogRequest: clear");
 		
+		return null;
 	}
 
 	@Override

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRGetLogResponse.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRGetLogResponse.java
@@ -31,9 +31,10 @@ public class MRGetLogResponse extends ProtocolMessage<MRGetLogResponse> implemen
 	}
 
 	@Override
-	public void clear() {
+	public MRGetLogResponse clear() {
 		System.out.println("stub in MRGetOututResponse: clear");
 		
+		return null;
 	}
 
 	@Override

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRGetOutputRequest.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRGetOutputRequest.java
@@ -29,9 +29,10 @@ public class MRGetOutputRequest extends ProtocolMessage<MRGetOutputRequest> impl
 	}
 	
 	@Override
-	public void clear() {
+	public MRGetOutputRequest clear() {
 		System.out.println("stub in MRGetOutputRequest: clear");
 		
+		return null;
 	}
 
 	@Override

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRGetOutputResponse.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRGetOutputResponse.java
@@ -31,9 +31,10 @@ public class MRGetOutputResponse extends ProtocolMessage<MRGetOutputResponse> im
 	}
 
 	@Override
-	public void clear() {
+	public MRGetOutputResponse clear() {
 		System.out.println("stub in MRGetLogResponse: clear");
 		
+		return null;
 	}
 
 	@Override

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRNodeNumRequest.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRNodeNumRequest.java
@@ -21,9 +21,10 @@ public class MRNodeNumRequest extends ProtocolMessage<MRNodeNumRequest> implemen
 	private static final long serialVersionUID = 7088956625147480383L;
 
 	@Override
-	public void clear() {
+	public MRNodeNumRequest clear() {
 		System.out.println("stub in MRNodeNumRequest: clear");
 		
+		return null;
 	}
 
 	@Override

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRNodeNumResponse.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRNodeNumResponse.java
@@ -33,9 +33,10 @@ public class MRNodeNumResponse extends ProtocolMessage<MRNodeNumResponse> implem
 	}
 
 	@Override
-	public void clear() {
+	public MRNodeNumResponse clear() {
 		System.out.println("stub in MRNodeNum: clear");
 		
+		return null;
 	}
 
 	@Override

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRPutRequest.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRPutRequest.java
@@ -35,9 +35,10 @@ public class MRPutRequest extends ProtocolMessage<MRPutRequest> implements Seria
 	}
 	
 	@Override
-	public void clear() {
+	public MRPutRequest clear() {
 		System.out.println("stub in MRPutRequest: clear");
 		
+		return null;
 	}
 
 	@Override

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRPutResponse.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRPutResponse.java
@@ -29,9 +29,10 @@ public class MRPutResponse extends ProtocolMessage<MRPutResponse> implements Ser
 
 	
 	@Override
-	public void clear() {
+	public MRPutResponse clear() {
 		System.out.println("stub in MRPutResponse: clear");
 		
+		return null;
 	}
 
 	@Override

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRRunRequest.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRRunRequest.java
@@ -54,9 +54,9 @@ public class MRRunRequest extends ProtocolMessage<MRRunRequest> implements Seria
 	}
 
 	@Override
-	public void clear() {
+	public MRRunRequest clear() {
 		System.out.println("stub in MRRunRequest: clear");
-		
+		return null;
 	}
 
 	@Override

--- a/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRRunResponse.java
+++ b/AppServer_Java/src/com/google/appengine/api/labs/mapreduce/MRRunResponse.java
@@ -22,9 +22,9 @@ public class MRRunResponse extends ProtocolMessage<MRRunResponse> implements Ser
 	private static final long serialVersionUID = 6671061287673019327L;
 
 	@Override
-	public void clear() {
+	public MRRunResponse clear() {
 		System.out.println("stub in MRPutResponse: clear");
-		
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
Version 1.8.0 contains a bug that causes a socket exception to be thrown when using MySQL with JPA and Hibernate. https://groups.google.com/forum/#!topic/appscale_community/ihbp8RSZ7hM

Google has fixed this in 1.8.1 and I have verified that this also fixes my socket exception on AppScale. With this patch I can now successfully connect to our MySQL database.