### PR TITLE
Redirect the user to a custom shibboleth logout

### DIFF
--- a/AppDashboard/lib/app_dashboard_helper.py
+++ b/AppDashboard/lib/app_dashboard_helper.py
@@ -142,6 +142,11 @@ class AppDashboardHelper(object):
   # The port that the Shibboleth connector is listening on.
   SHIBBOLETH_CONNECTOR_PORT = '443'
 
+  # The URL to redirect to upon logging out. This is often needed to instruct
+  # the user to close their browser in order to clear the cookie set by the
+  # shibboleth IdP.
+  SHIBBOLETH_LOGOUT_URL = SHIBBOLETH_CONNECTOR + '/Shibboleth.sso/Logout'
+
   def __init__(self):
     """ Sets up SOAP client fields, to avoid creating a new SOAP connection for
     every SOAP call.

--- a/AppServer/google/appengine/tools/devappserver2/login.py
+++ b/AppServer/google/appengine/tools/devappserver2/login.py
@@ -295,18 +295,22 @@ class Handler(webapp2.RequestHandler):
     login_url = self.request.path_url
 
     if action:
-      # Perform the action and then redirect
+      redirect_url = continue_url or login_url
+
+      # Perform the action.
       if action.lower() == LOGOUT_ACTION.lower():
         self.response.headers['Set-Cookie'] = _clear_user_info_cookie()
+        if AppDashboardHelper.USE_SHIBBOLETH:
+          redirect_url = AppDashboardHelper.SHIBBOLETH_LOGOUT_URL
       elif action.lower() == LOGIN_ACTION.lower() and set_email:
         self.response.headers['Set-Cookie'] = _set_user_info_cookie(set_email,
                                                                     set_admin)
 
-      redirect_url = continue_url or login_url
       # URLs should be ASCII-only byte strings.
       if isinstance(redirect_url, unicode):
         redirect_url = redirect_url.encode('ascii')
 
+      # Redirect the user after performing the action.
       self.response.status = 302
       self.response.status_message = 'Redirecting to continue URL'
       self.response.headers['Location'] = redirect_url


### PR DESCRIPTION
This is to address the issue of the IdP cookie preventing the ability to log in as a different user.