### PR TITLE
Start the dashboard as a normal application

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4544,6 +4544,7 @@ HOSTS
           'haproxy' => AppDashboard::PROXY_PORT,
           'language' => AppDashboard::APP_LANGUAGE
       }
+      @app_info_map[AppDashboard::APP_NAME]['appengine'] = []
       @app_names << AppDashboard::APP_NAME
     }
   end

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5324,7 +5324,7 @@ HOSTS
 
 
   def try_to_scale_up(app_name)
-    if @app_info_map[app_name].nil? or @app_info_map[app_name]['appengine'].nil?
+    if @app_info_map[app_name].nil? || !@app_names.include?(app_name)
       Djinn.log_info("Not scaling up app #{app_name}, since we aren't " +
         "hosting it anymore.")
       return

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4541,7 +4541,7 @@ HOSTS
         @app_names << AppDashboard::APP_NAME
       }
     else
-      FileUtils.rm_rf("PERSISTENT_MOUNT_POINT}/apps/#{app}.tar.gz")
+      FileUtils.rm_rf("PERSISTENT_MOUNT_POINT}/apps/#{AppDashboard::APP_NAME}.tar.gz")
     end
   end
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4654,7 +4654,7 @@ HOSTS
     Djinn.log_debug("Checking applications that have been stopped.")
     begin
       app_list = uac.get_all_apps()
-    rescue FailedNodeException => except
+    rescue FailedNodeException
       Djinn.log_warn("check_stopped_apps: failed to get apps (#{app_list}).")
       app_list = []
     end

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2792,7 +2792,7 @@ class Djinn
   # Returns:
   #   A boolean to indicate if we were able to restore the state.
   def restore_appcontroller_state()
-    Djinn.log_info("Restoring AppController state")
+    Djinn.log_debug("Reloading deployment state.")
     json_state=""
 
     unless File.exists?(ZK_LOCATIONS_FILE)
@@ -2813,7 +2813,7 @@ class Djinn
       Djinn.log_warn("Unable to get state from zookeeper: trying again.")
       pick_zookeeper(@zookeeper_data)
     }
-    Djinn.log_info("Reload State : #{json_state}")
+    Djinn.log_debug("Reload State : #{json_state}.")
 
     APPS_LOCK.synchronize {
       @@secret = json_state['@@secret']

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4542,7 +4542,7 @@ HOSTS
           'nginx' => AppDashboard::LISTEN_PORT,
           'nginx_https' => AppDashboard::LISTEN_SSL_PORT,
           'haproxy' => AppDashboard::PROXY_PORT,
-          'appengine' = [],
+          'appengine' => [],
           'language' => AppDashboard::APP_LANGUAGE
       }
       @app_names << AppDashboard::APP_NAME

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1522,7 +1522,7 @@ class Djinn
     end
 
     app_name.gsub!(/[^\w\d\-]/, "")
-    return "false: #{app_name} is a reserved app." if RESERVED_APPS.include?(appid)
+    return "false: #{app_name} is a reserved app." if RESERVED_APPS.include?(app_name)
     Djinn.log_info("Shutting down app named [#{app_name}]")
     result = ""
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1626,10 +1626,10 @@ class Djinn
        end
     end
 
-    RESERVED_APPS.each { |app|
-      if apps.include?(app)
-        Djinn.log_warn("Cannot update reserved app #{app}.")
-        apps.delete(app)
+    RESERVED_APPS.each { |reserved_app|
+      if apps.include?(reserved_app)
+        Djinn.log_warn("Cannot update reserved app #{reserved_app}.")
+        apps.delete(reserved_app)
       end
     }
     Djinn.log_info("Received request to update these apps: #{apps.join(', ')}.")
@@ -3526,8 +3526,8 @@ class Djinn
       }
     end
 
