### PR TITLE
Recover composite indices

### DIFF
--- a/AppDB/datastore_server.py
+++ b/AppDB/datastore_server.py
@@ -3658,7 +3658,7 @@ class DatastoreDistributed():
       value_index = 0
       for def_prop in definition.property_list():
         # If the value contained the separator, try to recover the value.
-        if len(tokens[:-1]) != len(definition.property_list()):
+        if len(tokens[:-1]) > len(definition.property_list()):
           end_slice = value_index + 1
           while end_slice <= len(tokens[:-1]):
             value = self._SEPARATOR.join(tokens[value_index:end_slice])

--- a/AppDB/datastore_server.py
+++ b/AppDB/datastore_server.py
@@ -3656,7 +3656,7 @@ class DatastoreDistributed():
       for def_prop in definition.property_list():
         value = tokens.pop(0) 
         if def_prop.name() not in prop_name_list:
-          logging.warning("Skipping prop in projection: {0}".format(
+          logging.debug("Skipping prop in projection: {0}".format(
             def_prop.name()))
           continue
 


### PR DESCRIPTION
Since reverse_lex is applied to values after the delimiter is replaced, it's possible for the delimiter to get stored as part of the property value.