### PR TITLE
Allow the tools to collect the crash log

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3906,7 +3906,7 @@ class Djinn
       begin
         appengine_info = imc.spawn_vms(nodes.length, @options, roles, disks)
       rescue FailedNodeException, AppScaleException => exception
-        @state = "Couldn't spawn the requires resources: stopping.")
+        @state = "Couldn't spawn the requires resources: stopping."
         HelperFunctions.log_and_crash("Couldn't spawn #{nodes.length} VMs " +
           "with roles #{roles} because: #{exception.message}", 30)
       end

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -842,7 +842,7 @@ class Djinn
         end
       }
 
-      if has_soap_server?(my_node)
+      if my_node.is_db_master? or my_node.is_db_slave?
         stop_soap_server()
         stop_datastore_server()
         stop_groomer_service()
@@ -3568,7 +3568,7 @@ class Djinn
         end
 
         # Always colocate the Datastore Server and UserAppServer (soap_server).
-        if has_soap_server?(my_node)
+        if my_node.is_db_master? or my_node.is_db_slave?
           @state = "Starting up SOAP Server and Datastore Server"
           start_datastore_server()
           start_soap_server()
@@ -3592,7 +3592,7 @@ class Djinn
 
         # Currently we always run the Datastore Server and SOAP
         # server on the same nodes.
-        if has_soap_server?(my_node)
+        if my_node.is_db_master? or my_node.is_db_slave?
           @state = "Starting up SOAP Server and Datastore Server"
           start_datastore_server()
           start_soap_server()

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -319,6 +319,11 @@ class Djinn
   DUTY_CYCLE = 20
 
 
+  # This is the time to wait before aborting after a crash. We use this
+  # time to give a chance to the tools to collect the crashlog.
+  WAIT_TO_CRASH = 30
+
+
   # This is a 'small' sleep that we generally use when waiting for
   # services to be up.
   SMALL_WAIT = 5
@@ -2382,7 +2387,7 @@ class Djinn
   def self.convert_location_class_to_array(djinn_locations)
     if djinn_locations.class != Array
       @state = "Locations is not an Array, not a #{djinn_locations.class}."
-      HelperFunctions.log_and_crash(@state, 30)
+      HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
     end
 
     djinn_loc_array = []
@@ -2398,7 +2403,7 @@ class Djinn
     }
 
     @state = "No login nodes found."
-    HelperFunctions.log_and_crash(@state, 30)
+    HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
   end
 
   def get_shadow()
@@ -2407,7 +2412,7 @@ class Djinn
     }
 
     @state = "No shadow nodes found."
-    HelperFunctions.log_and_crash(@state, 30)
+    HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
   end
 
   def get_db_master()
@@ -2416,7 +2421,7 @@ class Djinn
     }
 
     @state = "No DB master nodes found."
-    HelperFunctions.log_and_crash(@state, 30)
+    HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
   end
 
   def self.get_db_master_ip()
@@ -2486,7 +2491,7 @@ class Djinn
     }
 
     @state = "Couldn't find a working UserAppServer."
-    HelperFunctions.log_and_crash(@state, 30)
+    HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
   end
 
   def get_public_ip(private_ip)
@@ -3543,7 +3548,7 @@ class Djinn
           start_zookeeper(@options['clear_datastore'].downcase == "true")
         rescue FailedZooKeeperOperationException
           @state = "Couldn't start Zookeeper."
-          HelperFunctions.log_and_crash(@state, 30)
+          HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
         end
         start_backup_service()
       end
@@ -3663,7 +3668,7 @@ class Djinn
     }
 
     @state = "Failed to prime #{table}."
-    HelperFunctions.log_and_crash(@state, 30)
+    HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
   end
 
 
@@ -3906,7 +3911,7 @@ class Djinn
       rescue Exception => exception
         @state = "Couldn't spawn #{nodes.length} VMs " +
           "with roles #{roles} because: #{exception.message}"
