### PR TITLE
Don't use killall to stop the controller.

### DIFF
--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -30,7 +30,7 @@ module TerminateHelper
 
     # Let's make sure we restart any non-appscale service.
     `service monit restart`
-    `killall -9 -g -r djinnServer`
+    `/usr/bin/python2 /root/appscale/scripts/stop_service.py /root/appscale/AppController/djinnServer.rb /usr/bin/ruby`
     `monit start all`
     `rm -f #{APPSCALE_CONFIG_DIR}/port-*.txt`
     `rm -f #{APPSCALE_CONFIG_DIR}/search_ip`


### PR DESCRIPTION
killall -r will not work if the controller is not started by
start-stop-daemon.