### PR TITLE
Fix keyname on restore

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2897,7 +2897,6 @@ class Djinn
       return false
     end
 
-    keyname = @options['keyname']
     loop {
       begin
         json_state = ZKInterface.get_appcontroller_state()

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2914,6 +2914,7 @@ class Djinn
 
     APPS_LOCK.synchronize {
       @@secret = json_state['@@secret']
+      keyname = json_state['@options']['keyname']
 
       # Puts json_state.
       json_state.each { |k, v|


### PR DESCRIPTION
If AC restarts, we need to make sure we use the keyname stored in zookeeper.