### PR TITLE
Upgrading GAE version to 1.8.5

### DIFF
--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -2,7 +2,7 @@
 <project name="AppServer_Java" default="install">
   <property name="src" location="src" />
   <property name="build" location="build" />
-  <property name="gae_version" value="1.8.4" />
+  <property name="gae_version" value="1.8.5" />
   <property name="gae_url" value="http://googleappengine.googlecode.com/files/appengine-java-sdk-${gae_version}.zip" />
   <property name="gae_org" location="appengine-java-sdk-${gae_version}" />
   <property name="gae_dist" location="appengine-java-sdk-repacked" />


### PR DESCRIPTION
This commit upgrades the GAE Java server from 1.8.4 to 1.8.5:
* https://code.google.com/p/googleappengine/source/detail?r=389

According to the [official release notes](https://code.google.com/p/googleappengine/wiki/SdkForJavaReleaseNotes#Version_1.8.5_-_September_25,_2013) the following changes were made:
* The Search API is now a GA feature.
* The Conversion API, a decommissioned feature, has been removed from the runtime. Applications in production that import the API should be fixed as soon as possible.
* Fixed an issue with the Admin Console Datastore Viewer throwing errors when fetching UTF-8 kinds.
https://code.google.com/p/googleappengine/issues/detail?id=7570
* Fixed an issue where files that contain an '@' could not be deployed.
* Fixed an issue with the Datastore Admin not being able to backup to another app.
https://code.google.com/p/googleappengine/issues/detail?id=9808