### PR TITLE
Don't show error when some file don't exists.

### DIFF
--- a/firewall.conf
+++ b/firewall.conf
@@ -41,7 +41,7 @@ MASTER_FILE=/etc/appscale/masters
 SLAVES_FILE=/etc/appscale/slaves
 
 # Allow any connections between AppScale nodes
-cat $ALL_IPS_FILE $MASTER_FILE $SLAVES_FILE | sort -u | while read line; do
+cat $ALL_IPS_FILE $MASTER_FILE $SLAVES_FILE 2> /dev/null | sort -u | while read line; do
   test -n "$line" && iptables -A INPUT -s ${line} -j ACCEPT
 done
 


### PR DESCRIPTION
Current master has these errors in the logs early on in the start process:

D, [2016-05-01T04:00:20.083682 #2696] DEBUG -- : Running bash /root/appscale/firewall.conf
cat: /etc/appscale/masters: No such file or directory
cat: /etc/appscale/slaves: No such file or directory

this patch cleans them up.