### PR TITLE
Added a conntrack fallback in case that state is not availale.

### DIFF
--- a/firewall.conf
+++ b/firewall.conf
@@ -5,7 +5,14 @@ iptables -F
 
 # Allow all established connections 
 iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-
+# state is deprecated in favor of conntrack but on most systems, both work. 
+# On some systems like the Wheezy image for ODROID-U2/U3 devices, state is
+# not available and result in "iptables: No chain/target/match by that name."
+if [ $? -ne 0 ]; then
+   # Allow all established connections with conntrack if state is missing
+   iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+fi
+      
 # Allow all loopback traffic
 iptables -I INPUT 1 -i lo -j ACCEPT
 


### PR DESCRIPTION
Some sources:
* http://unix.stackexchange.com/questions/108169/what-is-the-difference-between-m-conntrack-ctstate-and-m-state-state
* http://serverfault.com/questions/358996/iptables-whats-the-difference-between-m-state-and-m-conntrack