### PR TITLE
Changing AC's monit start command to only start the Ruby process.

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4381,7 +4381,7 @@ HOSTS
       'EC2_HOME' => ENV['EC2_HOME'],
       'JAVA_HOME' => ENV['JAVA_HOME']
     }
-    start = "/usr/sbin/service appscale-controller start"
+    start = "/usr/bin/ruby -w /root/appscale/AppController/djinnServer.rb"
     stop = "/usr/sbin/service appscale-controller stop"
     match_cmd = "/usr/bin/ruby -w /root/appscale/AppController/djinnServer.rb"
 


### PR DESCRIPTION
Trusty: https://ocd.appscale.com:8080/job/Daily%20Build/1215/