### PR TITLE
Make sure lsof catches only servers.

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4932,7 +4932,7 @@ HOSTS
 
       # Check if the port is really available.
       if !in_use
-        actually_available = Djinn.log_run("lsof -i:#{possibly_free_port}")
+        actually_available = Djinn.log_run("lsof -i:#{possibly_free_port} -sTCP:LISTEN")
         if actually_available.empty?
           Djinn.log_debug("Port #{possibly_free_port} is available for use.")
           return possibly_free_port

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -1139,8 +1139,8 @@ class TestDjinn < Test::Unit::TestCase
       }
     }
 
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:80").and_return("")
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:4380").and_return("")
+    flexmock(Djinn).should_receive(:log_run).with("lsof -i:80 -sTCP:LISTEN").and_return("")
+    flexmock(Djinn).should_receive(:log_run).with("lsof -i:4380 -sTCP:LISTEN").and_return("")
 
     expected = "Error: requested http port is already in use."
     assert_equal(expected, djinn.relocate_app('myapp', 80, 4380, @secret))
@@ -1172,8 +1172,8 @@ class TestDjinn < Test::Unit::TestCase
       }
     }
 
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:8080").and_return("")
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:443").and_return("")
+    flexmock(Djinn).should_receive(:log_run).with("lsof -i:8080 -sTCP:LISTEN").and_return("")
+    flexmock(Djinn).should_receive(:log_run).with("lsof -i:443 -sTCP:LISTEN").and_return("")
 
     expected = "Error: requested https port is already in use."
     assert_equal(expected, djinn.relocate_app('myapp', 8080, 443, @secret))
@@ -1205,8 +1205,8 @@ class TestDjinn < Test::Unit::TestCase
       }
     }
 
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:8080").and_return("")
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:4380").and_return("")
+    flexmock(Djinn).should_receive(:log_run).with("lsof -i:8080 -sTCP:LISTEN").and_return("")
+    flexmock(Djinn).should_receive(:log_run).with("lsof -i:4380 -sTCP:LISTEN").and_return("")
 
     expected = "Error: requested https port is already in use."
     assert_equal(expected, djinn.relocate_app('myapp', 8080, 4380, @secret))
@@ -1238,8 +1238,8 @@ class TestDjinn < Test::Unit::TestCase
       }
     }
 
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:8080").and_return("")
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:4380").and_return("")
+    flexmock(Djinn).should_receive(:log_run).with("lsof -i:8080 -sTCP:LISTEN").and_return("")
+    flexmock(Djinn).should_receive(:log_run).with("lsof -i:4380 -sTCP:LISTEN").and_return("")
 
     expected = "Error: requested http port is already in use."
     assert_equal(expected, djinn.relocate_app('myapp', 8080, 4380, @secret))


### PR DESCRIPTION
Before we were catching anything related to the port, also outgoing
connections (ie a curl to a web site for example). We need to only check
the services ie the processes that are listening to the port.