### PR TITLE
Use curl throughout.

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -304,11 +304,6 @@ class Djinn
     'message' => 'not enough open nodes'})
 
 
-  # The options that should be used when invoking wget, so that the
-  # AppController can automatically probe a site to see if it's up.
-  WGET_OPTIONS = "--tries=1000 --no-check-certificate -q -O /dev/null"
-
-
   # This is the duty cycle for the main loop(s).
   DUTY_CYCLE = 20
 
@@ -3507,7 +3502,6 @@ class Djinn
 
         if my_node.is_db_master? or my_node.is_db_slave?
           start_groomer_service()
-          start_backup_service()
         end
 
         start_backup_service()

--- a/AppDB/backup/gcs_helper.py
+++ b/AppDB/backup/gcs_helper.py
@@ -116,11 +116,11 @@ def download_from_bucket(full_object_name, local_path):
     logging.error('Not enough space to download a backup.')
     return False
 
-  # Invoke 'wget' to retrieve the resource and store to local_path.
+  # Invoke 'curl' to retrieve the resource and store to local_path.
   try:
-    logging.debug("Downloading GCS object: wget -O {0} {1}".format(
+    logging.debug("Downloading GCS object: curl -o {0} {1}".format(
       local_path, content['mediaLink']))
-    subprocess.check_output(['wget', '-O', local_path, content['mediaLink']])
+    subprocess.check_output(['curl', '-o', local_path, content['mediaLink']])
   except subprocess.CalledProcessError as called_process_error:
     logging.error("Error while downloading file from GCS. Error: {0}".
       format(called_process_error))

--- a/debian/appscale_build.sh
+++ b/debian/appscale_build.sh
@@ -20,7 +20,7 @@ echo "done."
 
 # We need to make sure we have lsb-release, before we use it. On
 # streamlined images (like docker) it may not be present.
-if ! which lsb_release > /dev/null ; then 
+if ! which lsb_release > /dev/null ; then
     echo -n "Installing lsb-release..."
     ${PKG_CMD} install -y lsb-release > /dev/null
     echo "done."

--- a/debian/appscale_install.sh
+++ b/debian/appscale_install.sh
@@ -5,7 +5,7 @@ fi
 
 DESTDIR=$2
 APPSCALE_HOME=${DESTDIR}${APPSCALE_HOME_RUNTIME}
-WGET_OPTS="-q"                                    # Don't write wget progress.
+CURL_OPTS="-s"
 
 . debian/appscale_install_functions.sh
 

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -295,7 +295,7 @@ installsolr()
     mkdir -p ${APPSCALE_HOME}/SearchService/solr
     cd ${APPSCALE_HOME}/SearchService/solr
     rm -rfv solr
-    wget ${WGET_OPTS} $APPSCALE_PACKAGE_MIRROR/solr-${SOLR_VER}.tgz
+    curl ${CURL_OPTS} -o solr-${SOLR_VER}.tgz $APPSCALE_PACKAGE_MIRROR/solr-${SOLR_VER}.tgz
     tar zxvf solr-${SOLR_VER}.tgz
     mv -v solr-${SOLR_VER} solr
     rm -fv solr-${SOLR_VER}.tgz
@@ -309,7 +309,7 @@ installcassandra()
     mkdir -p ${APPSCALE_HOME}/AppDB/cassandra
     cd ${APPSCALE_HOME}/AppDB/cassandra
     rm -rfv cassandra
-    wget ${WGET_OPTS} $APPSCALE_PACKAGE_MIRROR/apache-cassandra-${CASSANDRA_VER}-bin.tar.gz
+    curl ${CURL_OPTS} -o apache-cassandra-${CASSANDRA_VER}-bin.tar.gz $APPSCALE_PACKAGE_MIRROR/apache-cassandra-${CASSANDRA_VER}-bin.tar.gz
     tar xzvf apache-cassandra-${CASSANDRA_VER}-bin.tar.gz
     mv -v apache-cassandra-${CASSANDRA_VER} cassandra
     rm -fv apache-cassandra-${CASSANDRA_VER}-bin.tar.gz
@@ -326,7 +326,7 @@ installcassandra()
     pipwrapper  pycassa
 
     cd ${APPSCALE_HOME}/AppDB/cassandra/cassandra/lib
-    wget ${WGET_OPTS} $APPSCALE_PACKAGE_MIRROR/jamm-0.2.2.jar
+    curl ${CURL_OPTS} -o jamm-0.2.2.jar $APPSCALE_PACKAGE_MIRROR/jamm-0.2.2.jar
 
     # Create separate log directory.
     mkdir -pv /var/log/appscale/cassandra
@@ -368,7 +368,7 @@ installpythonmemcache()
 
         mkdir -pv ${APPSCALE_HOME}/downloads
         cd ${APPSCALE_HOME}/downloads
-        wget ${WGET_OPTS} $APPSCALE_PACKAGE_MIRROR/python-memcached-${VERSION}.tar.gz
+        curl ${CURL_OPTS} -o python-memcached-${VERSION}.tar.gz $APPSCALE_PACKAGE_MIRROR/python-memcached-${VERSION}.tar.gz
         tar zxvf python-memcached-${VERSION}.tar.gz
         cd python-memcached-${VERSION}
         python setup.py install
@@ -382,7 +382,7 @@ installzookeeper()
 {
     if [ "$DIST" = "precise" ]; then
         ZK_REPO_PKG=cdh4-repository_1.0_all.deb
-        wget ${WGET_OPTS} -O  /tmp/${ZK_REPO_PKG} http://archive.cloudera.com/cdh4/one-click-install/precise/amd64/${ZK_REPO_PKG}
+        curl ${CURL_OPTS} -o /tmp/${ZK_REPO_PKG} http://archive.cloudera.com/cdh4/one-click-install/precise/amd64/${ZK_REPO_PKG}
         dpkg -i /tmp/${ZK_REPO_PKG}
         apt-get update
         apt-get install -y zookeeper-server


### PR DESCRIPTION
We had both curl and wget in our scripts. This patch uniform our usage to
curl which seems the one mostly used in the google SDK.