### PR TITLE
No remote monit

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -545,7 +545,7 @@ class Djinn
     @memcache_contents = ""
 
     # Make sure monit is started.
-    MonitInterface.start_monit(nil, nil)
+    MonitInterface.start_monit()
   end
 
   # This method is needed, since we are not able to change log level on
@@ -4368,7 +4368,7 @@ HOSTS
 
     begin
       MonitInterface.start(:controller, start, stop, SERVER_PORT, env,
-        nil, nil, match_cmd)
+        match_cmd)
     rescue => e
       Djinn.log_warn("Failed to set local AppController monit: retrying.")
       retry

--- a/AppController/lib/ejabberd.rb
+++ b/AppController/lib/ejabberd.rb
@@ -35,7 +35,7 @@ module Ejabberd
     stop_cmd = "/etc/init.d/ejabberd stop"
     match_cmd = "sname ejabberd"
     MonitInterface.start(:ejabberd, start_cmd, stop_cmd, ports=9999,
-      env_vars=nil, remote_ip=nil, remote_key=nil, match_cmd=match_cmd)
+      env_vars=nil, match_cmd=match_cmd)
   end
 
   def self.stop

--- a/AppController/lib/groomer_service.rb
+++ b/AppController/lib/groomer_service.rb
@@ -20,7 +20,7 @@ module GroomerService
     stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
       "#{groomer} /usr/bin/python2"
     MonitInterface.start(:groomer_service, start_cmd, stop_cmd, "9999", {},
-      nil, nil, start_cmd, MAX_MEM)
+      start_cmd, MAX_MEM)
     MonitInterface.start_file(:groomer_file_check,
       "/var/log/appscale/groomer_service-9999.log", stop_cmd, "12")
   end

--- a/AppController/lib/haproxy.rb
+++ b/AppController/lib/haproxy.rb
@@ -59,7 +59,7 @@ module HAProxy
     stop_cmd = "/usr/sbin/service haproxy stop"
     match_cmd = "/usr/sbin/haproxy"
     MonitInterface.start(:haproxy, start_cmd, stop_cmd, ports=9999,
-      env_vars=nil, remote_ip=nil, remote_key=nil, match_cmd=match_cmd)
+      env_vars=nil, match_cmd=match_cmd)
   end
 
   def self.stop()

--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -22,7 +22,7 @@ module MonitInterface
   MONIT = "/usr/bin/monit"
 
   def self.start_monit()
-    self.execute_command("service monit start")
+    Djinn.log_run("service monit start")
   end
   
   def self.start(watch, start_cmd, stop_cmd, ports, env_vars=nil,
@@ -34,7 +34,7 @@ module MonitInterface
         env_vars, match_cmd, mem)
     }
 
-    self.execute_command("#{MONIT} start -g #{watch}")
+    Djinn.log_run("#{MONIT} start -g #{watch}")
   end
 
   def self.start_file(watch, path, action, hours=12)
@@ -46,17 +46,17 @@ BOO
     monit_file = "/etc/monit/conf.d/appscale-#{watch}.cfg"
     HelperFunctions.write_file(monit_file, contents)
 
-    self.execute_command("service monit reload")
+    Djinn.log_run("service monit reload")
 
     Djinn.log_info("Watching file #{path} for #{watch}" +
       " with exec action [#{action}]")
 
 
-    self.execute_command("#{MONIT} start -g #{watch}")
+    Djinn.log_run("#{MONIT} start -g #{watch}")
   end
 
   def self.restart(watch)
