### PR TITLE
Handle optional 's~' app ID prefix in TaskQueue REST API...

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/rest_api.py
+++ b/AppTaskQueue/appscale/taskqueue/rest_api.py
@@ -18,7 +18,7 @@ sys.path.append(APPSCALE_LIB_DIR)
 from constants import HTTPCodes
 
 # The prefix for all of the handlers of the pull queue REST API.
-REST_PREFIX = '/taskqueue/v1beta2/projects/([a-z0-9-]+)/taskqueues'
+REST_PREFIX = '/taskqueue/v1beta2/projects/(?:s~)?([a-z0-9-]+)/taskqueues'
 
 # Matches commas that are outside of parentheses.
 FIELD_DELIMITERS_RE = re.compile(r',(?=[^)]*(?:\(|$))')

--- a/AppTaskQueue/appscale/taskqueue/rest_api.py
+++ b/AppTaskQueue/appscale/taskqueue/rest_api.py
@@ -18,7 +18,7 @@ sys.path.append(APPSCALE_LIB_DIR)
 from constants import HTTPCodes
 
 # The prefix for all of the handlers of the pull queue REST API.
-REST_PREFIX = '/taskqueue/v1beta2/projects/(?:s~)?([a-z0-9-]+)/taskqueues'
+REST_PREFIX = '/taskqueue/v1beta2/projects/(?:.~)?([a-z0-9-]+)/taskqueues'
 
 # Matches commas that are outside of parentheses.
 FIELD_DELIMITERS_RE = re.compile(r',(?=[^)]*(?:\(|$))')


### PR DESCRIPTION
…for compatibility with GCP