### PR TITLE
Check the return value from done_uploading

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5444,10 +5444,9 @@ HOSTS
           Djinn.log_info("This node is now hosting #{app} source (#{result}).")
           return
         end
-        Djinn.log_debug("Retrying done_uploading since it failed (#{result}).")
+        Djinn.log_warn("Retrying done_uploading since it failed with: #{result}.")
         Kernel.sleep(SMALL_WAIT)
       }
-      Djinn.log_warn("Failed to notify zookeeper we host #{app} (#{result}).")
     end
   end
 


### PR DESCRIPTION
done_uploading adds the node to the list of 'app-hosters' in zookeeper.
This is used to find which nodes has a recent copy of the application when
it's time to refresh the local copy. It could happen that zookeeper is not
available at that time, so we need to retry few times and print an error
message if something goes wrong.

Reference:
https://ocd.appscale.com:8080/job/Blobstore/1149/artifact/appscale-logs/192.168.103.178/appscale/controller-17443.log