### PR TITLE
Upgrade Java AppEngine Support From 1.8.2 to 1.8.3

### DIFF
--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -2,7 +2,7 @@
 <project name="AppServer_Java" default="install">
   <property name="src" location="src" />
   <property name="build" location="build" />
-  <property name="gae_version" value="1.8.2" />
+  <property name="gae_version" value="1.8.3" />
   <property name="gae_url" value="http://googleappengine.googlecode.com/files/appengine-java-sdk-${gae_version}.zip" />
   <property name="gae_org" location="appengine-java-sdk-${gae_version}" />
   <property name="gae_dist" location="appengine-java-sdk-repacked" />


### PR DESCRIPTION
This commit upgrades the Java server from 1.8.2 to 1.8.3. There were no changes to AppScale java files so it looks like we get this one for free! Original Google commit: https://code.google.com/p/googleappengine/source/detail?r=376 . 

According to the [offical release notes](https://code.google.com/p/googleappengine/wiki/SdkForJavaReleaseNotes#Version_1.8.3_-_August_6,_2013) the following changes were made:
* Published a major rewrite of the Search API documentation. Please see: https://developers.google.com/appengine/docs/java/search
Interfacing into the Task Queue REST API no longer requires including "s~" at the beginning of the project name.
* Fixed an issue with the Mail API, email addresses that contain encoded newlines as specified in rfc2047 are now parsed correctly.
* Fixed an issue with ChannelService.sendMessage() failing when a client id has 3 or more dashes.
* Fixed an issue with the Channel API send_message function not working in the SDK.
* Fixed an issue with the Local Channel service failing to properly validate tokens.
* Fixed an issue with enabling cloud integration for existing apps.
https://code.google.com/p/googleappengine/issues/detail?id=9602
* Fixed an issue with the Datastore Admin UI failing to load due to the app having too many kinds.
https://code.google.com/p/googleappengine/issues/detail?id=9749