### PR TITLE
Fix logic so that 'stop' actually works

### DIFF
--- a/AppController/scripts/appcontroller
+++ b/AppController/scripts/appcontroller
@@ -44,14 +44,18 @@ do_stop()
 
 case "$1" in
  
-    start|stop)
+    start)
         if status_of_proc "$DAEMON_NAME" "$DAEMON" > /dev/null; then
                 echo "$DAEMON_NAME already running."
                 exit 0
         fi
         do_${1}
         ;;
- 
+        
+    stop)
+        do_stop
+        ;;
+        
     restart|reload|force-reload)
         do_stop
         do_start


### PR DESCRIPTION
Previous version of this file would check to see if the service was running, and if it was running, refuse to stop it.