### PR TITLE
Keep only 2 months of logs.

### DIFF
--- a/scripts/appscale-logotate.conf
+++ b/scripts/appscale-logotate.conf
@@ -1,7 +1,8 @@
 /var/log/appscale/*.log {
+  size 50M
   weekly
   missingok
-  rotate 52
+  rotate 8
   compress
   delaycompress
   notifempty
@@ -9,9 +10,10 @@
 }
 
 /var/log/appscale/celery_workers/*.log {
+  size 50M
   weekly
   missingok
-  rotate 52
+  rotate 8
   compress
   delaycompress
   notifempty

--- a/scripts/appscale-logotate.conf
+++ b/scripts/appscale-logotate.conf
@@ -1,6 +1,5 @@
 /var/log/appscale/*.log {
   size 50M
-  weekly
   missingok
   rotate 8
   compress
@@ -11,7 +10,6 @@
 
 /var/log/appscale/celery_workers/*.log {
   size 50M
-  weekly
   missingok
   rotate 8
   compress


### PR DESCRIPTION
We configured logrotate to rotate weekly, and keep at most 8 older logs
(that is up to about 2 months). We added a clause to rotate sooner if the
logs is getting bigger.