-        HelperFunctions.log_and_crash(@state, 30)
+        HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
       end
     else
       nodes.each { |node|
@@ -4465,7 +4470,7 @@ HOSTS
       Djinn.log_info("Setting parameters on node at #{ip} returned #{result}.")
     rescue FailedNodeException
       @state = "Couldn't set parameters on node at #{ip}."
-      HelperFunctions.log_and_crash(@state, 30)
+      HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
     end
   end
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2042,7 +2042,7 @@ class Djinn
 
     begin
       new_nodes_info = imc.spawn_vms(num_of_vms, @options, roles, disks)
-    rescue Exception => exception
+    rescue FailedNodeException, AppScaleException => exception
       Djinn.log_error("Couldn't spawn #{num_of_vms} VMs with roles #{roles} " +
         "because: #{exception.message}")
       return []
@@ -2171,7 +2171,7 @@ class Djinn
         imc = InfrastructureManagerClient.new(@@secret)
         begin
           new_nodes_info = imc.spawn_vms(vms_to_spawn, @options, "open", disks)
-        rescue Exception => exception
+        rescue FailedNodeException, AppScaleException => exception
           Djinn.log_error("Couldn't spawn #{vms_to_spawn} VMs with roles " +
             "open because: #{exception.message}")
           return exception.message
@@ -3908,7 +3908,7 @@ class Djinn
       imc = InfrastructureManagerClient.new(@@secret)
       begin
         appengine_info = imc.spawn_vms(nodes.length, @options, roles, disks)
-      rescue Exception => exception
+      rescue FailedNodeException, AppScaleException => exception
         @state = "Couldn't spawn #{nodes.length} VMs " +
           "with roles #{roles} because: #{exception.message}"
         HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2037,7 +2037,7 @@ class Djinn
 
     begin
       new_nodes_info = imc.spawn_vms(num_of_vms, @options, roles, disks)
-    rescue FailedNodeException, AppScaleException => exception
+    rescue Exception => exception
       Djinn.log_error("Couldn't spawn #{num_of_vms} VMs with roles #{roles} " +
         "because: #{exception.message}")
       return []
@@ -2166,7 +2166,7 @@ class Djinn
         imc = InfrastructureManagerClient.new(@@secret)
         begin
           new_nodes_info = imc.spawn_vms(vms_to_spawn, @options, "open", disks)
-        rescue FailedNodeException, AppScaleException => exception
+        rescue Exception => exception
           Djinn.log_error("Couldn't spawn #{vms_to_spawn} VMs with roles " +
             "open because: #{exception.message}")
           return exception.message
@@ -3911,7 +3911,7 @@ class Djinn
       imc = InfrastructureManagerClient.new(@@secret)
       begin
         appengine_info = imc.spawn_vms(nodes.length, @options, roles, disks)
-      rescue FailedNodeException, AppScaleException => exception
+      rescue Exception => exception
         @state = "Couldn't spawn #{nodes.length} VMs " +
           "with roles #{roles} because: #{exception.message}"
         HelperFunctions.log_and_crash(@state, 30)

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2397,8 +2397,6 @@ class Djinn
       return node if node.is_login?
     }
 
-    Djinn.log_fatal("Couldn't find a login node in the following nodes: " +
-      "#{@nodes.join(', ')}")
     @state = "No login nodes found."
     HelperFunctions.log_and_crash(@state, 30)
   end
@@ -2408,8 +2406,6 @@ class Djinn
       return node if node.is_shadow?
     }
 
-    Djinn.log_fatal("Couldn't find a shadow node in the following nodes: " +
-      "#{@nodes.join(', ')}")
     @state = "No shadow nodes found."
     HelperFunctions.log_and_crash(@state, 30)
   end
@@ -2419,8 +2415,6 @@ class Djinn
       return node if node.is_db_master?
     }
 
-    Djinn.log_fatal("Couldn't find a db master node in the following nodes: " +
-      "#{@nodes.join(', ')}")
     @state = "No DB master nodes found."
     HelperFunctions.log_and_crash(@state, 30)
   end
@@ -2491,7 +2485,6 @@ class Djinn
       end
     }
 
-    Djinn.log_fatal("[get uaserver ip] Couldn't find a UAServer.")
     @state = "Couldn't find a working UserAppServer."
     HelperFunctions.log_and_crash(@state, 30)
   end
@@ -3669,7 +3662,6 @@ class Djinn
       break if retries.zero?
     }
 
-    Djinn.log_fatal("Failed to prime #{table}. Cannot continue.")
     @state = "Failed to prime #{table}."
     HelperFunctions.log_and_crash(@state, 30)
   end
@@ -4473,7 +4465,6 @@ HOSTS
       Djinn.log_info("Setting parameters on node at #{ip} returned #{result}.")
     rescue FailedNodeException
       @state = "Couldn't set parameters on node at #{ip}."
-      Djinn.log_error(@state)
       HelperFunctions.log_and_crash(@state, 30)
     end
   end

--- a/AppController/lib/helperfunctions.rb
+++ b/AppController/lib/helperfunctions.rb
@@ -1511,11 +1511,17 @@ module HelperFunctions
   #   message: A String that indicates why the AppController is crashing.
   # Raises:
   #   SystemExit: Always occurs, since this method crashes the AppController.
-  def self.log_and_crash(message)
+  def self.log_and_crash(message, sleep=nil)
     self.write_file(APPCONTROLLER_CRASHLOG_LOCATION, Time.new.to_s + ": " +
       message)
     # Try to also log to the normal log file.
     Djinn.log_error("FATAL: #{message}")
+
+    # If asked for, wait for a while before crashing. This will help the
+    # tools to collect the status report or crashlog.
+    if !sleep.nil?
+      Kernel.sleep(sleep)
+    end
     abort(message)
   end
 