-    # Headnode need to ensure we have the appscale user, and need to
-    # prepare the dashboard to be started.
+    # The headnode needs to ensure we have the appscale user, and it needs
+    # to prepare the dashboard to be started.
     if my_node.is_shadow?
       threads << Thread.new {
         create_appscale_user()
@@ -4542,9 +4542,9 @@ HOSTS
           'nginx' => AppDashboard::LISTEN_PORT,
           'nginx_https' => AppDashboard::LISTEN_SSL_PORT,
           'haproxy' => AppDashboard::PROXY_PORT,
+          'appengine' = [],
           'language' => AppDashboard::APP_LANGUAGE
       }
-      @app_info_map[AppDashboard::APP_NAME]['appengine'] = []
       @app_names << AppDashboard::APP_NAME
     }
   end

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5236,7 +5236,8 @@ HOSTS
   def get_scaling_info_for_app(app_name, update_dashboard=true)
     # Let's make sure we have the minimum number of AppServers running.
     Djinn.log_debug("Evaluating app #{app_name} for scaling.")
-    if @app_info_map[app_name]['appengine'].length < @num_appengines
+    if (@app_info_map[app_name]['appengine'].nil? ||
+        @app_info_map[app_name]['appengine'].length < @num_appengines)
       Djinn.log_info("App #{app_name} doesn't have enough AppServers.")
       @last_decision[app_name] = 0
       return :scale_up

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -65,7 +65,7 @@ module CronHelper
         begin
           # Parse URL to prevent malicious code from being appended.
           url = URI.parse(item['url']).to_s()
-          Djinn.log_info("Parsed cron URL: #{url}")
+          Djinn.log_debug("Parsed cron URL: #{url}")
         rescue URI::InvalidURIError
           Djinn.log_warn("Invalid cron URL: #{item['url']}. Skipping entry.")
           next
@@ -164,7 +164,7 @@ CRON
   # Returns:
   #   A boolean that expresses the validity of the line.
   def self.valid_crontab_line(line)
-    crontab_exists = system('crontab -l')
+    crontab_exists = system('crontab -l 2> /dev/null')
     if crontab_exists
       `crontab -l > crontab.backup`
     end

--- a/AppController/lib/ejabberd.rb
+++ b/AppController/lib/ejabberd.rb
@@ -82,7 +82,7 @@ module Ejabberd
 
     return if nodes.nil?
     nodes.each { |node|
-      next if node.is_login? # don't copy the file to itself
+      next if node.is_shadow? # don't copy the file to itself
       ip = node.private_ip
       ssh_key = node.ssh_key
       HelperFunctions.scp_file(ONLINE_USERS_FILE, ONLINE_USERS_FILE, ip, ssh_key)

--- a/AppController/lib/user_app_client.rb
+++ b/AppController/lib/user_app_client.rb
@@ -269,6 +269,9 @@ class UserAppClient
     }
 
     app_list = all_apps.split(":")
+    if app_list[0] = "Error"
+      raise FailedNodeException.new("get_all_apps: got #{all_apps}.")
+    end
     app_list = app_list - [app_list[0]] # first item is a dummy value
     return app_list
   end
@@ -280,6 +283,9 @@ class UserAppClient
     }
 
     user_list = all_users.split(":")
+    if user_list[0] = "Error"
+      raise FailedNodeException.new("get_all_users: got #{all_users}.")
+    end
     user_list = user_list - [user_list[0]]  # first item is a dummy value
     return user_list
   end

--- a/AppController/lib/user_app_client.rb
+++ b/AppController/lib/user_app_client.rb
@@ -269,7 +269,7 @@ class UserAppClient
     }
 
     app_list = all_apps.split(":")
-    if app_list[0] = "Error"
+    if app_list[0] == "Error"
       raise FailedNodeException.new("get_all_apps: got #{all_apps}.")
     end
     app_list = app_list - [app_list[0]] # first item is a dummy value


### PR DESCRIPTION
This patch allow the autoscaler to start/stop/restart the dashboard as a
normal application. This allow for more flexibility when multiple
load_balancer are active.