### PR TITLE
Monit file check every 2 cycles.

### DIFF
--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -39,7 +39,7 @@ module MonitInterface
 
   def self.start_file(watch, path, action, hours=12, remote_ip=nil, remote_key=nil)
     contents = <<BOO
-check file #{watch} path "#{path}"
+check file #{watch} path "#{path} every 2 cycles"
   group #{watch}
   if timestamp > 12 hours then exec "#{action}"
 BOO


### PR DESCRIPTION
Monit was not restarting the groomer because the file check was failing,

Build: https://ocd.appscale.com:8080/job/Daily%20Build/791/