-    self.execute_command("#{MONIT} restart -g #{watch}")
+    Djinn.log_run("#{MONIT} restart -g #{watch}")
   end
 
   def self.write_monit_config(watch, start_cmd, stop_cmd, port,
@@ -113,24 +113,16 @@ BOO
   end
 
   def self.stop(watch)
-    self.execute_command("#{MONIT} stop -g #{watch}")
+    Djinn.log_run("#{MONIT} stop -g #{watch}")
   end
 
   def self.remove(watch)
-    self.execute_command("#{MONIT} stop -g #{watch}")
-    self.execute_command("#{MONIT} unmonitor -g #{watch}")
+    Djinn.log_run("#{MONIT} stop -g #{watch}")
+    Djinn.log_run("#{MONIT} unmonitor -g #{watch}")
   end
 
   def self.is_running?(watch)
-    output = self.execute_command("#{MONIT} summary | grep #{watch} | grep Running")
+    output = Djinn.log_run("#{MONIT} summary | grep #{watch} | grep Running")
     return (not output == "")
-  end
-
-  private
-  def self.execute_command(cmd)
-    output = Djinn.log_run(cmd)
-    Djinn.log_debug("running command #{cmd} returned #{output}.")
-
-    return output
   end
 end

--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -22,7 +22,7 @@ module MonitInterface
   MONIT = "/usr/bin/monit"
 
   def self.start_monit()
-    self.execute_command("service monit start", remote_ip, remote_key)
+    self.execute_command("service monit start")
   end
   
   def self.start(watch, start_cmd, stop_cmd, ports, env_vars=nil,

--- a/AppController/lib/nginx.rb
+++ b/AppController/lib/nginx.rb
@@ -67,7 +67,7 @@ module Nginx
     stop_cmd = "#{service_bin} nginx stop"
     match_cmd = "nginx: (.*) process"
     MonitInterface.start(:nginx, start_cmd, stop_cmd, ports=9999, env_vars=nil,
-      remote_ip=nil, remote_key=nil, match_cmd=match_cmd)
+      match_cmd=match_cmd)
   end
 
   def self.stop()

--- a/AppController/lib/search.rb
+++ b/AppController/lib/search.rb
@@ -66,7 +66,7 @@ module Search
     start_cmd = "/root/appscale/SearchService/solr/solr/bin/solr start -noprompt -s /opt/appscale/solr/schemaless-appscale/solr/"
     stop_cmd = "/root/appscale/SearchService/solr/solr/bin/solr stop -all"
     MonitInterface.start(:solr, start_cmd, stop_cmd, ports=SOLR_SERVER_PORT,
-      env_vars=nil, remote_ip=nil, remote_key=nil, match_cmd="solr")
+      env_vars=nil, match_cmd="solr")
     HelperFunctions.sleep_until_port_is_open("localhost", SOLR_SERVER_PORT)
     Djinn.log_debug("Done starting SOLR.")
   end

--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -72,7 +72,7 @@ module TaskQueue
     stop_cmd = "/usr/sbin/rabbitmqctl stop"
     match_cmd = "sname rabbit"
     MonitInterface.start(:rabbitmq, start_cmd, stop_cmd, ports=9999,
-      env_vars=nil, remote_ip=nil, remote_key=nil, match_cmd=match_cmd)
+      env_vars=nil, match_cmd=match_cmd)
 
     # Next, start up the TaskQueue Server.
     start_taskqueue_server()
@@ -137,7 +137,7 @@ module TaskQueue
     tries_left = RABBIT_START_RETRY
     loop {
       MonitInterface.start(:rabbitmq, full_cmd, stop_cmd, ports=9999,
-        env_vars=nil, remote_ip=nil, remote_key=nil, match_cmd=match_cmd)
+        env_vars=nil, match_cmd=match_cmd)
       Djinn.log_debug("Waiting for RabbitMQ on local node to come up")
       begin
         Timeout::timeout(MAX_WAIT_FOR_RABBITMQ) do

--- a/AppController/lib/zookeeper_helper.rb
+++ b/AppController/lib/zookeeper_helper.rb
@@ -94,7 +94,7 @@ def start_zookeeper(clear_datastore)
   stop_cmd = "/usr/sbin/service #{zk_server} stop"
   match_cmd = "org.apache.zookeeper.server.quorum.QuorumPeerMain"
   MonitInterface.start(:zookeeper, start_cmd, stop_cmd, ports=ZOOKEEPER_PORT, env_vars=nil,
-    remote_ip=nil, remote_key=nil, match_cmd=match_cmd)
+    match_cmd=match_cmd)
 end
 
 def is_zookeeper_running?

--- a/AppDB/cassandra/cassandra_helper.rb
+++ b/AppDB/cassandra/cassandra_helper.rb
@@ -146,7 +146,7 @@ def start_cassandra(clear_datastore)
   stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py java cassandra"
   match_cmd = "#{APPSCALE_HOME}/AppDB/cassandra"
   MonitInterface.start(:cassandra, start_cmd, stop_cmd, ports=9999, env_vars=nil,
-    remote_ip=nil, remote_key=nil, match_cmd=match_cmd)
+    match_cmd=match_cmd)
   HelperFunctions.sleep_until_port_is_open(HelperFunctions.local_ip,
     THRIFT_PORT)
 end


### PR DESCRIPTION
Remove the (not used) ability to call monit remotely from MonitInterface.