### PR TITLE
Make the writing to log synchronous.

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -454,6 +454,7 @@ class Djinn
     @@logs_buffer = []
 
     file = File.open(LOG_FILE, File::WRONLY | File::APPEND | File::CREAT)
+    file.sync = true
 
     @@log = Logger.new(file)
     @@log.level = Logger::DEBUG

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -574,7 +574,8 @@ class TestDjinn < Test::Unit::TestCase
   end
 
   def test_start_new_roles_on_nodes_in_cluster
-    flexmock(File).should_receive(:open).and_return()
+    mock_file = flexmock(File.open('/dev/null'))
+    flexmock(File).should_receive(:open).and_return(mock_file)
     flexmock(HelperFunctions).should_receive(:scp_file).and_return(true)
     flexmock(Kernel).should_receive(:system).and_return('')
     # try adding two new nodes to an appscale deployment, assuming that
@@ -747,7 +748,8 @@ class TestDjinn < Test::Unit::TestCase
 
   def test_start_new_roles_on_nodes_in_cloud
     flexmock(Djinn).should_receive(:initialize_nodes_in_parallel).and_return()
-    flexmock(File).should_receive(:open).and_return()
+    mock_file = flexmock(File.open('/dev/null'))
+    flexmock(File).should_receive(:open).and_return(mock_file)
     flexmock(HelperFunctions).should_receive(:scp_file).and_return(true)
     flexmock(Kernel).should_receive(:system).and_return('')
 


### PR DESCRIPTION
This prevent log files to be clipped in case of errors.