### PR TITLE
Fixing enviroment paths GOPATH and GOROOT

### DIFF
--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -119,8 +119,8 @@ def start_app(config):
   start_cmd = ""
   stop_cmd = ""
   env_vars = config['env_vars']
-  env_vars['GOPATH'] = '/root/appscale/AppServer/goroot/'
-  env_vars['GOROOT'] = '/root/appscale/AppServer/gopath/'
+  env_vars['GOPATH'] = '/root/appscale/AppServer/gopath/'
+  env_vars['GOROOT'] = '/root/appscale/AppServer/goroot/'
   watch = "app___" + config['app_name']
 
   if config['language'] == constants.PYTHON27 or \


### PR DESCRIPTION
I was working in my appengine app when a client ask me to make it work in situ, I try appscale with go and I find a problem with the imports and file the issue 1716 (https://github.com/AppScale/appscale/issues/1716) 

With a few days of experimentation I find this little error maybe in a copy paste of the path's common error and really hard to find. 

Now it works as a charm with my apps. But no with the app suggested in the contribute page ( github.com/mjibson/goread ) because it uses a library from golang ( transform ) where I have finded an other error. That I am working on right now. 

The problem was the confusion of the assignation of two environment variables. Really a two lines switch.