### PR TITLE
Fetch more entities if needed during a composite query

### DIFF
--- a/AppDB/datastore_server.py
+++ b/AppDB/datastore_server.py
@@ -3363,27 +3363,67 @@ class DatastoreDistributed():
     multiple_equality_filters = self.__get_multiple_equality_filters(
       query.filter_list())
 
-    index_result = self.datastore_batch.range_query(table_name, 
-                                             column_names, 
-                                             startrow, 
-                                             endrow, 
-                                             limit, 
-                                             offset=0, 
-                                             start_inclusive=start_inclusive,
-                                             end_inclusive=True)
-    # This is a projection query.
-    if query.property_name_size() > 0:
-      entities = self.__extract_entities_from_composite_indexes(query, index_result)
-    else:
-      entities = self.__fetch_entities(index_result, clean_app_id(query.app()))
+    entities = []
+    current_limit = limit
+    while True:
+      references = self.datastore_batch.range_query(
+        table_name,
+        column_names,
+        startrow,
+        endrow,
+        current_limit,
+        offset=0,
+        start_inclusive=start_inclusive,
+        end_inclusive=True
+      )
 
-    if len(multiple_equality_filters) > 0:
-      logging.debug('Detected multiple equality filters on a repeated'
-        'property. Removing results that do not match query.')
-      entities = self.__apply_multiple_equality_filters(entities,
-        multiple_equality_filters)
+      # This is a projection query.
+      if query.property_name_size() > 0:
+        potential_entities = self.__extract_entities_from_composite_indexes(
+          query, references)
+      else:
+        potential_entities = self.__fetch_entities(
+          references, clean_app_id(query.app()))
 
-    return entities
+      if len(multiple_equality_filters) > 0:
+        logging.debug('Detected multiple equality filters on a repeated'
+          'property. Removing results that do not match query.')
+        potential_entities = self.__apply_multiple_equality_filters(
+          potential_entities, multiple_equality_filters)
+
+      entities.extend(potential_entities)
+
+      # If we have enough valid entities to satisfy the query, we're done.
+      if len(entities) >= limit:
+        break
+
+      # If we received fewer references than we asked for, they are exhausted.
+      if len(references) < current_limit:
+        break
+
+      # If all of the references that we fetched were valid, we're done.
+      if len(potential_entities) == len(references):
+        break
+
+      invalid_refs = len(references) - len(potential_entities)
+
+      # Pad the limit to increase the likelihood of fetching all the valid
+      # references that we need.
+      current_limit = invalid_refs + zk.MAX_GROUPS_FOR_XG
+
+      logging.debug('{} entities do not match query. '
+        'Fetching {} more references.'
+        .format(invalid_refs, current_limit))
+
+      last_startrow = startrow
+      # Start from the last reference fetched.
+      startrow = references[-1].keys()[0]
+
+      if startrow == last_startrow:
+        raise dbconstants.AppScaleDBError(
+          'An infinite loop was detected while fetching references.')
+
+    return entities[:limit]
 
   def __get_multiple_equality_filters(self, filter_list):
     """ Returns filters from the query that contain multiple equality

--- a/AppDB/datastore_server.py
+++ b/AppDB/datastore_server.py
@@ -2551,16 +2551,16 @@ class DatastoreDistributed():
         end_compiled_cursor=end_compiled_cursor
       )
 
-      valid_entities = self.__fetch_entities_dict(references, app_id)
+      potential_entities = self.__fetch_entities_dict(references, app_id)
 
       # Since the entities may be out of order due to invalid references,
       # we construct a new list in order of valid references.
       new_entities = []
       for reference in references:
-        if self.__valid_index_entry(reference, valid_entities, direction,
+        if self.__valid_index_entry(reference, potential_entities, direction,
           property_name):
           entity_key = reference[reference.keys()[0]]['reference']
-          valid_entity = valid_entities[entity_key]
+          valid_entity = potential_entities[entity_key]
           new_entities.append(valid_entity)
 
       entities.extend(new_entities)


### PR DESCRIPTION
This fix is needed due to the additional filtering logic we use for multiple equality filters.