### PR TITLE
Don't run a 'nodetool refresh' right after cassandra restore

### DIFF
--- a/AppDB/backup/cassandra_backup.py
+++ b/AppDB/backup/cassandra_backup.py
@@ -53,15 +53,6 @@ def create_snapshot(snapshot_name=''):
     return False
   return True
 
-def refresh_data():
-  """ Performs a refresh of the data in Cassandra. """
-  for column_family in dbconstants.INITIAL_TABLES:
-    try:
-      subprocess.check_call([NODE_TOOL, 'refresh', KEYSPACE, column_family])
-    except CalledProcessError as error:
-      logging.error('Error while refreshing Cassandra data. Error: {0}'.\
-        format(error))
-
 def remove_old_data():
   """ Removes previous node data from the Cassandra store. """
   for directory in CASSANDRA_DATA_SUBDIRS:
@@ -228,7 +219,6 @@ def restore_data(storage, path=''):
   # Start Cassandra and repair.
   logging.info("Starting Cassandra.")
   start_cassandra.run()
-  refresh_data()
 
   # Local cleanup.
   clear_old_snapshots()

--- a/AppDB/test/unit/test_cassandra_backup.py
+++ b/AppDB/test/unit/test_cassandra_backup.py
@@ -30,11 +30,6 @@ class TestCassandraBackup(unittest.TestCase):
       'snapshot']).and_return().times(1)
     cassandra_backup.create_snapshot()
 
-  def test_refresh_data(self):
-    flexmock(subprocess).should_receive("check_call").and_return().\
-      at_least.times(1)
-    cassandra_backup.refresh_data()
-
   def test_remove_old_data(self):
     pass
 
@@ -168,7 +163,6 @@ class TestCassandraBackup(unittest.TestCase):
       and_return()
     flexmock(cassandra_backup).should_receive('restore_snapshots').and_return()
     flexmock(start_cassandra).should_receive('run').and_return()
-    flexmock(cassandra_backup).should_receive('refresh_data').and_return()
     flexmock(cassandra_backup).should_receive('clear_old_snapshots').\
       and_return()
     flexmock(backup_recovery_helper).\
@@ -197,7 +191,6 @@ class TestCassandraBackup(unittest.TestCase):
       and_return()
     flexmock(cassandra_backup).should_receive('restore_snapshots').and_return()
     flexmock(start_cassandra).should_receive('run').and_return()
-    flexmock(cassandra_backup).should_receive('refresh_data').and_return()
     flexmock(cassandra_backup).should_receive('clear_old_snapshots').\
       and_return()
     self.assertEquals(True, cassandra_backup.restore_data('', ''))


### PR DESCRIPTION
These commands were getting stuck when restoring a multinode deployment.