### PR TITLE
Don't define initial token

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4180,7 +4180,7 @@ class Djinn
     HelperFunctions.write_file("#{APPSCALE_CONFIG_DIR}/slaves", "#{slave_ips_newlined}\n")
 
     # Invoke datastore helper function
-    setup_db_config_files(master_ip, slave_ips)
+    setup_db_config_files(master_ip)
 
     update_hosts_info()
 

--- a/AppController/lib/cassandra_helper.rb
+++ b/AppController/lib/cassandra_helper.rb
@@ -51,45 +51,16 @@ def has_soap_server?(job)
 end
 
 
-# Calculates the token that should be set on this machine, which dictates how
-# data should be partitioned between machines.
-#
-# Args:
-#   master_ip: A String corresponding to the private FQDN or IP address of the
-#     machine hosting the Database Master role.
-#   slave_ips: An Array of Strings, where each String corresponds to a private
-#     FQDN or IP address of a machine hosting a Database Slave role.
-# Returns:
-#   A Fixnum that corresponds to the token that should be used on this machine's
-#   Cassandra configuration.
-def get_local_token(master_ip, slave_ips)
-  return if master_ip == HelperFunctions.local_ip
-
-  slave_ips.each_with_index { |ip, index|
-    # This token generation was taken from:
-    # http://www.datastax.com/docs/0.8/install/cluster_init#cluster-init
-    if ip == HelperFunctions.local_ip
-      # Add one to offset the master
-      return (index + 1)*(2**127)/(1 + slave_ips.length)
-    end
-  }
-end
-
-
 # Writes all the configuration files necessary to start Cassandra on this
 # machine.
 #
 # Args:
 #   master_ip: A String corresponding to the private FQDN or IP address of the
 #     machine hosting the Database Master role.
-#   slave_ips: An Array of Strings, where each String corresponds to a private
-#     FQDN or IP address of a machine hosting a Database Slave role.
-def setup_db_config_files(master_ip, slave_ips)
-  local_token = get_local_token(master_ip, slave_ips)
+def setup_db_config_files(master_ip)
   local_ip = HelperFunctions.local_ip
   setup_script = "#{SETUP_CONFIG_SCRIPT} --local-ip #{local_ip} "\
                  "--master-ip #{master_ip}"
-  setup_script << " --local-token #{local_token}" unless local_token.nil?
   Djinn.log_run(setup_script)
 end
 

--- a/AppDB/cassandra_env/templates/cassandra.yaml
+++ b/AppDB/cassandra_env/templates/cassandra.yaml
@@ -22,13 +22,13 @@ cluster_name: 'Test Cluster'
 #
 # If you already have a cluster with 1 token per node, and wish to migrate to 
 # multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
-num_tokens: APPSCALE-NUM-TOKENS
+num_tokens: 256
 
 # initial_token allows you to specify tokens manually.  While you can use # it with
 # vnodes (num_tokens > 1, above) -- in which case you should provide a 
 # comma-separated list -- it's primarily used when adding nodes # to legacy clusters 
 # that do not have vnodes enabled.
-initial_token: APPSCALE-TOKEN
+# initial_token:
 
 # See http://wiki.apache.org/cassandra/HintedHandoff
 # May either be "true" or "false" to enable globally, or contain a list

--- a/scripts/datastore_upgrade.py
+++ b/scripts/datastore_upgrade.py
@@ -90,14 +90,9 @@ def start_cassandra(db_ips, db_master, keyname):
     AppScaleDBError if unable to start Cassandra.
   """
   logging.info("Starting Cassandra...")
-  nodes_with_tokens = set(db_ips) - {db_master}
-  for index, ip in enumerate(db_ips):
+  for ip in db_ips:
     init_config = '{script} --local-ip {ip} --master-ip {db_master}'.format(
       script=SETUP_CASSANDRA_SCRIPT, ip=ip, db_master=db_master)
-    if ip in nodes_with_tokens:
-      # This was taken from get_local_token in cassandra_helper.rb.
-      token = index * (2**127) / len(db_ips)
-      init_config += ' --local-token {}'.format(token)
     try:
       utils.ssh(ip, keyname, init_config)
     except subprocess.CalledProcessError:

--- a/scripts/setup_cassandra_config_files.py
+++ b/scripts/setup_cassandra_config_files.py
@@ -23,18 +23,10 @@ if __name__ == "__main__":
                       help='The private IP address of this machine.')
   parser.add_argument('--master-ip',
                       help='The private IP address of the database master.')
-  parser.add_argument('--local-token', default='',
-                      help='The initial Cassandra token.')
   args = parser.parse_args()
 
-  num_tokens = '256'
-  if args.local_token:
-    num_tokens = '1'
-
   replacements = {'APPSCALE-LOCAL': args.local_ip,
-                  'APPSCALE-MASTER': args.master_ip,
-                  'APPSCALE-TOKEN': args.local_token,
-                  'APPSCALE-NUM-TOKENS': num_tokens}
+                  'APPSCALE-MASTER': args.master_ip}
 
   for filename in os.listdir(CASSANDRA_TEMPLATES):
     source_file_path = os.path.join(CASSANDRA_TEMPLATES, filename)


### PR DESCRIPTION
Previous versions of Cassandra would change num_tokens
on restarts, so setting num_tokens to 256 without defining an
initial token is the most compatible configurations for existing
deployments.