### PR TITLE
Set num_tokens to 1

### DIFF
--- a/AppDB/cassandra_env/templates/cassandra.yaml
+++ b/AppDB/cassandra_env/templates/cassandra.yaml
@@ -22,7 +22,7 @@ cluster_name: 'Test Cluster'
 #
 # If you already have a cluster with 1 token per node, and wish to migrate to 
 # multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
-num_tokens: 1
+num_tokens: APPSCALE-NUM-TOKENS
 
 # initial_token allows you to specify tokens manually.  While you can use # it with
 # vnodes (num_tokens > 1, above) -- in which case you should provide a 

--- a/AppDB/cassandra_env/templates/cassandra.yaml
+++ b/AppDB/cassandra_env/templates/cassandra.yaml
@@ -22,7 +22,7 @@ cluster_name: 'Test Cluster'
 #
 # If you already have a cluster with 1 token per node, and wish to migrate to 
 # multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
-num_tokens: 256
+num_tokens: 1
 
 # initial_token allows you to specify tokens manually.  While you can use # it with
 # vnodes (num_tokens > 1, above) -- in which case you should provide a 

--- a/AppDB/zkappscale/zktransaction.py
+++ b/AppDB/zkappscale/zktransaction.py
@@ -3,6 +3,7 @@
 Distributed id and lock service for transaction support.
 """
 import logging
+import os
 import re
 import sys
 import threading
@@ -91,6 +92,10 @@ MAX_GROUPS_FOR_XG = 25
 
 # The separator value for the lock list when using XG transactions.
 LOCK_LIST_SEPARATOR = "!XG_LIST!"
+
+# The location of the ZooKeeper server script.
+ZK_SERVER_CMD = os.path.join('/usr', 'share', 'zookeeper', 'bin',
+                             'zkServer.sh')
 
 class ZKTransactionException(Exception):
   """ ZKTransactionException defines a custom exception class that should be

--- a/scripts/datastore_upgrade.py
+++ b/scripts/datastore_upgrade.py
@@ -27,6 +27,7 @@ from datastore_server import ID_KEY_LENGTH
 from dbconstants import APP_ENTITY_SCHEMA
 from dbconstants import APP_ENTITY_TABLE
 from zkappscale import zktransaction as zk
+from zkappscale.zktransaction import ZK_SERVER_CMD
 from zkappscale.zktransaction import ZKInternalException
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../InfrastructureManager"))
@@ -112,7 +113,13 @@ def start_cassandra(db_ips, db_master, keyname):
       logging.exception(message)
       raise dbconstants.AppScaleDBError(message)
 
-    logging.info("Successfully started Cassandra.")
+  logging.info('Waiting for Cassandra to be ready')
+  status_cmd = '{} status'.format(cassandra_interface.NODE_TOOL)
+  while (utils.ssh(db_master, keyname, status_cmd,
+                     method=subprocess.call) != 0):
+    time.sleep(5)
+
+  logging.info("Successfully started Cassandra.")
 
 
 def start_zookeeper(zk_ips, keyname):
@@ -131,7 +138,13 @@ def start_zookeeper(zk_ips, keyname):
       logging.exception(message)
       raise ZKInternalException(message)
 
-    logging.info("Successfully started ZooKeeper.")
+  logging.info('Waiting for ZooKeeper to be ready')
+  status_cmd = '{} status'.format(ZK_SERVER_CMD)
+  while (utils.ssh(zk_ips[0], keyname, status_cmd,
+                   method=subprocess.call) != 0):
+    time.sleep(5)
+
+  logging.info("Successfully started ZooKeeper.")
 
 
 def get_datastore():

--- a/scripts/datastore_upgrade.py
+++ b/scripts/datastore_upgrade.py
@@ -90,7 +90,7 @@ def start_cassandra(db_ips, db_master, keyname):
     AppScaleDBError if unable to start Cassandra.
   """
   logging.info("Starting Cassandra...")
-  nodes_with_tokens = set(db_ips) - set(db_master)
+  nodes_with_tokens = set(db_ips) - {db_master}
   for index, ip in enumerate(db_ips):
     init_config = '{script} --local-ip {ip} --master-ip {db_master}'.format(
       script=SETUP_CASSANDRA_SCRIPT, ip=ip, db_master=db_master)

--- a/scripts/datastore_upgrade.py
+++ b/scripts/datastore_upgrade.py
@@ -89,9 +89,14 @@ def start_cassandra(db_ips, db_master, keyname):
     AppScaleDBError if unable to start Cassandra.
   """
   logging.info("Starting Cassandra...")
