### PR TITLE
The app_manager do not use the list of DBs.

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2435,22 +2435,6 @@ class Djinn
     return slave_ips
   end
 
-  def self.get_nearest_db_ip()
-    db_ips = self.get_db_slave_ips
-    db_ips << self.get_db_master_ip
-    db_ips.compact!
-
-    local_ip = HelperFunctions.local_ip()
-    Djinn.log_debug("DB IPs are [#{db_ips.join(', ')}]")
-    if db_ips.include?(local_ip)
-      # If there is a local database then use it
-      local_ip
-    else
-      # Otherwise just select one randomly
-      db_ips.sort_by { rand }[0]
-    end
-  end
-
   def get_all_appengine_nodes()
     ae_nodes = []
     @nodes.each { |node|
@@ -4826,7 +4810,7 @@ HOSTS
           begin
             pid = app_manager.start_app(app, appengine_port,
               get_load_balancer_ip(), app_language, xmpp_ip,
-              [Djinn.get_nearest_db_ip()], HelperFunctions.get_app_env_vars(app),
+              HelperFunctions.get_app_env_vars(app),
               Integer(@options['max_memory']), get_login.private_ip)
           rescue FailedNodeException
             Djinn.log_warn("Failed to talk to AppManager to start #{app}.")

--- a/AppController/lib/app_dashboard.rb
+++ b/AppController/lib/app_dashboard.rb
@@ -80,7 +80,7 @@ module AppDashboard
       while true
         begin
           pid = app_manager.start_app(APP_NAME, port, uaserver_ip, APP_LANGUAGE,
-            login_ip, [uaserver_ip], {})
+            login_ip, {})
           if pid != -1
             break
           end

--- a/AppController/lib/app_manager_client.rb
+++ b/AppController/lib/app_manager_client.rb
@@ -78,7 +78,6 @@ class AppManagerClient
   #   load_balancer_port: The port of the load balancer
   #   language: The language the application is written in
   #   xmpp_ip: The IP for XMPP
-  #   db_locations: An Array of datastore server IPs
   #   env_vars: A Hash of environemnt variables that should be passed to the
   #     application to start.
   #   max_memory: An Integer that names the maximum amount of memory (in
@@ -96,7 +95,6 @@ class AppManagerClient
                 load_balancer_ip,
                 language,
                 xmpp_ip,
-                db_locations,
                 env_vars,
                 max_memory=500,
                 syslog_server="")
@@ -105,7 +103,6 @@ class AppManagerClient
               'load_balancer_ip' => load_balancer_ip,
               'language' => language,
               'xmpp_ip' => xmpp_ip,
-              'dblocations' => db_locations,
               'env_vars' => env_vars,
               'max_memory' => max_memory,
               'syslog_server' => syslog_server}

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -38,7 +38,6 @@ REQUIRED_CONFIG_FIELDS = ['app_name',
                           'language',
                           'load_balancer_ip',
                           'xmpp_ip',
-                          'dblocations',
                           'env_vars',
                           'max_memory']
 
@@ -104,7 +103,6 @@ def start_app(config):
        language: What language the app is written in
        load_balancer_ip: Public ip of load balancer
        xmpp_ip: IP of XMPP service
-       dblocations: List of database locations
        env_vars: A dict of environment variables that should be passed to the
         app.
        max_memory: An int that names the maximum amount of memory that this


### PR DESCRIPTION
Thus this patch removes it from the paramenters it accepts. This will
remove the need for get_nearest_db_ip in the djinn.