### PR TITLE
Make sure HAProxy can start properly

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4294,8 +4294,6 @@ HOSTS
 
   # This function performs basic setup ahead of starting the API services.
   def initialize_server()
-    head_node_ip = get_public_ip(@options['hostname'])
-
     if not HAProxy.is_running?
       HAProxy.initialize_config()
       HAProxy.create_app_load_balancer_config(my_node.public_ip,

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4308,6 +4308,8 @@ HOSTS
 
     if not Nginx.is_running?
       Nginx.initialize_config()
+      Nginx.create_app_load_balancer_config(my_node.public_ip,
+        my_node.private_ip, AppDashboard::PROXY_PORT)
       Nginx.start()
       Djinn.log_info("Nginx configured and started.")
     else

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2573,7 +2573,7 @@ class Djinn
     # If this function is called twice, ensure there are no duplicate values.
     @app_info_map[app_id]['appengine'].uniq!()
 
-    unless app_id == AppDashboard.APP_NAME
+    unless app_id == AppDashboard::APP_NAME
       HAProxy.update_app_config(my_node.private_ip, app_id,
         @app_info_map[app_id])
     end

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2573,8 +2573,10 @@ class Djinn
     # If this function is called twice, ensure there are no duplicate values.
     @app_info_map[app_id]['appengine'].uniq!()
 
-    HAProxy.update_app_config(my_node.private_ip, app_id,
-      @app_info_map[app_id])
+    unless app_id == AppDashboard.APP_NAME
+      HAProxy.update_app_config(my_node.private_ip, app_id,
+        @app_info_map[app_id])
+    end
 
     unless Nginx.is_app_already_configured(app_id)
       # Get static handlers and make sure cache path is readable.
@@ -4296,6 +4298,8 @@ HOSTS
 
     if not HAProxy.is_running?
       HAProxy.initialize_config()
+      HAProxy.create_app_load_balancer_config(my_node.public_ip,
+        my_node.private_ip, AppDashboard::PROXY_PORT)
       HAProxy.start()
       Djinn.log_info("HAProxy configured and started.")
     else

--- a/AppController/lib/haproxy.rb
+++ b/AppController/lib/haproxy.rb
@@ -84,13 +84,13 @@ module HAProxy
     START_PORT + app_number
   end
 
-  # Create the config file for Datastore Server applications
+  # Create the config file for Datastore Server applications.
   def self.create_datastore_server_config(my_ip, listen_port, table)
     self.create_app_config(my_ip, my_ip, listen_port, 
       DatastoreServer.get_server_ports(table), DatastoreServer::NAME)
   end
 
-  # Create the configuration file for the AppDashboard application
+  # Create the configuration file for the AppDashboard application.
   def self.create_app_load_balancer_config(my_public_ip, my_private_ip,
     listen_port)
     self.create_app_config(my_public_ip, my_private_ip, listen_port,

--- a/AppController/lib/haproxy.rb
+++ b/AppController/lib/haproxy.rb
@@ -90,6 +90,13 @@ module HAProxy
       DatastoreServer.get_server_ports(table), DatastoreServer::NAME)
   end
 
+  # Create the configuration file for the AppDashboard application
+  def self.create_app_load_balancer_config(my_public_ip, my_private_ip,
+    listen_port)
+    self.create_app_config(my_public_ip, my_private_ip, listen_port,
+      AppDashboard::SERVER_PORTS, AppDashboard::APP_NAME)
+  end
+
   # A generic function for creating haproxy config files used by appscale services
   def self.create_app_config(my_public_ip, my_private_ip, listen_port, 
     server_ports, name)

--- a/AppController/lib/nginx.rb
+++ b/AppController/lib/nginx.rb
@@ -523,7 +523,7 @@ CONFIG
     end
   end
 
-  # Create the configuration file for the AppDashboard application
+  # Create the configuration file for the AppDashboard application.
   def self.create_app_load_balancer_config(my_public_ip, my_private_ip,
     proxy_port)
     self.create_app_config(my_public_ip, my_private_ip, proxy_port,
@@ -531,7 +531,7 @@ CONFIG
       AppDashboard::PUBLIC_DIRECTORY, AppDashboard::LISTEN_SSL_PORT)
   end
 
-  # Create the configuration file for the datastore_server
+  # Create the configuration file for the datastore_server.
   def self.create_datastore_server_config(all_private_ips, proxy_port)
     config = <<CONFIG
 upstream #{DatastoreServer::NAME} {

--- a/AppController/lib/nginx.rb
+++ b/AppController/lib/nginx.rb
@@ -523,6 +523,14 @@ CONFIG
     end
   end
 
+  # Create the configuration file for the AppDashboard application
+  def self.create_app_load_balancer_config(my_public_ip, my_private_ip,
+    proxy_port)
+    self.create_app_config(my_public_ip, my_private_ip, proxy_port,
+      AppDashboard::LISTEN_PORT, AppDashboard::APP_NAME,
+      AppDashboard::PUBLIC_DIRECTORY, AppDashboard::LISTEN_SSL_PORT)
+  end
+
   # Create the configuration file for the datastore_server
   def self.create_datastore_server_config(all_private_ips, proxy_port)
     config = <<CONFIG


### PR DESCRIPTION
This restores the old behavior of the dashboard getting HAProxy
routing before HAProxy first starts to prevent config errors.