### PR TITLE
Validate payload when adding pull tasks with REST API

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/rest_api.py
+++ b/AppTaskQueue/appscale/taskqueue/rest_api.py
@@ -24,6 +24,9 @@ REST_PREFIX = '/taskqueue/v1beta2/projects/(?:.~)?([a-z0-9-]+)/taskqueues'
 # Matches commas that are outside of parentheses.
 FIELD_DELIMITERS_RE = re.compile(r',(?=[^)]*(?:\(|$))')
 
+# Matches strings that only contain the standard Base64 alphabet.
+BASE64_CHARS_RE = re.compile(r'^[a-zA-Z0-9-+/=]*$')
+
 
 def parse_fields(fields_string):
   """ Converts a fields string to a tuple.
@@ -144,6 +147,16 @@ class RESTTasks(RequestHandler):
     except ValueError:
       write_error(self, HTTPCodes.BAD_REQUEST,
                   'The request body must contain a task.')
+      return
+
+    if 'payloadBase64' not in task_info:
+      write_error(self, HTTPCodes.BAD_REQUEST,
+                  'payloadBase64 must be specified.')
+      return
+
+    if not BASE64_CHARS_RE.match(task_info['payloadBase64']):
+      write_error(self, HTTPCodes.BAD_REQUEST,
+                  'Invalid payloadBase64 value.')
       return
 
     task = Task(task_info)

--- a/AppTaskQueue/appscale/taskqueue/task.py
+++ b/AppTaskQueue/appscale/taskqueue/task.py
@@ -66,7 +66,18 @@ class Task(object):
     self.retry_count = 0
 
     if 'payloadBase64' in task_info:
-      self.payloadBase64 = task_info['payloadBase64']
+      encoded_payload = task_info['payloadBase64']
+
+      # Google's REST API adds missing padding.
+      missing_padding = 4 - (len(encoded_payload) % 4)
+      encoded_payload += '=' * missing_padding
+
+      # This decode/encode step is performed in order to match Google's
+      # behavior in cases where the given payload does not have the correct
+      # padding. It can be removed if we start storing the payload as binary
+      # blobs.
+      payload = base64.b64decode(encoded_payload)
+      self.payloadBase64 = base64.b64encode(payload)
 
     if 'id' in task_info and task_info['id']:
       self.id = task_info['id']


### PR DESCRIPTION
In the future, we will likely want to store the payload as a blob. For now, however, this fix gives us the same behavior as Google's API.