--- a/AppController/lib/infrastructure_manager_client.rb
+++ b/AppController/lib/infrastructure_manager_client.rb
@@ -176,7 +176,8 @@ class InfrastructureManagerClient
     vm_info = {}
     loop {
       describe_result = describe_instances("reservation_id" => reservation_id)
-      Djinn.log_debug("[IM] Describe instances info says [#{describe_result}]")
+      Djinn.log_debug("[IM] Describe instances state is #{describe_result['state']} " +
+        "and vm_info is #{describe_result['vm_info']}.")
 
       if describe_result["state"] == "running"
         vm_info = describe_result["vm_info"]

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -76,17 +76,6 @@ class ZKInterface
   SCALING_DECISION_PATH = "#{APPCONTROLLER_PATH}/scale"
 
 
-  # The location in ZooKeeper that the Babel Master and Slaves will read and
-  # write data to that should be globally accessible or fault-tolerant.
-  BABEL_PATH = "/babel"
-
-
-  # The location in ZooKeeper that the Babel Master's threads read and write
-  # to, to determine the maximum number of machines that should be used to
-  # run Babel tasks.
-  BABEL_MAX_MACHINES_PATH = "#{BABEL_PATH}/max_slaves_machines"
-
-
   # The name of the file that nodes use to store the list of Google App Engine
   # instances that the given node runs.
   APP_INSTANCE = "app_instance"
@@ -513,29 +502,6 @@ class ZKInterface
     return self.exists?("#{APPCONTROLLER_NODE_PATH}/#{ip}/live")
   end
 
-
-  # Writes the integer corresponding to the maximum number of nodes that
-  # should be acquired (whether they be already running open nodes or newly
-  # spawned virtual machines) to become Babel slaves (workers).
-  def self.set_max_machines_for_babel_slaves(maximum)
-    if !self.exists?(BABEL_PATH)
-      self.set(BABEL_PATH, DUMMY_DATA, NOT_EPHEMERAL)
-    end
-
-    self.set(BABEL_MAX_MACHINES_PATH, JSON.dump(maximum), NOT_EPHEMERAL)
-  end
-
-  
-  # Returns the maximum number of nodes that should be used to run Babel
-  # jobs (not including the Babel Master).
-  def self.get_max_machines_for_babel_slaves()
-    if !self.exists?(BABEL_MAX_MACHINES_PATH)
-      return 0
-    end
-
-    return JSON.load(self.get(BABEL_MAX_MACHINES_PATH))
-  end
-  
 
   # Returns an Array of Hashes that correspond to the App Engine applications
   # hosted on the given ip address. Each hash contains the application's name,

--- a/AppController/lib/zookeeper_helper.rb
+++ b/AppController/lib/zookeeper_helper.rb
@@ -91,7 +91,7 @@ def start_zookeeper(clear_datastore)
   start_cmd = "/usr/sbin/service #{zk_server} start"
   stop_cmd = "/usr/sbin/service #{zk_server} stop"
   match_cmd = "org.apache.zookeeper.server.quorum.QuorumPeerMain"
-  MonitInterface.start(:zookeeper, start_cmd, stop_cmd, ports=9999, env_vars=nil,
+  MonitInterface.start(:zookeeper, start_cmd, stop_cmd, ports=ZOOKEEPER_PORT, env_vars=nil,
     remote_ip=nil, remote_key=nil, match_cmd=match_cmd)
   Djinn.log_info("Started ZooKeeper")
 end

--- a/AppDB/cassandra/cassandra_helper.rb
+++ b/AppDB/cassandra/cassandra_helper.rb
@@ -25,6 +25,22 @@ CASSANDRA_DIR = "#{APPSCALE_HOME}/AppDB/cassandra"
 CASSANDRA_EXECUTABLE = "#{CASSANDRA_DIR}/cassandra/bin/cassandra"
 
 
+# Determines if a UserAppServer should run on this machine.
+#
+# Args:
+#   job: A DjinnJobData that indicates if the node runs a Database role.
+#
+# Returns:
+#   true if the given node runs a Database role, and false otherwise.
+def has_soap_server?(job)
+  if job.is_db_master? or job.is_db_slave?
+    return true
+  else
+    return false
+  end
+end
+
+
 # Calculates the token that should be set on this machine, which dictates how
 # data should be partitioned between machines.
 #

--- a/AppDB/cassandra/cassandra_helper.rb
+++ b/AppDB/cassandra/cassandra_helper.rb
@@ -25,34 +25,6 @@ CASSANDRA_DIR = "#{APPSCALE_HOME}/AppDB/cassandra"
 CASSANDRA_EXECUTABLE = "#{CASSANDRA_DIR}/cassandra/bin/cassandra"
 
 
-# Determines where the closest UserAppServer runs in this AppScale deployment.
-# For Cassandra, multiple UserAppServers can be running, so we defer this
-# calculation elsewhere.
-#
-# Returns:
-#   A String that names the private FQDN or IP address where a UserAppServer
-#   runs in this AppScale deployment.
-def get_uaserver_ip()
-  Djinn.get_nearest_db_ip
-end
-
-
-# Determines if a UserAppServer should run on this machine.
-#
-# Args:
-#   job: A DjinnJobData that indicates if the node runs a Database role.
-#
-# Returns:
-#   true if the given node runs a Database role, and false otherwise.
-def has_soap_server?(job)
-  if job.is_db_master? or job.is_db_slave?
-    return true
-  else
-    return false
-  end
-end
-
-
 # Calculates the token that should be set on this machine, which dictates how
 # data should be partitioned between machines.
 #


### PR DESCRIPTION
This patch adds some timeout before crashing to allow the tools to collect some logs before the instance gets terminated.