### PR TITLE
Remove has_soap_server: the check is really ...

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -842,7 +842,7 @@ class Djinn
         end
       }
 
-      if has_soap_server?(my_node)
+      if my_node.is_db_master? or my_node.is_db_slave?
         stop_soap_server()
         stop_datastore_server()
         stop_groomer_service()
@@ -3568,7 +3568,7 @@ class Djinn
         end
 
         # Always colocate the Datastore Server and UserAppServer (soap_server).
-        if has_soap_server?(my_node)
+        if my_node.is_db_master? or my_node.is_db_slave?
           @state = "Starting up SOAP Server and Datastore Server"
           start_datastore_server()
           start_soap_server()
@@ -3592,7 +3592,7 @@ class Djinn
 
         # Currently we always run the Datastore Server and SOAP
         # server on the same nodes.
-        if has_soap_server?(my_node)
+        if my_node.is_db_master? or my_node.is_db_slave?
           @state = "Starting up SOAP Server and Datastore Server"
           start_datastore_server()
           start_soap_server()

--- a/AppDB/cassandra/cassandra_helper.rb
+++ b/AppDB/cassandra/cassandra_helper.rb
@@ -25,34 +25,6 @@ CASSANDRA_DIR = "#{APPSCALE_HOME}/AppDB/cassandra"
 CASSANDRA_EXECUTABLE = "#{CASSANDRA_DIR}/cassandra/bin/cassandra"
 
 
-# Determines where the closest UserAppServer runs in this AppScale deployment.
-# For Cassandra, multiple UserAppServers can be running, so we defer this
-# calculation elsewhere.
-#
-# Returns:
-#   A String that names the private FQDN or IP address where a UserAppServer
-#   runs in this AppScale deployment.
-def get_uaserver_ip()
-  Djinn.get_nearest_db_ip
-end
-
-
-# Determines if a UserAppServer should run on this machine.
-#
-# Args:
-#   job: A DjinnJobData that indicates if the node runs a Database role.
-#
-# Returns:
-#   true if the given node runs a Database role, and false otherwise.
-def has_soap_server?(job)
-  if job.is_db_master? or job.is_db_slave?
-    return true
-  else
-    return false
-  end
-end
-
-
 # Calculates the token that should be set on this machine, which dictates how
 # data should be partitioned between machines.
 #


### PR DESCRIPTION
... about looking for a DB role, and djinn knows it, not cassandra.