### PR TITLE
Upgrade Java AppEngine Support From 1.8.3 to 1.8.4

### DIFF
--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -2,7 +2,7 @@
 <project name="AppServer_Java" default="install">
   <property name="src" location="src" />
   <property name="build" location="build" />
-  <property name="gae_version" value="1.8.2" />
+  <property name="gae_version" value="1.8.3" />
   <property name="gae_url" value="http://googleappengine.googlecode.com/files/appengine-java-sdk-${gae_version}.zip" />
   <property name="gae_org" location="appengine-java-sdk-${gae_version}" />
   <property name="gae_dist" location="appengine-java-sdk-repacked" />

--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -2,7 +2,7 @@
 <project name="AppServer_Java" default="install">
   <property name="src" location="src" />
   <property name="build" location="build" />
-  <property name="gae_version" value="1.8.3" />
+  <property name="gae_version" value="1.8.4" />
   <property name="gae_url" value="http://googleappengine.googlecode.com/files/appengine-java-sdk-${gae_version}.zip" />
   <property name="gae_org" location="appengine-java-sdk-${gae_version}" />
   <property name="gae_dist" location="appengine-java-sdk-repacked" />

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerImpl.java
@@ -111,6 +111,7 @@ class DevAppServerImpl
     	requestedPort, serviceProperties);
       }
       this.backendContainer.setServiceProperties(properties);
+      DevAppServerDatastorePropertyHelper.setDefaultProperties(this.serviceProperties);
     }
   }
 
@@ -155,7 +156,7 @@ class DevAppServerImpl
       Module mainServer = modules.getMainModule();
 
       Map portMapping = this.backendContainer.getPortMapping();
-      AbstractContainerService.installLocalInitializationEnvironment(mainServer.getMainContainer().getAppEngineWebXmlConfig(), -1, getPort(), null, -1, portMapping);
+      AbstractContainerService.installLocalInitializationEnvironment(mainServer.getMainContainer().getAppEngineWebXmlConfig(), -1, getPort(), getPort(), null, -1, portMapping);
 
       this.backendContainer.startupAll(this.apiProxyLocal);
     } finally {

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
@@ -50,6 +50,7 @@ public class DevAppServerMain
     private String              externalResourceDir                   = null;
     private List<String>        propertyOptions                       = null;
     private String              generatedDirectory                    = null;
+    private String 				defaultGcsBucketName 				  = null;
 
     // add for AppScale
     private String              db_location;
@@ -144,7 +145,17 @@ public class DevAppServerMain
             {
                 return ImmutableList.of(" --generated_dir=DIR        Set the directory where generated files are created.");
             }
-        }, new DevAppServerOption(main, null, "disable_restricted_check", true)
+        }, new DevAppServerOption(main, null, "default_gcs_bucket", false) {
+            @Override
+            public void apply() {
+                this.main.defaultGcsBucketName = getValue();
+                }
+            @Override
+            public List<String> getHelpLines() {
+                return ImmutableList.of(
+                        " --default_gcs_bucket=NAME  Set the default Google Cloud Storage bucket name.");
+                }
+        },new DevAppServerOption(main, null, "disable_restricted_check", true)
         {
             public void apply()
             {
@@ -425,6 +436,7 @@ public class DevAppServerMain
                 Map stringProperties = properties;
                 setTimeZone(stringProperties);
                 setGeneratedDirectory(stringProperties);
+                setDefaultGcsBucketName(stringProperties);
                 setSecret();
                 if (DevAppServerMain.this.disableRestrictedCheck)
                 {
@@ -517,6 +529,12 @@ public class DevAppServerMain
                 }
                 stringProperties.put("appengine.generated.dir", DevAppServerMain.this.generatedDirectory);
             }
+        }
+        
+        private void setDefaultGcsBucketName(Map<String, String> stringProperties) {
+          if (defaultGcsBucketName != null) {
+              stringProperties.put("appengine.default.gcs.bucket.name", defaultGcsBucketName);
+          }
         }
 
         private void setRdbmsPropertiesFile( Map<String, String> stringProperties, File appDir, File externalResourceDir )

--- a/AppServer_Java/src/com/google/appengine/tools/development/LocalHttpRequestEnvironment.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/LocalHttpRequestEnvironment.java
@@ -34,9 +34,9 @@ public class LocalHttpRequestEnvironment extends LocalEnvironment
     private String                                    DEVEL_FAKE_IS_ADMIN_RAW_HEADER = "X-AppEngine-Fake-Is-Admin";
     private String                                    DEVEL_PAYLOAD_RAW_HEADER = "HTTP_X_APPENGINE_DEVELOPMENT_PAYLOAD";
 
-     public LocalHttpRequestEnvironment(String appId, String serverName, String majorVersionId, int instance, HttpServletRequest request, Long deadlineMillis, ModulesFilterHelper modulesFilterHelper)
+     public LocalHttpRequestEnvironment(String appId, String serverName, String majorVersionId, int instance, Integer port, HttpServletRequest request, Long deadlineMillis, ModulesFilterHelper modulesFilterHelper)
      {
-        super(appId, majorVersionId, deadlineMillis);
+    	super(appId, serverName, majorVersionId, instance, port, deadlineMillis);
 
         this.loginCookieData = LoginCookieUtils.getCookieData(request);
         this.FORCE_ADMIN = checkForceAdmin(request);


### PR DESCRIPTION
This commit upgrades the GAE Java server from 1.8.3 to 1.8.4: 
* https://code.google.com/p/googleappengine/source/detail?r=382
* https://code.google.com/p/googleappengine/source/detail?r=383

According to the [offical release notes](https://code.google.com/p/googleappengine/wiki/SdkForJavaReleaseNotes#Version_1.8.4_-_September_9,_2013) the following changes were made:
* A Datastore Admin fix in this release improves security by ensuring that scheduled backups can now only be started by a cron or task queue task. Administrators can still start a backup by going to the Datastore Admin in the Admin Console.
* The Java SDK local datastore now defaults to an HRD-like consistency policy, including eventually consistent global queries. For more information see developers.google.com/appengine/docs/java/tools/devserver#Using_the_Datastore
* The Conversion API, a decommissioned feature, has been removed from the SDK. In the next release, the API will be removed from the runtime and any attempt to import the API will raise an * exception. Applications in production that import the API should be fixed as soon as possible.
* Fixed the implementation of the Cloud SQL JDBC driver for App Engine which restricted the connection lifetime to the lifetime of the HTTP request. This will unblock users who want to use long running connections (e.g. in connection pools).
* Fixed bulkloader issue for Java caused by improper updates of the Java Remote API handlers in a previous version of the runtimes.
* Fixed Eclipse plugin on the development server to eliminate complaints about missing indexes when using equality filters.
* Fixed the issue with SASL provider registration that was impacting developers' ability to connect to GMail via IMAP.