### PR TITLE
Coordinate backup and restore operations from head node

### DIFF
--- a/AppDB/backup/backup_exceptions.py
+++ b/AppDB/backup/backup_exceptions.py
@@ -1,5 +1,14 @@
 """ AppScale exceptions for backup or restores. """
 
+
 class BRException(Exception):
   """ Base class for backup and recovery exceptions. """
   pass
+
+
+class NoKeyException(Exception):
+  """ Indicates that a required key is missing. """
+
+
+class AmbiguousKeyException(Exception):
+  """ Indicates that there is more than one key to choose from. """

--- a/AppDB/backup/backup_recovery_constants.py
+++ b/AppDB/backup/backup_recovery_constants.py
@@ -36,8 +36,8 @@ PADDING_PERCENTAGE = 0.9
 TMP_ZOOKEEPER_BACKUP = "{0}/zookeeper_backup".format(
   BACKUP_DIR_LOCATION)
 
-# Zookeeper paths that are not considered while taking a backup.
-ZK_IGNORE_PATHS = ['/appcontroller', '/appscale/deployment_id', '/zookeeper']
+# Zookeeper paths that should not be altered during a restore.
+ZK_KEEP_PATHS = ['/appcontroller', '/appscale/deployment_id']
 
 # Zookeeper top level path.
 ZK_TOP_LEVEL = "/"
@@ -45,6 +45,9 @@ ZK_TOP_LEVEL = "/"
 # Zookeeper tarred backup file location.
 ZOOKEEPER_BACKUP_FILE_LOCATION = "{0}/zookeeper_backup.tar.gz".format(
   BACKUP_DIR_LOCATION)
+
+# The directory where ZooKeeper data is stored.
+ZK_DATA_DIR = '/opt/appscale/zookeeper'
 
 # Zookeeper data directories.
 ZOOKEEPER_DATA_SUBDIRS = ["version-2"]

--- a/AppDB/backup/backup_recovery_constants.py
+++ b/AppDB/backup/backup_recovery_constants.py
@@ -32,6 +32,9 @@ HTTP_OK = 200
 # The percentage of disk fullness that is considered reasonable.
 PADDING_PERCENTAGE = 0.9
 
+# Number of times to retry stopping a service.
+SERVICE_STOP_RETRIES = 10
+
 # Temporary Zookeeper backup file location.
 TMP_ZOOKEEPER_BACKUP = "{0}/zookeeper_backup".format(
   BACKUP_DIR_LOCATION)

--- a/AppDB/backup/backup_recovery_helper.py
+++ b/AppDB/backup/backup_recovery_helper.py
@@ -114,7 +114,7 @@ def get_snapshot_paths(service):
     return file_list
 
   look_for = 'snapshots'
-  data_dir = "{0}{1}".format(APPSCALE_DATA_DIR, service)
+  data_dir = "{0}/{1}".format(APPSCALE_DATA_DIR, service)
   for full_path, _, file in os.walk(data_dir):
     if look_for in full_path:
       file_list.append(full_path)

--- a/AppDB/backup/backup_recovery_helper.py
+++ b/AppDB/backup/backup_recovery_helper.py
@@ -215,7 +215,7 @@ def tar_backup_files(file_paths, target):
       format(backup_file_location))
 
   # Tar up the backup files.
-  tar = tarfile.open(backup_file_location, "w:gz")
+  tar = tarfile.open(backup_file_location, "w")
   for name in file_paths:
     tar.add(name)
   tar.close()

--- a/AppDB/backup/cassandra_backup.py
+++ b/AppDB/backup/cassandra_backup.py
@@ -56,7 +56,7 @@ def create_snapshot(snapshot_name=''):
 def remove_old_data():
   """ Removes previous node data from the Cassandra store. """
   for directory in CASSANDRA_DATA_SUBDIRS:
