### PR TITLE
Allow up to 25 groups in xg transactions

### DIFF
--- a/AppDB/zkappscale/zktransaction.py
+++ b/AppDB/zkappscale/zktransaction.py
@@ -84,7 +84,7 @@ DS_RESTORE_LOCK_PATH = "/appscale_datastore_restore"
 XG_PREFIX = "xg"
 
 # Maximum number of groups allowed in cross group transactions.
-MAX_GROUPS_FOR_XG = 5
+MAX_GROUPS_FOR_XG = 25
 
 # The separator value for the lock list when using XG transactions.
 LOCK_LIST_SEPARATOR = "!XG_LIST!"


### PR DESCRIPTION
This is to match GAE: https://cloud.google.com/appengine/docs/python/datastore/#Python_Transactions_and_entity_groups