### PR TITLE
Increate Java API file size limit from 1MB to 33MB. 

### DIFF
--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
@@ -44,7 +44,7 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
     /**
      * The maximum size of any given API request.
      */
-    private static final int MAX_API_REQUEST_SIZE = 1048576;
+    private static final int MAX_API_REQUEST_SIZE = 33554432;
 
     private static final Logger logger = Logger.getLogger(ApiProxyLocalImpl.class.getName());
 


### PR DESCRIPTION
Increasing the Java API file size limit from 1MB to 33MB. This allows larger external files to be downloaded using UrlFetch. The 33MB limit was chosen based on [file size limit](https://github.com/AppScale/appscale/blob/master/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java#L188) set for images, memcache, and mail defined later in the file. 