### PR TITLE
Use monit to stop all running services.

### DIFF
--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -228,7 +228,8 @@ module TaskQueue
   #   flower_password: A String that is used as the password to log into flower.
   def self.start_flower(flower_password)
     start_cmd = "/usr/local/bin/flower --basic_auth=appscale:#{flower_password}"
-    stop_cmd = "/bin/ps ax | /bin/grep flower | /bin/grep -v grep | /usr/bin/awk '{print $1}' | xargs kill -9"
+    stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
+          "flower #{flower_password}"
     MonitInterface.start(:flower, start_cmd, stop_cmd, FLOWER_SERVER_PORT)
   end
 

--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -20,6 +20,7 @@ module TerminateHelper
     `rm -f /etc/monit/conf.d/appscale*.cfg`
     `rm -f /etc/monit/conf.d/controller-17443.cfg`
     `service monit restart`
+    `killall -9 -g -r djinnServer`
     `monit start all`
     `rm -f #{APPSCALE_CONFIG_DIR}/port-*.txt`
     `rm -f #{APPSCALE_CONFIG_DIR}/search_ip`


### PR DESCRIPTION
All AppScale services are monitored by monit, so instead of using kill to
stop them, we can use monit. This allow us to not kill generic processes
(like python) and to use our script to stop services (which means we stop
also child processes).