### PR TITLE
Ensure the syslog user runs the custom rules

### DIFF
--- a/lib/templates/appscale-app-logrotate.conf
+++ b/lib/templates/appscale-app-logrotate.conf
@@ -1,3 +1,5 @@
+su root syslog
+
 /var/log/appscale/app___*.log {
   size 250M
   missingok

--- a/lib/templates/appscale-logrotate.conf
+++ b/lib/templates/appscale-logrotate.conf
@@ -1,3 +1,5 @@
+su root syslog
+
 /var/log/appscale/appmanager*.log {
   size 10M
   missingok


### PR DESCRIPTION
This fixes the cron.hourly job to rotate the logs in /var/log/appscale.