-    data_dir = "{0}{1}/{2}".format(APPSCALE_DATA_DIR, "cassandra",
+    data_dir = "{0}/{1}/{2}".format(APPSCALE_DATA_DIR, "cassandra",
       directory)
     logging.warning("Removing data from {0}".format(data_dir))
     try:
@@ -76,7 +76,7 @@ def restore_snapshots():
   logging.info("Restoring Cassandra snapshots.")
 
   for directory in CASSANDRA_DATA_SUBDIRS:
-    data_dir = "{0}{1}/{2}/".format(APPSCALE_DATA_DIR, "cassandra",
+    data_dir = "{0}/{1}/{2}/".format(APPSCALE_DATA_DIR, "cassandra",
       directory)
     logging.debug("Restoring in dir {0}".format(data_dir))
     for path, _, filenames in os.walk(data_dir):

--- a/AppDB/backup/cassandra_backup.py
+++ b/AppDB/backup/cassandra_backup.py
@@ -32,6 +32,7 @@ from constants import LOG_FORMAT
 sys.path.append(
   os.path.join(os.path.dirname(__file__), '../../InfrastructureManager'))
 from utils import utils
+from utils.utils import ExitCodes
 from utils.utils import KEY_DIRECTORY
 from utils.utils import MonitStates
 
@@ -180,9 +181,9 @@ def restore_data(path, keyname):
 
   machines_without_restore = []
   for db_ip in db_ips:
-    e_code = utils.ssh(db_ip, keyname, 'ls {}'.format(path),
+    exit_code = utils.ssh(db_ip, keyname, 'ls {}'.format(path),
       method=subprocess.call)
-    if e_code != 0:
+    if exit_code != ExitCodes.SUCCESS:
       machines_without_restore.append(db_ip)
 
   if len(machines_without_restore) > 0:

--- a/AppDB/backup/cassandra_backup.py
+++ b/AppDB/backup/cassandra_backup.py
@@ -131,8 +131,7 @@ def backup_data(path, keyname):
   logging.info("Starting new db backup.")
 
   db_ips = appscale_info.get_db_ips()
-  print('db_ips: {}'.format(db_ips))
-  if len(db_ips) < 1:
+  if not db_ips:
     raise BRException('Unable to find any Cassandra machines.')
 
   for db_ip in db_ips:
@@ -176,7 +175,7 @@ def restore_data(path, keyname):
   logging.info("Starting new db restore.")
 
   db_ips = appscale_info.get_db_ips()
-  if len(db_ips) < 1:
+  if not db_ips:
     raise BRException('Unable to find any Cassandra machines.')
 
   machines_without_restore = []
@@ -186,7 +185,7 @@ def restore_data(path, keyname):
     if exit_code != ExitCodes.SUCCESS:
       machines_without_restore.append(db_ip)
 
-  if len(machines_without_restore) > 0:
+  if machines_without_restore:
     logging.info('The following machines do not have a restore file: {}'.
       format(machines_without_restore))
     response = raw_input('Would you like to continue? [y/N] ')
@@ -247,7 +246,7 @@ if "__main__" == __name__:
   if len(keys) > 1:
     raise AmbiguousKeyException(
       'There is more than one ssh key in {}'.format(KEY_DIRECTORY))
-  if len(keys) < 1:
+  if not keys:
     raise NoKeyException('There is no ssh key in {}'.format(KEY_DIRECTORY))
   keyname = keys[0].split('.')[0]
 

--- a/AppDB/backup/cassandra_backup.py
+++ b/AppDB/backup/cassandra_backup.py
@@ -17,6 +17,7 @@ import backup_recovery_helper
 from backup_recovery_constants import BACKUP_DIR_LOCATION
 from backup_recovery_constants import CASSANDRA_DATA_SUBDIRS
 from backup_recovery_constants import PADDING_PERCENTAGE
+from backup_recovery_constants import SERVICE_STOP_RETRIES
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 from cassandra import shut_down_cassandra
@@ -196,7 +197,7 @@ def restore_data(path, keyname):
     summary = utils.ssh(db_ip, keyname, 'monit summary',
       method=subprocess.check_output)
     status = utils.monit_status(summary, CASSANDRA_MONIT_WATCH_NAME)
-    retries = 10
+    retries = SERVICE_STOP_RETRIES
     while status != MonitStates.UNMONITORED:
       utils.ssh(db_ip, keyname,
         'monit stop {}'.format(CASSANDRA_MONIT_WATCH_NAME))

--- a/AppDB/backup/zookeeper_backup.py
+++ b/AppDB/backup/zookeeper_backup.py
@@ -1,24 +1,38 @@
-""" Zookeeper data backup. """
+#!/usr/bin/env python2
+""" Backup or restore ZooKeeper Data. """
 
+import argparse
 import json
 import kazoo.client
+import kazoo.exceptions
 import logging
+import os
+from StringIO import StringIO
+import subprocess
+import sys
+import time
 
-import backup_exceptions
-import backup_recovery_helper
-import gcs_helper
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../lib'))
+import appscale_info
+from constants import CONTROLLER_SERVICE
+from constants import LOG_FORMAT
 
-from backup_recovery_constants import ZK_IGNORE_PATHS
+sys.path.append(
+  os.path.join(os.path.dirname(__file__), '../../InfrastructureManager'))
+from utils import utils
+from utils.utils import KEY_DIRECTORY
+
+from backup_exceptions import AmbiguousKeyException
+from backup_exceptions import BRException
+from backup_exceptions import NoKeyException
+from backup_recovery_constants import BACKUP_DIR_LOCATION
+from backup_recovery_constants import ZK_KEEP_PATHS
 from backup_recovery_constants import ZK_TOP_LEVEL
-from backup_recovery_constants import ZOOKEEPER_BACKUP_FILE_LOCATION
-from backup_recovery_constants import StorageTypes
-from backup_recovery_constants import TMP_ZOOKEEPER_BACKUP
+from backup_recovery_constants import ZK_DATA_DIR
 
 from zkappscale import shut_down_zookeeper
 from zkappscale.zktransaction import DEFAULT_HOST as ZK_DEFAULT_HOST
 from zkappscale.zktransaction import PATH_SEPARATOR
-
-logging.getLogger().setLevel(logging.INFO)
 
 def dump_zk(filename):
   """ Dumps Zookeeper application data to a file.
@@ -43,26 +57,18 @@ def recursive_dump(handle, path, file_handler):
   """
   try:
     children = handle.get_children(path)
-    if not any(path.startswith(item) for item in ZK_IGNORE_PATHS):
-      logging.debug("Processing path: {0}".format(path))
-      for child in children:
-        logging.debug("Processing child: {0}".format(child))
-        new_path = '{0}{1}'.format(path, child)
-        if path != ZK_TOP_LEVEL:
-          new_path = PATH_SEPARATOR.join([path, child])
-        recursive_dump(handle, new_path, file_handler)
+    logging.debug("Processing path: {0}".format(path))
+    for child in children:
+      logging.debug("Processing child: {0}".format(child))
+      new_path = '{0}{1}'.format(path, child)
       if path != ZK_TOP_LEVEL:
-        value = handle.get(path)[0].encode('base64')
-        file_handler.write("{}\n".format(json.dumps({path: value})))
+        new_path = PATH_SEPARATOR.join([path, child])
+      recursive_dump(handle, new_path, file_handler)
+    if path != ZK_TOP_LEVEL:
+      value = handle.get(path)[0].encode('base64')
+      file_handler.write("{}\n".format(json.dumps({path: value})))
   except kazoo.exceptions.NoNodeError:
     logging.debug('Reached the end of the zookeeper path.')
-
-def flush_zk():
-  """ Deletes Zookeeper data. """
-  handle = kazoo.client.KazooClient(hosts=ZK_DEFAULT_HOST)
-  handle.start()
-  recursive_flush(handle, ZK_TOP_LEVEL)
-  handle.stop()
 
 def recursive_flush(handle, path):
   """ Recursively deletes the path and the value of the children of the given
@@ -74,53 +80,49 @@ def recursive_flush(handle, path):
   """
   try:
     children = handle.get_children(path)
-    if not any(path.startswith(item) for item in ZK_IGNORE_PATHS):
-      logging.debug("Processing path: {0}".format(path))
-      for child in children:
-        logging.debug("Processing child: {0}".format(child))
-        new_path = '{0}{1}'.format(path, child)
-        if path != ZK_TOP_LEVEL:
-          new_path = PATH_SEPARATOR.join([path, child])
-        recursive_flush(handle, new_path)
-      try:
-        handle.delete(path)
-      except kazoo.exceptions.BadArgumentsError:
-        logging.warning('BadArgumentsError while deleting path: {0}.'.format(
-          path))
-      except kazoo.exceptions.NotEmptyError:
-        logging.warning('NotEmptyError while deleting path: {0}. Skipping..'.
-          format(path))
+    logging.debug("Processing path: {0}".format(path))
+    for child in children:
+      logging.debug("Processing child: {0}".format(child))
+      new_path = '{0}{1}'.format(path, child)
+      if path != ZK_TOP_LEVEL:
+        new_path = PATH_SEPARATOR.join([path, child])
+      recursive_flush(handle, new_path)
+    try:
+      handle.delete(path)
+    except kazoo.exceptions.BadArgumentsError:
+      logging.warning('BadArgumentsError while deleting path: {0}.'.format(
+        path))
+    except kazoo.exceptions.NotEmptyError:
+      logging.warning('NotEmptyError while deleting path: {0}. Skipping..'.
+        format(path))
   except kazoo.exceptions.NoNodeError:
     logging.debug('Reached the end of the zookeeper path.')
 
-def restore_zk(filename):
+def restore_zk(handle, zk_persist_file):
   """ Restores Zookeeper data from a fixed file in the local FS.
 
   Args:
-    filename: A str, the path to the temporary Zookeeper backup file.
+    handle: A Zookeeper client handler.
+    zk_persist_file: A file object containing the ZooKeeper data.
   """
-  handle = kazoo.client.KazooClient(hosts=ZK_DEFAULT_HOST)
-  handle.start()
-  with open(filename, 'r') as f:
-    for line in f.readlines():
-      pair = json.loads(line)
-      path = pair.keys()[0]
-      value = pair.values()[0].decode('base64')
+  for line in zk_persist_file.readlines():
+    pair = json.loads(line)
+    path = pair.keys()[0]
+    value = pair.values()[0].decode('base64')
+    try:
+      handle.create(path, bytes(value), makepath=True)
+      logging.debug("Created '{0}'".format(path))
+    except kazoo.exceptions.NodeExistsError:
       try:
-        handle.create(path, bytes(value), makepath=True)
-        logging.debug("Created '{0}'".format(path))
-      except kazoo.exceptions.NodeExistsError:
-        try:
-          handle.set(path, bytes(value))
-          logging.debug("Updated '{0}'".format(path))
-        except kazoo.exceptions.BadArgumentsError:
-          logging.warning("BadArgumentsError for path '{0}'".format(path))
-      except kazoo.exceptions.NoNodeError:
-        logging.warning("NoNodeError for path '{0}'. Parent nodes are "
-          "missing".format(path))
-      except kazoo.exceptions.ZookeeperError:
-        logging.warning("ZookeeperError for path '{0}'".format(path))
-  handle.stop()
+        handle.set(path, bytes(value))
+        logging.debug("Updated '{0}'".format(path))
+      except kazoo.exceptions.BadArgumentsError:
+        logging.warning("BadArgumentsError for path '{0}'".format(path))
+    except kazoo.exceptions.NoNodeError:
+      logging.warning("NoNodeError for path '{0}'. Parent nodes are "
+        "missing".format(path))
+    except kazoo.exceptions.ZookeeperError:
+      logging.warning("ZookeeperError for path '{0}'".format(path))
 
 def shutdown_zookeeper():
   """ Top level function for bringing down Zookeeper.
@@ -133,98 +135,169 @@ def shutdown_zookeeper():
     return False
   return True
 
-def backup_data(storage, path=''):
-  """ Backup Zookeeper directories/files.
+def backup_data(path, keyname):
+  """ Backup Zookeeper data to path.
 
   Args:
-    storage: A str, one of the StorageTypes class members.
     path: A str, the name of the backup file to be created.
-  Returns:
-    The path to the backup file on success, None otherwise.
+    keyname: A string containing the deployment's keyname.
+  Raises:
+    BRException if unable to find any ZooKeeper machines.
   """
-  if storage not in StorageTypes().get_storage_types():
-    logging.error("Storage '{0}' not supported.")
-    return None
-
   logging.info("Starting new zk backup.")
-  dump_zk(TMP_ZOOKEEPER_BACKUP)
 
-  tar_file = backup_recovery_helper.tar_backup_files([TMP_ZOOKEEPER_BACKUP],
-    ZOOKEEPER_BACKUP_FILE_LOCATION)
-  if not tar_file:
-    logging.error('Error while tarring up Zookeeper files. Aborting backup...')
-    backup_recovery_helper.remove(TMP_ZOOKEEPER_BACKUP)
-    backup_recovery_helper.delete_local_backup_file(tar_file)
-    backup_recovery_helper.move_secondary_backup(tar_file)
-    return None
+  running = subprocess.call(['service', CONTROLLER_SERVICE, 'status']) == 0
+  if not running:
+    logging.error('Please start AppScale before backing up ZooKeeper.')
+    sys.exit(1)
 
-  if storage == StorageTypes.LOCAL_FS:
-    logging.info("Done with local zk backup!")
-    backup_recovery_helper.remove(TMP_ZOOKEEPER_BACKUP)
-    backup_recovery_helper.\
-      delete_secondary_backup(ZOOKEEPER_BACKUP_FILE_LOCATION)
-    return tar_file
-  elif storage == StorageTypes.GCS:
-    return_value = path
-    # Upload to GCS.
-    if not gcs_helper.upload_to_bucket(path, tar_file):
-      logging.error("Upload to GCS failed. Aborting backup...")
-      backup_recovery_helper.move_secondary_backup(tar_file)
-      return_value = None
-    else:
-      logging.info("Done with zk backup!")
-      backup_recovery_helper.\
-        delete_secondary_backup(ZOOKEEPER_BACKUP_FILE_LOCATION)
+  # Stop ZooKeeper and backup data on only one ZooKeeper machine.
+  # This is to avoid downtime on deployments with multiple ZooKeeper machines.
+  zk_ips = appscale_info.get_zk_node_ips()
+  if len(zk_ips) < 1:
+    raise BRException('Unable to find any ZooKeeper machines.')
+  zk_ip = zk_ips[0]
 
-    # Remove local backup files.
-    backup_recovery_helper.remove(TMP_ZOOKEEPER_BACKUP)
-    backup_recovery_helper.delete_local_backup_file(tar_file)
-    return return_value
+  timestamp = int(time.time())
+  backup_file = '{}/zk_backup_{}.tar.gz'.format(BACKUP_DIR_LOCATION, timestamp)
+  try:
+    utils.ssh(zk_ip, keyname, 'monit stop -g zookeeper')
+    utils.ssh(zk_ip, keyname,
+      'tar czf {} -C {} .'.format(backup_file, ZK_DATA_DIR))
+    utils.scp_from(zk_ip, keyname, backup_file, path)
+  finally:
+    utils.ssh(zk_ip, keyname, 'rm -f {}'.format(backup_file))
+    utils.ssh(zk_ip, keyname, 'monit start -g zookeeper')
 
-def restore_data(storage, path=''):
+def restore_data(path, keyname):
   """ Restores the Zookeeper snapshot.
 
   Args:
-    storage: A str, one of the StorageTypes class members.
     path: A str, the name of the backup file to restore from.
+    keyname: A string containing the deployment's keyname.
+  Raises:
+    BRException if unable to find any ZooKeeper machines.
   """
-  if storage not in StorageTypes().get_storage_types():
-    logging.error("Storage '{0}' not supported.")
-    return False
-
   logging.info("Starting new zk restore.")
 
-  if storage == StorageTypes.GCS:
-    # Download backup file and store locally with a fixed name.
-    if not gcs_helper.download_from_bucket(path,
-        ZOOKEEPER_BACKUP_FILE_LOCATION):
-      logging.error("Download from GCS failed. Aborting recovery...")
-      return False
+  running = subprocess.call(['service', CONTROLLER_SERVICE, 'status']) == 0
+  if running:
+    logging.error('Please stop AppScale before restoring ZooKeeper.')
+    sys.exit(1)
 
-  # TODO Make sure there's a snapshot to rollback to if restore fails.
-  # Not pressing for fresh deployments.
+  zk_ips = appscale_info.get_zk_node_ips()
+  if len(zk_ips) < 1:
+    raise BRException('Unable to find any ZooKeeper machines.')
 
-  flush_zk()
-  try:
-    backup_recovery_helper.untar_backup_files(ZOOKEEPER_BACKUP_FILE_LOCATION)
-  except backup_exceptions.BRException as br_exception:
-    logging.exception("Error while unpacking backup files. Exception: {0}".
-      format(str(br_exception)))
-    if storage == StorageTypes.GCS:
-      backup_recovery_helper.\
-        delete_local_backup_file(ZOOKEEPER_BACKUP_FILE_LOCATION)
-    return False
-  restore_zk(TMP_ZOOKEEPER_BACKUP)
+  timestamp = int(time.time())
+  restore_file = '{}/zk_restore_{}.tar.gz'.\
+    format(BACKUP_DIR_LOCATION, timestamp)
 
-  # Local cleanup.
-  backup_recovery_helper.remove(TMP_ZOOKEEPER_BACKUP)
-  if storage == StorageTypes.GCS:
-    backup_recovery_helper.\
-      delete_local_backup_file(ZOOKEEPER_BACKUP_FILE_LOCATION)
+  # Cache name of ZooKeeper service for each machine.
+  zk_service_names = {}
+  for zk_ip in zk_ips:
+    zk_service_names[zk_ip] = utils.zk_service_name(zk_ip, keyname)
+
+  # Copy restore file to and start ZooKeeper on relevant machines.
+  logging.info('Copying data to ZooKeeper machines.')
+  for zk_ip in zk_ips:
+    zk_service = zk_service_names[zk_ip]
+    try:
+      utils.scp_to(zk_ip, keyname, path, restore_file)
+      utils.ssh(zk_ip, keyname, 'service {} restart'.format(zk_service))
+    except subprocess.CalledProcessError as error:
+      logging.exception('Failed to prepare restore on {}'.format(zk_ip))
+      utils.ssh(zk_ip, keyname, 'rm -f {}'.format(restore_file))
+      utils.ssh(zk_ip, keyname, 'service {} stop'.format(zk_service))
+      raise error
+
+  # Save deployment-specific data.
+  deployment_data = StringIO()
+  zk = kazoo.client.KazooClient(hosts=':2181,'.join(zk_ips) + ':2181')
+  zk.start()
+  for zk_node in ZK_KEEP_PATHS:
+    recursive_dump(zk, zk_node, deployment_data)
+  zk.stop()
+
+  # Stop ZooKeeper and clear existing data directory.
+  logging.info('Clearing existing data on ZooKeeper machines.')
+  for zk_ip in zk_ips:
+    zk_service = zk_service_names[zk_ip]
+    try:
+      utils.ssh(zk_ip, keyname, 'service {} stop'.format(zk_service))
+      utils.ssh(zk_ip, keyname, 'rm -rf {}/*'.format(ZK_DATA_DIR))
+    except subprocess.CalledProcessError as error:
+      logging.exception('Unable to clear data on {}'.format(zk_ip))
+      deployment_data.close()
+      utils.ssh(zk_ip, keyname, 'rm -f {}'.format(restore_file))
+      utils.ssh(zk_ip, keyname, 'service {} stop'.format(zk_service))
+      raise error
+
+  # Restore data and restart ZooKeeper on relevant machines.
+  logging.info('Restoring data on ZooKeeper machines.')
+  for zk_ip in zk_ips:
+    zk_service = zk_service_names[zk_ip]
+    try:
+      utils.ssh(zk_ip, keyname,
+        'tar xzf {} -C {}'.format(restore_file, ZK_DATA_DIR))
+      utils.ssh(zk_ip, keyname, 'service {} start'.format(zk_service))
+    except subprocess.CalledProcessError as error:
+      logging.exception('Unable to restore on {}'.format(zk_ip))
+      deployment_data.close()
+      utils.ssh(zk_ip, keyname, 'rm -f {}'.format(restore_file))
+      utils.ssh(zk_ip, keyname, 'service {} stop'.format(zk_service))
+      raise error
+
+  # Restore deployment-specific data.
+  logging.info('Restoring deployment-specific data.')
+  zk = kazoo.client.KazooClient(hosts=':2181,'.join(zk_ips) + ':2181')
+  zk.start()
+  for zk_node in ZK_KEEP_PATHS:
+    recursive_flush(zk, zk_node)
+  deployment_data.seek(0)
+  restore_zk(zk, deployment_data)
+  zk.stop()
+
+  # Stop ZooKeeper on relevant machines.
+  logging.info('Stopping ZooKeeper.')
+  for zk_ip in zk_ips:
+    zk_service = zk_service_names[zk_ip]
+    try:
+      utils.ssh(zk_ip, keyname, 'service {} stop'.format(zk_service))
+      utils.ssh(zk_ip, keyname, 'rm -rf {}'.format(restore_file))
+    finally:
+      deployment_data.close()
 
   logging.info("Done with zk restore.")
   return True
 
 if "__main__" == __name__:
-  backup_data(storage='', path='')
-  # restore_data(storage='', path='')
+  logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
+
+  parser = argparse.ArgumentParser(
+    description='Backup or restore ZooKeeper data.')
+  io_group = parser.add_mutually_exclusive_group(required=True)
+  io_group.add_argument('--input',
+    help='The file to use for restoring ZooKeeper data.')
+  io_group.add_argument('--output',
+    help='The location to store the ZooKeeper backup.')
+  parser.add_argument('--verbose', action='store_true',
+    help='Enable debug-level logging.')
+
+  args = parser.parse_args()
+
+  if args.verbose:
+    logging.getLogger().setLevel(logging.DEBUG)
+
+  keys = [key for key in os.listdir(KEY_DIRECTORY) if key.endswith('.key')]
+  if len(keys) > 1:
+    raise AmbiguousKeyException(
+      'There is more than one ssh key in {}'.format(KEY_DIRECTORY))
+  if len(keys) < 1:
+    raise NoKeyException('There is no ssh key in {}'.format(KEY_DIRECTORY))
+  keyname = keys[0].split('.')[0]
+
+  if args.input is not None:
+    restore_data(args.input, keyname)
+  else:
+    backup_data(args.output, keyname)

--- a/AppDB/backup/zookeeper_backup.py
+++ b/AppDB/backup/zookeeper_backup.py
@@ -154,7 +154,7 @@ def backup_data(path, keyname):
   # Stop ZooKeeper and backup data on only one ZooKeeper machine.
   # This is to avoid downtime on deployments with multiple ZooKeeper machines.
   zk_ips = appscale_info.get_zk_node_ips()
-  if len(zk_ips) < 1:
+  if not zk_ips:
     raise BRException('Unable to find any ZooKeeper machines.')
   zk_ip = zk_ips[0]
 

--- a/AppDB/backup/zookeeper_backup.py
+++ b/AppDB/backup/zookeeper_backup.py
@@ -17,6 +17,9 @@ import appscale_info
 from constants import CONTROLLER_SERVICE
 from constants import LOG_FORMAT
 
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../AppDB'))
+from zkappscale import zktransaction
+
 sys.path.append(
   os.path.join(os.path.dirname(__file__), '../../InfrastructureManager'))
 from utils import utils
@@ -213,7 +216,9 @@ def restore_data(path, keyname):
 
   # Save deployment-specific data.
   deployment_data = StringIO()
-  zk = kazoo.client.KazooClient(hosts=':2181,'.join(zk_ips) + ':2181')
+  hosts_template = ':{},'.join(zk_ips) + ':{}'
+  zk = kazoo.client.KazooClient(
+    hosts=hosts_template.format(zktransaction.DEFAULT_PORT))
   zk.start()
   for zk_node in ZK_KEEP_PATHS:
     recursive_dump(zk, zk_node, deployment_data)

--- a/AppDB/backup/zookeeper_backup.py
+++ b/AppDB/backup/zookeeper_backup.py
@@ -216,9 +216,9 @@ def restore_data(path, keyname):
 
   # Save deployment-specific data.
   deployment_data = StringIO()
-  hosts_template = ':{},'.join(zk_ips) + ':{}'
+  hosts_template = ':{port},'.join(zk_ips) + ':{port}'
   zk = kazoo.client.KazooClient(
-    hosts=hosts_template.format(zktransaction.DEFAULT_PORT))
+    hosts=hosts_template.format(port=zktransaction.DEFAULT_PORT))
   zk.start()
   for zk_node in ZK_KEEP_PATHS:
     recursive_dump(zk, zk_node, deployment_data)

--- a/AppDB/backup/zookeeper_backup.py
+++ b/AppDB/backup/zookeeper_backup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-""" Backup or restore ZooKeeper Data. """
+""" Backup or restore ZooKeeper data. """
 
 import argparse
 import json
@@ -7,10 +7,10 @@ import kazoo.client
 import kazoo.exceptions
 import logging
 import os
-from StringIO import StringIO
 import subprocess
 import sys
 import time
+from StringIO import StringIO
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../lib'))
 import appscale_info
@@ -26,9 +26,9 @@ from backup_exceptions import AmbiguousKeyException
 from backup_exceptions import BRException
 from backup_exceptions import NoKeyException
 from backup_recovery_constants import BACKUP_DIR_LOCATION
+from backup_recovery_constants import ZK_DATA_DIR
 from backup_recovery_constants import ZK_KEEP_PATHS
 from backup_recovery_constants import ZK_TOP_LEVEL
-from backup_recovery_constants import ZK_DATA_DIR
 
 from zkappscale import shut_down_zookeeper
 from zkappscale.zktransaction import DEFAULT_HOST as ZK_DEFAULT_HOST

--- a/AppDB/test/unit/test_cassandra_backup.py
+++ b/AppDB/test/unit/test_cassandra_backup.py
@@ -6,12 +6,10 @@ import subprocess
 import unittest
 from flexmock import flexmock
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../../backup/"))
-import backup_exceptions
-import backup_recovery_constants
-import backup_recovery_helper
-import cassandra_backup
-import gcs_helper
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
+from backup import backup_exceptions
+from backup import cassandra_backup
+
 
 from cassandra import shut_down_cassandra
 from cassandra import start_cassandra

--- a/AppDB/test/unit/test_cassandra_backup.py
+++ b/AppDB/test/unit/test_cassandra_backup.py
@@ -85,7 +85,7 @@ class TestCassandraBackup(unittest.TestCase):
       keyname, 'ls {}'.format(path)).and_return(0)
 
     flexmock(utils).should_receive('ssh').with_args(re.compile('^192.*'),
-      keyname,  'monit summary').and_return('summary output')
+      keyname, 'monit summary').and_return('summary output')
     flexmock(utils).should_receive('monit_status').and_return('Not monitored')
 
     flexmock(utils).should_receive('ssh').with_args(re.compile('^192.*'),

--- a/AppDB/test/unit/test_cassandra_backup.py
+++ b/AppDB/test/unit/test_cassandra_backup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import re
 import sys
 import subprocess
 import unittest
@@ -10,9 +11,14 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../../"))
 from backup import backup_exceptions
 from backup import cassandra_backup
 
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../lib'))
+import appscale_info
+
+sys.path.append(
+  os.path.join(os.path.dirname(__file__), '../../../InfrastructureManager'))
+from utils import utils
 
 from cassandra import shut_down_cassandra
-from cassandra import start_cassandra
 from cassandra.cassandra_interface import NODE_TOOL
 
 class TestCassandraBackup(unittest.TestCase):
@@ -39,159 +45,57 @@ class TestCassandraBackup(unittest.TestCase):
     cassandra_backup.shutdown_datastore()
 
   def test_backup_data(self):
-    # Test for unsupported storage backend.
-    flexmock(backup_recovery_constants.StorageTypes()).\
-      should_receive("get_storage_types").and_return([])
-    self.assertEquals(None, cassandra_backup.backup_data('blah', ''))
+    db_ips = ['192.168.33.10', '192.168.33.11']
+    keyname = 'key1'
+    path = '~/cassandra_backup.tar'
 
-    flexmock(cassandra_backup).should_receive('clear_old_snapshots').\
-      and_return()
+    flexmock(appscale_info).should_receive('get_db_ips').and_return(db_ips)
 
-    # Test with failure to create new snapshots.
-    flexmock(cassandra_backup).should_receive('create_snapshot').\
-      and_return(False)
-    self.assertEquals(None, cassandra_backup.backup_data('', ''))
+    flexmock(utils).should_receive('ssh').with_args(re.compile('^192.*'),
+      keyname, re.compile('.*snapshot$'))
 
-    # Test with missing Cassandra snapshots.
-    flexmock(cassandra_backup).should_receive('create_snapshot').\
-      and_return(True)
-    flexmock(backup_recovery_helper).\
-      should_receive('get_snapshot_paths').and_return([])
-    self.assertEquals(None, cassandra_backup.backup_data('', ''))
+    flexmock(utils).should_receive('ssh').with_args(db_ips[0], keyname,
+      re.compile('.*du -s.*')).and_return('200 file1\n500 file2\n')
+    flexmock(utils).should_receive('ssh').with_args(db_ips[1], keyname,
+      re.compile('.*du -s.*')).and_return('900 file1\n100 file2\n')
 
-    # Test with at least one Cassandra snapshot and not enough disk space.
-    flexmock(backup_recovery_helper).\
-      should_receive('get_snapshot_paths').and_return(['some/snapshot'])
-    flexmock(backup_recovery_helper).should_receive('enough_disk_space').\
-      with_args('cassandra').and_return(False)
-    self.assertEquals(None, cassandra_backup.backup_data('', ''))
+    # Assume first DB machine does not have enough space.
+    flexmock(utils).should_receive('ssh').with_args(db_ips[0], keyname,
+      re.compile('^df .*')).and_return('headers\ndisk blocks used 100 etc')
+    self.assertRaises(backup_exceptions.BRException,
+      cassandra_backup.backup_data, path, keyname)
 
-    # Test with at least one Cassandra snapshot and failure to create the tar.
-    flexmock(backup_recovery_helper).should_receive('enough_disk_space').\
-      with_args('cassandra').and_return(True)
-    flexmock(backup_recovery_helper).should_receive('tar_backup_files').\
-      and_return(None)
-    flexmock(cassandra_backup).should_receive('clear_old_snapshots').\
-      and_return()
-    flexmock(backup_recovery_helper).\
-      should_receive('delete_local_backup_file').\
-      and_return()
-    flexmock(backup_recovery_helper).should_receive('move_secondary_backup').\
-      and_return()
-    self.assertEquals(None, cassandra_backup.backup_data('', ''))
+    flexmock(utils).should_receive('ssh').with_args(db_ips[0], keyname,
+      re.compile('^df .*')).and_return('headers\ndisk blocks used 2000 etc')
+    flexmock(utils).should_receive('ssh').with_args(db_ips[1], keyname,
+      re.compile('^df .*')).and_return('headers\ndisk blocks used 3000 etc')
 
-    # Test with successful tar creation and local storage.
-    flexmock(backup_recovery_helper).\
-      should_receive('get_snapshot_paths').\
-      and_return(['some/snapshot'])
-    flexmock(backup_recovery_helper).should_receive('tar_backup_files').\
-      and_return('some/tar')
-    flexmock(cassandra_backup).should_receive('clear_old_snapshots').\
-      and_return()
-    flexmock(backup_recovery_helper).should_receive('delete_secondary_backup').\
-      and_return()
-    self.assertIsNotNone(cassandra_backup.backup_data('', ''))
-
-    # Test with GCS as storage backend and failure to upload.
-    flexmock(gcs_helper).should_receive('upload_to_bucket').and_return(False)
-    flexmock(backup_recovery_helper).should_receive('move_secondary_backup').\
-      and_return()
-    flexmock(cassandra_backup).should_receive('clear_old_snapshots').\
-      and_return()
-    flexmock(backup_recovery_helper).\
-      should_receive('delete_local_backup_file').\
-      and_return()
-    self.assertEquals(None, cassandra_backup.backup_data(
-      backup_recovery_constants.StorageTypes.GCS, ''))
-
-    # Test with GCS as storage backend and successful upload.
-    flexmock(gcs_helper).should_receive('upload_to_bucket').and_return(True)
-    flexmock(backup_recovery_helper).should_receive('delete_secondary_backup').\
-      and_return()
-    flexmock(cassandra_backup).should_receive('clear_old_snapshots').\
-      and_return()
-    flexmock(backup_recovery_helper).\
-      should_receive('delete_local_backup_file').\
-      and_return()
-    self.assertIsNotNone(cassandra_backup.backup_data(
-      backup_recovery_constants.StorageTypes.GCS, ''))
+    flexmock(utils).should_receive('ssh').with_args(re.compile('^192.*'),
+      keyname, re.compile('.*tar --transform.*'))
+    cassandra_backup.backup_data(path, keyname)
 
   def test_restore_data(self):
-    # Test for unsupported storage backend.
-    flexmock(backup_recovery_constants.StorageTypes()).\
-      should_receive("get_storage_types").and_return([])
-    self.assertEquals(False, cassandra_backup.restore_data('blah', ''))
+    db_ips = ['192.168.33.10', '192.168.33.11']
+    keyname = 'key1'
+    path = '~/cassandra_backup.tar'
 
-    # Test with failure to download backup from GCS.
-    flexmock(gcs_helper).should_receive('download_from_bucket').and_return(
-      False)
-    self.assertEquals(False, cassandra_backup.restore_data(
-      backup_recovery_constants.StorageTypes.GCS, ''))
+    flexmock(appscale_info).should_receive('get_db_ips').and_return(db_ips)
 
-    # Test with successful download from GCS and failure to shut down Cassandra.
-    flexmock(gcs_helper).should_receive('download_from_bucket').and_return(
-      True)
-    flexmock(shut_down_cassandra).should_receive('run').and_return(False)
-    flexmock(backup_recovery_helper).\
-      should_receive('delete_local_backup_file').\
-      and_return()
-    self.assertEquals(False, cassandra_backup.restore_data(
-      backup_recovery_constants.StorageTypes.GCS, ''))
+    flexmock(utils).should_receive('ssh').with_args(re.compile('^192.*'),
+      keyname, 'ls {}'.format(path)).and_return(0)
 
-    # Test with successful Cassandra shutdown and failure to untar.
-    flexmock(gcs_helper).should_receive('download_from_bucket').and_return(
-      True)
-    flexmock(shut_down_cassandra).should_receive('run').and_return(True)
-    flexmock(cassandra_backup).should_receive('remove_old_data').and_return()
-    flexmock(backup_recovery_helper).should_receive(
-      'untar_backup_files').and_raise(backup_exceptions.BRException)
-    flexmock(start_cassandra).should_receive('run').and_return()
-    flexmock(backup_recovery_helper).\
-      should_receive('delete_local_backup_file').\
-      and_return()
-    self.assertEquals(False, cassandra_backup.restore_data(
-      backup_recovery_constants.StorageTypes.GCS, ''))
+    flexmock(utils).should_receive('ssh').with_args(re.compile('^192.*'),
+      keyname,  'monit summary').and_return('summary output')
+    flexmock(utils).should_receive('monit_status').and_return('Not monitored')
 
-    # Test normal case for GCS.
-    flexmock(gcs_helper).should_receive('download_from_bucket').and_return(
-      True)
-    flexmock(shut_down_cassandra).should_receive('run').and_return(True)
-    flexmock(cassandra_backup).should_receive('remove_old_data').and_return()
-    flexmock(backup_recovery_helper).should_receive('untar_backup_files').\
-      and_return()
-    flexmock(cassandra_backup).should_receive('restore_snapshots').and_return()
-    flexmock(start_cassandra).should_receive('run').and_return()
-    flexmock(cassandra_backup).should_receive('clear_old_snapshots').\
-      and_return()
-    flexmock(backup_recovery_helper).\
-      should_receive('delete_local_backup_file').\
-      and_return()
-    self.assertEquals(True, cassandra_backup.restore_data(
-      backup_recovery_constants.StorageTypes.GCS, ''))
+    flexmock(utils).should_receive('ssh').with_args(re.compile('^192.*'),
+      keyname, re.compile('^find.* -exec rm .*'))
+    flexmock(utils).should_receive('ssh').with_args(re.compile('^192.*'),
+      keyname, re.compile('^tar xf .*'))
+    flexmock(utils).should_receive('ssh').with_args(re.compile('^192.*'),
+      keyname, re.compile('^monit start .*'))
 
-    # Test with failure to shut down Cassandra in local mode.
-    flexmock(shut_down_cassandra).should_receive('run').and_return(False)
-    self.assertEquals(False, cassandra_backup.restore_data('', ''))
-
-    # Test with successful Cassandra shutdown and failure to untar in local
-    # mode.
-    flexmock(shut_down_cassandra).should_receive('run').and_return(True)
-    flexmock(cassandra_backup).should_receive('remove_old_data').and_return()
-    flexmock(backup_recovery_helper).should_receive(
-      'untar_backup_files').and_raise(backup_exceptions.BRException)
-    flexmock(start_cassandra).should_receive('run').and_return()
-    self.assertEquals(False, cassandra_backup.restore_data('', ''))
-
-    # Test normal case in local mode.
-    flexmock(shut_down_cassandra).should_receive('run').and_return(True)
-    flexmock(cassandra_backup).should_receive('remove_old_data').and_return()
-    flexmock(backup_recovery_helper).should_receive('untar_backup_files').\
-      and_return()
-    flexmock(cassandra_backup).should_receive('restore_snapshots').and_return()
-    flexmock(start_cassandra).should_receive('run').and_return()
-    flexmock(cassandra_backup).should_receive('clear_old_snapshots').\
-      and_return()
-    self.assertEquals(True, cassandra_backup.restore_data('', ''))
+    cassandra_backup.restore_data(path, keyname)
 
 if __name__ == "__main__":
   unittest.main()    

--- a/AppDB/test/unit/test_zookeeper_backup.py
+++ b/AppDB/test/unit/test_zookeeper_backup.py
@@ -6,12 +6,9 @@ import sys
 import unittest
 from flexmock import flexmock
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../../backup/"))
-import backup_exceptions
-import backup_recovery_constants
-import backup_recovery_helper
-import zookeeper_backup
-import gcs_helper
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
+from backup import zookeeper_backup
+
 
 from zkappscale.zktransaction import DEFAULT_HOST as ZK_DEFAULT_HOST
 from zkappscale import shut_down_zookeeper

--- a/AppDB/zkappscale/zktransaction.py
+++ b/AppDB/zkappscale/zktransaction.py
@@ -29,8 +29,11 @@ TX_TIMEOUT = 30
 # garbage collector.
 GC_INTERVAL = 30
 
+# The default port that ZooKeeper runs on.
+DEFAULT_PORT = 2181
+
 # The host and port that the Zookeeper service runs on, if none is provided.
-DEFAULT_HOST = "localhost:2181"
+DEFAULT_HOST = 'localhost:{}'.format(DEFAULT_PORT)
 
 # The value that we should set for paths whose value we don't care about.
 DEFAULT_VAL = "default"

--- a/InfrastructureManager/system_manager.py
+++ b/InfrastructureManager/system_manager.py
@@ -125,8 +125,7 @@ class SystemManager():
 
     monit_stats_dict = {}
     for line in monit_stats.split("\n"):
-      # Get rid of extra whitespaces.
-      tokens = " ".join(line.split()).split(" ")
+      tokens = line.split()
       if 'Process' in tokens:
         process_name = tokens[1][1:-1] # Remove quotes.
         # Only keep the service port to identify distinct app servers.

--- a/InfrastructureManager/system_manager.py
+++ b/InfrastructureManager/system_manager.py
@@ -131,7 +131,7 @@ class SystemManager():
         # Only keep the service port to identify distinct app servers.
         if not process_name.startswith("app___"):
           process_name = process_name[:process_name.rfind("-")]
-        process_status = tokens[2].lower()
+        process_status = ' '.join(tokens[2:]).lower()
         monit_stats_dict[process_name] = process_status
     logging.debug("Monit stats: {}".format(monit_stats_dict))
 

--- a/InfrastructureManager/utils/utils.py
+++ b/InfrastructureManager/utils/utils.py
@@ -258,7 +258,7 @@ def scp_from(ip_address, keyname, remote_file, local_file):
 
 
 def zk_service_name(ip_address, keyname):
-  """ Fetches the name of the zookeeper service on a given machine.
+  """ Fetches the name of the ZooKeeper service on a given machine.
 
   Args:
     ip_address: A string containing the IP address of the ZooKeeper machine.

--- a/InfrastructureManager/utils/utils.py
+++ b/InfrastructureManager/utils/utils.py
@@ -283,5 +283,5 @@ def monit_status(summary, service):
   """
   for line in summary.split('\n'):
     if service in line:
-      return line.split()[-1]
+      return ' '.join(line.split()[2:])
   raise ServiceException('Unable to find Monit entry for {}')

--- a/InfrastructureManager/utils/utils.py
+++ b/InfrastructureManager/utils/utils.py
@@ -14,6 +14,12 @@ from constants import SERVICES_DIR
 # The directory that contains the deployment's private SSH key.
 KEY_DIRECTORY = '/etc/appscale/keys/cloud1'
 
+
+class ExitCodes(object):
+  """ Shell exit codes. """
+  SUCCESS = 0
+
+
 class MonitStates(object):
   RUNNING = 'Running'
   UNMONITORED = 'Not monitored'

--- a/Rakefile
+++ b/Rakefile
@@ -136,4 +136,21 @@ namespace :xmppreceiver do
 
 end
 
-task :default => ['appcontroller:test', 'infrastructuremanager:test', 'appmanager:test', 'appdb:test', 'apptaskqueue:test', 'go:test', 'hermes:test', 'searchservice:test', 'lib:test', 'appserver:test', 'xmppreceiver:test', 'appdashboard:test']
+python_tests = [
+  'appdashboard:test',
+  'appdb:test',
+  'appmanager:test',
+  'appserver:test',
+  'apptaskqueue:test',
+  'hermes:test',
+  'infrastructuremanager:test',
+  'lib:test',
+  'searchservice:test',
+  'xmppreceiver:test',
+]
+ruby_tests = ['appcontroller:test']
+go_tests = ['go:test']
+
+task :brief => python_tests + ruby_tests
+
+task :default => python_tests + ruby_tests + go_tests

--- a/lib/appscale_info.py
+++ b/lib/appscale_info.py
@@ -188,6 +188,14 @@ def get_db_slave_ips():
     nodes = nodes[:-1]
   return nodes
 
+def get_db_ips():
+  """ Returns a list of database machines.
+
+  Returns:
+    A list of strings containing IP addresses.
+  """
+  return list(set([get_db_master_ip()] + get_db_slave_ips()))
+
 def get_search_location():
   """ Returns the IP and port of where the search service is running.
 

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -86,3 +86,9 @@ RESERVED_APP_IDS = [DASHBOARD_APP_ID]
 
 # Location of where the search service is running.
 SEARCH_FILE_LOC = "/etc/appscale/search_ip"
+
+# Service scripts directory.
+SERVICES_DIR = '/etc/init.d'
+
+# The AppController's service name.
+CONTROLLER_SERVICE = 'appscale-controller'

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -10,7 +10,7 @@ APPSCALE_HOME = os.environ.get("APPSCALE_HOME", "/root/appscale")
 APP_PID_DIR = '/etc/appscale/'
 
 # Location of where data is persisted on disk.
-APPSCALE_DATA_DIR = '/opt/appscale/'
+APPSCALE_DATA_DIR = '/opt/appscale'
 
 # Location of Java AppServer.
 JAVA_APPSERVER = APPSCALE_HOME + '/AppServer_Java'


### PR DESCRIPTION
This changes the format for both the ZooKeeper and Cassandra backup. The ZooKeeper backup is now based on the full data directory to preserve node metadata. The Cassandra backup is no longer gzipped, and the file paths are relative to the data directory.