### PR TITLE
Don't crash the AC when a cron line is unparseable

### DIFF
--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -256,7 +256,7 @@ CRON
 
     unless splitted.length == 3 or splitted.length == 5
       Djinn.log_error("bad format, length = #{splitted.length}")
-      return ""
+      return [""]
     end
 
     ord = splitted[0]


### PR DESCRIPTION
The function should return a list.