### PR TITLE
Wait until the app is uploaded before enabling

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2000,6 +2000,8 @@ class Djinn
     if File.exists?(location)
       begin
         ZKInterface.add_app_entry(appname, my_node.public_ip, location)
+        uac = UserAppClient.new(my_node.private_ip, @@secret)
+        uac.enable_app(appname)
         result = "Found #{appname} in zookeeper."
       rescue FailedZooKeeperOperationException => e
         Djinn.log_warn("(done_uploading) couldn't talk to zookeeper " +

--- a/AppDB/soap_server.py
+++ b/AppDB/soap_server.py
@@ -158,7 +158,7 @@ class Apps:
     self.last_time_updated_date_ = str(self.creation_date_)
     self.cksum_ = "0"
     self.num_entries_ = "0"
-    self.enabled_ = "true"
+    self.enabled_ = "false"
     self.indexes_ = "0"
     return
 


### PR DESCRIPTION
This is to prevent the AppController from trying to deploy the
application before it has finished uploading.