### PR TITLE
start cron in docker for faststart.sh

### DIFF
--- a/scripts/fast-start.sh
+++ b/scripts/fast-start.sh
@@ -102,6 +102,8 @@ PRIVATE_IP=""
 if grep docker /proc/1/cgroup > /dev/null ; then
     # We need to start sshd by hand.
     /usr/sbin/sshd
+    # Force Start cron
+    /usr/sbin/cron 
     PROVIDER="Docker"
 elif lspci | grep VirtualBox > /dev/null ; then
     PROVIDER="VirtualBox"


### PR DESCRIPTION
Cron must be started manually inside of Docker.