### PR TITLE
Use older version of httparty

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -281,7 +281,7 @@ installgems()
     gem install json ${GEMOPT} -v 1.8.3
     sleep 1
     gem install soap4r-ruby1.9 ${GEMOPT}
-    gem install httparty ${GEMOPT}
+    gem install httparty ${GEMOPT} -v 0.13.7
     gem install httpclient ${GEMOPT}
     # This is for the unit testing framework.
     gem install simplecov ${GEMOPT}


### PR DESCRIPTION
Some Ruby code depends on httparty 0.13.7's behavior of allowing additional types to be passed to JSON.dump. This is intended as a quick fix until all of the JSON code can be inspected and fixed.