### PR TITLE
Upgrade Java AppEngine Support From 1.8.1 to 1.8.2

### DIFF
--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -2,7 +2,7 @@
 <project name="AppServer_Java" default="install">
   <property name="src" location="src" />
   <property name="build" location="build" />
-  <property name="gae_version" value="1.8.1" />
+  <property name="gae_version" value="1.8.2" />
   <property name="gae_url" value="http://googleappengine.googlecode.com/files/appengine-java-sdk-${gae_version}.zip" />
   <property name="gae_org" location="appengine-java-sdk-${gae_version}" />
   <property name="gae_dist" location="appengine-java-sdk-repacked" />

--- a/AppServer_Java/src/com/google/appengine/api/log/dev/LocalLogService.java
+++ b/AppServer_Java/src/com/google/appengine/api/log/dev/LocalLogService.java
@@ -6,7 +6,7 @@ import com.google.appengine.tools.development.LocalRpcService;
 import com.google.appengine.tools.development.LocalRpcService.Status;
 import com.google.appengine.tools.development.ServiceProvider;
 import com.google.apphosting.api.logservice.LogServicePb;
-import com.google.apphosting.api.logservice.LogServicePb.LogServerVersion;
+import com.google.apphosting.api.logservice.LogServicePb.LogModuleVersion;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashSet;
@@ -99,11 +99,11 @@ public class LocalLogService extends AbstractLocalRpcService
             {
               if ((request.versionIds().size() <= 0) || (request.versionIds().contains(thisLog.getVersionId())) || (!thisLog.hasVersionId()))
               {
-                if ((request.serverVersions().size() > 0) && ((thisLog.hasServerId()) || (thisLog.hasVersionId())))
+                if ((request.moduleVersions().size() > 0) && ((thisLog.hasModuleId()) || (thisLog.hasVersionId())))
                 {
                   boolean serverVersionMatch = false;
-                  for (LogServicePb.LogServerVersion serverVersion : request.serverVersions()) {
-                    if ((thisLog.getServerId().equals(serverVersion.getServerId())) && (thisLog.getVersionId().equals(serverVersion.getVersionId())))
+                  for (LogServicePb.LogModuleVersion moduleVersion : request.moduleVersions()) {
+                    if ((thisLog.getModuleId().equals(moduleVersion.getModuleId())) && (thisLog.getVersionId().equals(moduleVersion.getVersionId())))
                     {
                       serverVersionMatch = true;
                     }
@@ -178,14 +178,14 @@ public class LocalLogService extends AbstractLocalRpcService
     addRequestInfo(appId, "default", versionId, requestId, ip, nickname, startTimeUsec, endTimeUsec, method, resource, httpVersion, userAgent, complete, status, referrer);
   }
 
-  public synchronized void addRequestInfo(String appId, String serverId, String versionId, String requestId, String ip, String nickname, long startTimeUsec, long endTimeUsec, String method, String resource, String httpVersion, String userAgent, boolean complete, Integer status, String referrer)
+  public synchronized void addRequestInfo(String appId, String moduleId, String versionId, String requestId, String ip, String nickname, long startTimeUsec, long endTimeUsec, String method, String resource, String httpVersion, String userAgent, boolean complete, Integer status, String referrer)
   {
     LogServicePb.RequestLog log = findLogInLogMapOrAddNewLog(requestId);
     log.setAppId(appId);
 
     String majorVersionId = versionId.split("\\.")[0];
-    if (serverId.equals("default")) {
-      log.setServerId(serverId);
+    if (moduleId.equals("default")) {
+      log.setModuleId(moduleId);
     }
     log.setVersionId(majorVersionId);
     log.setStartTime(startTimeUsec);

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerFactory.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerFactory.java
@@ -37,7 +37,7 @@ public class DevAppServerFactory {
       USER_CODE_CLASSPATH_MANAGER_PROP + ".requiresWebInf";
 
   /**
-   * Creates a new {@link DevAppServer} ready to start serving
+   * Creates a new {@link DevAppServer} ready to start serving.
    *
    * @param appDir The top-level directory of the web application to be run
    * @param address Address to bind to
@@ -50,7 +50,7 @@ public class DevAppServerFactory {
   }
 
   /**
-   * Creates a new {@link DevAppServer} ready to start serving
+   * Creates a new {@link DevAppServer} ready to start serving.
    *
    * @param appDir The top-level directory of the web application to be run
    * @param externalResourceDir If not {@code null}, a resource directory external to the appDir.
@@ -63,12 +63,30 @@ public class DevAppServerFactory {
   public DevAppServer createDevAppServer(File appDir, File externalResourceDir, String address,
       int port) {
     return createDevAppServer(appDir, externalResourceDir, null, null, address, port, true,
-        true, new HashMap<String, Object>());
+        true, new HashMap<String, Object>(), false);
+  }
+  
+  /**
+   * Creates a new {@link DevAppServer} ready to start serving.
+   *
+   * @param appDir The top-level directory of the web application to be run
+   * @param externalResourceDir If not {@code null}, a resource directory external to the appDir.
+   *        This will be searched before appDir when looking for resources.
+   * @param address Address to bind to
+   * @param port Port to bind to
+   * @param noJavaAgent whether to disable detection of the Java agent or not
+   *
+   * @return a {@code DevAppServer}
+   */
+  public DevAppServer createDevAppServer(File appDir, File externalResourceDir, String address,
+     int port, boolean noJavaAgent) {
+    return createDevAppServer(appDir, externalResourceDir, null, null, address, port, true,
+		  true, new HashMap<String, Object>(), noJavaAgent);
   }
 
   /**
    * Creates a new {@link DevAppServer} with a custom classpath for the web
-   * app..
+   * app.
    *
    * @param appDir The top-level directory of the web application to be run
    * @param webXmlLocation The location of a file whose format complies with
@@ -87,7 +105,7 @@ public class DevAppServerFactory {
    * there is something in your test environment that prevents you from
    * installing a security manager.
    * @param classpath The classpath of the test and all its dependencies
-   * (possibly the entire app)..
+   * (possibly the entire app).
    *
    * @return a {@code DevAppServer}
    */
@@ -96,7 +114,43 @@ public class DevAppServerFactory {
       boolean useCustomStreamHandler, boolean installSecurityManager, Collection<URL> classpath) {
     Map<String, Object> containerConfigProps = newContainerConfigPropertiesForTest(classpath);
     return createDevAppServer(appDir, null, webXmlLocation, appEngineWebXmlLocation,
-        address, port, useCustomStreamHandler, installSecurityManager, containerConfigProps);
+        address, port, useCustomStreamHandler, installSecurityManager, containerConfigProps, false);
+  }
+  
+  /**
+   * Creates a new {@link DevAppServer} with a custom classpath for the web
+   * app.
+   *
+   * @param appDir The top-level directory of the web application to be run
+   * @param webXmlLocation The location of a file whose format complies with
+   * http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd.  If {@code null},
+   * defaults to <appDir>/WEB-INF/web.xml
+   * @param appEngineWebXmlLocation The name of the app engine config file.  If
+   * {@code null}, defaults to <appDir>/WEB-INF/appengine-web.xml.
+   * @param address Address to bind to
+   * @param port Port to bind to
+   * @param useCustomStreamHandler If {@code true}, install
+   * {@link StreamHandlerFactory}.  This is "normal" behavior for the dev
+   * app server but tests may want to disable this since there are some
+   * compatibility issues with our custom handler and Selenium.
+   * @param installSecurityManager Whether or not to install the dev appserver
+   * security manager.  It is strongly recommended you pass {@code true} unless
+   * there is something in your test environment that prevents you from
+   * installing a security manager.
+   * @param classpath The classpath of the test and all its dependencies
+   * (possibly the entire app).
+   * @param noJavaAgent whether to disable detection of the Java agent or not
+   *
+   * @return a {@code DevAppServer}
+   */
+  public DevAppServer createDevAppServer(File appDir, File webXmlLocation,
+		   File appEngineWebXmlLocation, String address, int port,
+		   boolean useCustomStreamHandler, boolean installSecurityManager, Collection<URL> classpath,
+		   boolean noJavaAgent) {
+	   Map<String, Object> containerConfigProps = newContainerConfigPropertiesForTest(classpath);
+	   return createDevAppServer(appDir, null, webXmlLocation, appEngineWebXmlLocation,
+			   address, port, useCustomStreamHandler, installSecurityManager, containerConfigProps,
+			   noJavaAgent);
   }
 
   /**
@@ -123,7 +177,7 @@ public class DevAppServerFactory {
   private DevAppServer createDevAppServer(File appDir,File webXmlLocation,
       File appEngineWebXmlLocation, String address, int port, boolean useCustomStreamHandler) {
     return createDevAppServer(appDir, null, webXmlLocation, appEngineWebXmlLocation,
-        address, port, useCustomStreamHandler, true, new HashMap<String, Object>());
+        address, port, useCustomStreamHandler, true, new HashMap<String, Object>(), false);
   }
 
   @SuppressWarnings("unused")
@@ -131,13 +185,21 @@ public class DevAppServerFactory {
       File appEngineWebXmlLocation, String address, int port, boolean useCustomStreamHandler,
       boolean installSecurityManager, Map<String, Object> containerConfigProperties) {
     return createDevAppServer(appDir, null, webXmlLocation, appEngineWebXmlLocation, address, port,
-        useCustomStreamHandler,installSecurityManager, containerConfigProperties);
+        useCustomStreamHandler,installSecurityManager, containerConfigProperties, false);
   }
 
+  @SuppressWarnings("unused")
   private DevAppServer createDevAppServer(File appDir, File externalResourceDir,
       File webXmlLocation, File appEngineWebXmlLocation, String address, int port,
       boolean useCustomStreamHandler, boolean installSecurityManager,
       Map<String, Object> containerConfigProperties) {
+    return createDevAppServer(appDir, externalResourceDir, webXmlLocation, appEngineWebXmlLocation, address, port, useCustomStreamHandler, installSecurityManager, containerConfigProperties, false);
+  }
+  
+  private DevAppServer createDevAppServer(File appDir, File externalResourceDir,
+	      File webXmlLocation, File appEngineWebXmlLocation, String address, int port,
+	      boolean useCustomStreamHandler, boolean installSecurityManager,
+	      Map<String, Object> containerConfigProperties, boolean noJavaAgent) {
     if (installSecurityManager) {
       SecurityManagerInstaller.install();
     }
@@ -145,7 +207,9 @@ public class DevAppServerFactory {
     DevAppServerClassLoader loader = DevAppServerClassLoader.newClassLoader(
         DevAppServerFactory.class.getClassLoader());
 
-    testAgentIsInstalled();
+    if (!noJavaAgent) {
+    	testAgentIsInstalled();
+    }
 
     DevAppServer devAppServer;
     try {

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
@@ -34,15 +34,19 @@ public class DevAppServerMain
     public static final String  GENERATED_WAR_DIR_ARG                 = "generated_war_dir";
     private static final String DEFAULT_RDBMS_PROPERTIES_FILE         = ".local.rdbms.properties";
     private static final String RDBMS_PROPERTIES_FILE_SYSTEM_PROPERTY = "rdbms.properties.file";
+    
+    private static final String SYSTEM_PROPERTY_STATIC_MODULE_PORT_NUM_PREFIX = "com.google.appengine.devappserver_module.";
+    
     private static String       originalTimeZone;
     private final Action        ACTION                                = new StartAction();
 
-    private String              server                                = SdkInfo.getDefaultServer();
+    private String              versionCheckServer                    = SdkInfo.getDefaultServer();
 
     private String              address                               = "127.0.0.1";
     private int                 port                                  = 8080;
     private boolean             disableUpdateCheck;
     private boolean             disableRestrictedCheck                = true;
+    private boolean noJavaAgent = false;
     private String              externalResourceDir                   = null;
     private List<String>        propertyOptions                       = null;
     private String              generatedDirectory                    = null;
@@ -77,7 +81,7 @@ public class DevAppServerMain
         {
             public void apply()
             {
-                this.main.server = getValue();
+                this.main.versionCheckServer = getValue();
             }
 
             public List<String> getHelpLines()
@@ -182,6 +186,16 @@ public class DevAppServerMain
                 this.main.appscale_version = getValue();
                 System.setProperty("APP_SCALE_VERSION", this.main.appscale_version);
             }
+        }, new DevAppServerOption(main, null, "instance_port", false) {
+            @Override
+        	public void apply() {
+        	   processInstancePorts(getValues());
+        	}
+        }, new DevAppServerOption(main, null, "no_java_agent", true) {
+        	@Override
+        	public void apply() {
+        	    this.main.noJavaAgent = true;
+        	}
         }, new DevAppServerOption(main, null, "admin_console_version", false)
         { // changed from admin_console_server
                     public void apply()
@@ -208,6 +222,29 @@ public class DevAppServerMain
                         System.setProperty("NGINX_PORT", getNginxPort());
                     }
                 } });
+    }
+    
+    private static void processInstancePorts(List<String> optionValues) {
+      for (String optionValue : optionValues) {
+        String[] keyAndValue = optionValue.split("=", 2);
+        if (keyAndValue.length != 2) {
+            reportBadInstancePortValue(optionValue);
+            }
+
+        try {
+            Integer.parseInt(keyAndValue[1]);
+            } catch (NumberFormatException nfe) {
+                reportBadInstancePortValue(optionValue);
+                }
+
+        System.setProperty(
+                SYSTEM_PROPERTY_STATIC_MODULE_PORT_NUM_PREFIX + keyAndValue[0].trim() + ".port",
+                keyAndValue[1].trim());
+        }
+    }
+
+    private static void reportBadInstancePortValue(String optionValue) {
+        throw new IllegalArgumentException("Invalid instance_port value " + optionValue);
     }
 
     private static String getNginxPort()
@@ -374,14 +411,14 @@ public class DevAppServerMain
                     externalResourceDir = appDirs.getExternalResourceDir();
                 }
 
-                UpdateCheck updateCheck = new UpdateCheck(DevAppServerMain.this.server, appDir, true);
+                UpdateCheck updateCheck = new UpdateCheck(DevAppServerMain.this.versionCheckServer, appDir, true);
                 if ((updateCheck.allowedToCheckForUpdates()) && (!DevAppServerMain.this.disableUpdateCheck))
                 {
                     updateCheck.maybePrintNagScreen(System.err);
                 }
                 updateCheck.checkJavaVersion(System.err);
 
-                DevAppServer server = new DevAppServerFactory().createDevAppServer(appDir, externalResourceDir, DevAppServerMain.this.address, DevAppServerMain.this.port);
+                DevAppServer server = new DevAppServerFactory().createDevAppServer(appDir, externalResourceDir, DevAppServerMain.this.address, DevAppServerMain.this.port, noJavaAgent);
 
                 Map properties = System.getProperties();
 

--- a/AppServer_Java/src/com/google/appengine/tools/development/LocalHttpRequestEnvironment.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/LocalHttpRequestEnvironment.java
@@ -34,7 +34,7 @@ public class LocalHttpRequestEnvironment extends LocalEnvironment
     private String                                    DEVEL_FAKE_IS_ADMIN_RAW_HEADER = "X-AppEngine-Fake-Is-Admin";
     private String                                    DEVEL_PAYLOAD_RAW_HEADER = "HTTP_X_APPENGINE_DEVELOPMENT_PAYLOAD";
 
-     public LocalHttpRequestEnvironment(String appId, String serverName, String majorVersionId, int instance, HttpServletRequest request, Long deadlineMillis, ServersFilterHelper serversFilterHelper)
+     public LocalHttpRequestEnvironment(String appId, String serverName, String majorVersionId, int instance, HttpServletRequest request, Long deadlineMillis, ModulesFilterHelper modulesFilterHelper)
      {
         super(appId, majorVersionId, deadlineMillis);
 
@@ -89,7 +89,7 @@ public class LocalHttpRequestEnvironment extends LocalEnvironment
         }
 
         this.attributes.put("com.google.appengine.http_servlet_request", request);
-        this.attributes.put("com.google.appengine.tools.development.servers_filter_helper", serversFilterHelper);
+        this.attributes.put(DevAppServerImpl.MODULES_FILTER_HELPER_PROPERTY, modulesFilterHelper);
     }
 
     public boolean isLoggedIn()


### PR DESCRIPTION
This commit upgrades the Java server from 1.8.1 to 1.8.2. It contains all changes to Java AppScale files (no python code changes) that were checked in by Google: https://code.google.com/p/googleappengine/source/detail?r=362 . It appears that this adds Feature level support for App Engine Modules.