-  for ip in db_ips:
+  nodes_with_tokens = set(db_ips) - set(db_master)
+  for index, ip in enumerate(db_ips):
     init_config = '{script} --local-ip {ip} --master-ip {db_master}'.format(
       script=SETUP_CASSANDRA_SCRIPT, ip=ip, db_master=db_master)
+    if ip in nodes_with_tokens:
+      # This was taken from get_local_token in cassandra_helper.rb.
+      token = index * (2**127) / len(db_ips)
+      init_config += ' --local-token {}'.format(token)
     try:
       utils.ssh(ip, keyname, init_config)
     except subprocess.CalledProcessError:

--- a/scripts/monit_start_service.py
+++ b/scripts/monit_start_service.py
@@ -4,7 +4,6 @@ import logging
 import os
 import subprocess
 import sys
-import time
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../AppDB'))
 from cassandra_env import cassandra_interface
@@ -35,14 +34,12 @@ def start_service(service_name):
   """
   logging.info("Starting " + service_name)
   watch_name = ""
-  service_command = ""
   if service_name == datastore_upgrade.CASSANDRA_WATCH_NAME:
     start_cmd = CASSANDRA_EXECUTABLE + " start -p " + PID_FILE
     stop_cmd = "/usr/bin/python2 " + APPSCALE_HOME + "/scripts/stop_service.py java cassandra"
     watch_name = datastore_upgrade.CASSANDRA_WATCH_NAME
     ports = [CASSANDRA_PORT]
     match_cmd = cassandra_interface.CASSANDRA_INSTALL_DIR
-    service_command = cassandra_interface.NODE_TOOL
 
   if service_name == datastore_upgrade.ZK_WATCH_NAME:
     zk_server="zookeeper-server"
@@ -55,7 +52,6 @@ def start_service(service_name):
     watch_name = datastore_upgrade.ZK_WATCH_NAME
     match_cmd = "org.apache.zookeeper.server.quorum.QuorumPeerMain"
     ports = [zk.DEFAULT_PORT]
-    service_command = '/usr/share/zookeeper/bin/zkServer.sh'
 
   monit_app_configuration.create_config_file(watch_name, start_cmd, stop_cmd,
     ports, upgrade_flag=True, match_cmd=match_cmd)
@@ -64,17 +60,9 @@ def start_service(service_name):
     logging.error("Monit was unable to start " + service_name)
     return 1
   else:
-    sleep_until_service_is_up(service_command)
-    logging.info("Successfully started " + service_name)
+    logging.info('Monit configured for {}'.format(service_name))
     return 0
 
-def sleep_until_service_is_up(service_command):
-  """ Sleeps until the service is actually up after Monit has started it.
-    Args:
-      service_command: The command to check the status of the service.
-    """
-  while subprocess.call([service_command, 'status']) != 0:
-    time.sleep(10)
 
 if __name__ == "__main__":
   args_length = len(sys.argv)

--- a/scripts/setup_cassandra_config_files.py
+++ b/scripts/setup_cassandra_config_files.py
@@ -27,9 +27,9 @@ if __name__ == "__main__":
                       help='The initial Cassandra token.')
   args = parser.parse_args()
 
-  num_tokens = 256
+  num_tokens = '256'
   if args.local_token:
-    num_tokens = 1
+    num_tokens = '1'
 
   replacements = {'APPSCALE-LOCAL': args.local_ip,
                   'APPSCALE-MASTER': args.master_ip,

--- a/scripts/setup_cassandra_config_files.py
+++ b/scripts/setup_cassandra_config_files.py
@@ -27,9 +27,14 @@ if __name__ == "__main__":
                       help='The initial Cassandra token.')
   args = parser.parse_args()
 
+  num_tokens = 256
+  if args.local_token:
+    num_tokens = 1
+
   replacements = {'APPSCALE-LOCAL': args.local_ip,
                   'APPSCALE-MASTER': args.master_ip,
-                  'APPSCALE-TOKEN': args.local_token}
+                  'APPSCALE-TOKEN': args.local_token,
+                  'APPSCALE-NUM-TOKENS': num_tokens}
 
   for filename in os.listdir(CASSANDRA_TEMPLATES):
     source_file_path = os.path.join(CASSANDRA_TEMPLATES, filename)


### PR DESCRIPTION
This is for compatibility with existing deployments. Cassandra's
behavior changed in 2.1.15. Firstly, it actually uses this value
if initial_token is set to an empty string. Secondly, "Specifying
initial_token will override this setting on the node's initial
start, on subsequent starts, this setting will apply even if
initial token is set."