### PR TITLE
Use URL-safe base64 decoding with the REST API

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/distributed_tq.py
+++ b/AppTaskQueue/appscale/taskqueue/distributed_tq.py
@@ -583,7 +583,8 @@ class DistributedTaskQueue():
             taskqueue_service_pb.TaskQueueServiceError.INVALID_QUEUE_MODE)
           error_found = True
 
-        task_info = {'payloadBase64': base64.b64encode(add_request.body()),
+        encoded_payload = base64.urlsafe_b64encode(add_request.body())
+        task_info = {'payloadBase64': encoded_payload,
                      'leaseTimestamp': add_request.eta_usec()}
         if add_request.has_task_name():
           task_info['id'] = add_request.task_name()

--- a/AppTaskQueue/appscale/taskqueue/rest_api.py
+++ b/AppTaskQueue/appscale/taskqueue/rest_api.py
@@ -24,8 +24,8 @@ REST_PREFIX = '/taskqueue/v1beta2/projects/(?:.~)?([a-z0-9-]+)/taskqueues'
 # Matches commas that are outside of parentheses.
 FIELD_DELIMITERS_RE = re.compile(r',(?=[^)]*(?:\(|$))')
 
-# Matches strings that only contain the standard Base64 alphabet.
-BASE64_CHARS_RE = re.compile(r'^[a-zA-Z0-9-+/=]*$')
+# Matches strings that only contain the URL-safe Base64 alphabet.
+BASE64_CHARS_RE = re.compile(r'^[a-zA-Z0-9-_=]*$')
 
 
 def parse_fields(fields_string):
@@ -159,7 +159,11 @@ class RESTTasks(RequestHandler):
                   'Invalid payloadBase64 value.')
       return
 
-    task = Task(task_info)
+    try:
+      task = Task(task_info)
+    except TypeError:
+      write_error(self, HTTPCodes.BAD_REQUEST, 'Invalid payloadBase64 value.')
+      return
 
     requested_fields = self.get_argument('fields', None)
     if requested_fields is None:

--- a/AppTaskQueue/appscale/taskqueue/task.py
+++ b/AppTaskQueue/appscale/taskqueue/task.py
@@ -75,8 +75,10 @@ class Task(object):
       # This decode/encode step is performed in order to match Google's
       # behavior in cases where the given payload does not have the correct
       # padding. It can be removed if we start storing the payload as binary
-      # blobs.
-      payload = base64.urlsafe_b64decode(encoded_payload)
+      # blobs. The conversion from unicode string to byte string is needed
+      # because urlsafe_b64decode chokes on some invalid base64 that Google
+      # accepts.
+      payload = base64.urlsafe_b64decode(encoded_payload.encode('utf8'))
       self.payloadBase64 = base64.urlsafe_b64encode(payload)
 
     if 'id' in task_info and task_info['id']:

--- a/AppTaskQueue/appscale/taskqueue/task.py
+++ b/AppTaskQueue/appscale/taskqueue/task.py
@@ -76,8 +76,8 @@ class Task(object):
       # behavior in cases where the given payload does not have the correct
       # padding. It can be removed if we start storing the payload as binary
       # blobs.
-      payload = base64.b64decode(encoded_payload)
-      self.payloadBase64 = base64.b64encode(payload)
+      payload = base64.urlsafe_b64decode(encoded_payload)
+      self.payloadBase64 = base64.urlsafe_b64encode(payload)
 
     if 'id' in task_info and task_info['id']:
       self.id = task_info['id']
@@ -204,7 +204,7 @@ class Task(object):
     task_pb.set_eta_usec(
       int((self.get_eta() - epoch).total_seconds()) * 1000000)
     task_pb.set_retry_count(self.retry_count)
-    task_pb.set_body(base64.b64decode(self.payloadBase64))
+    task_pb.set_body(base64.urlsafe_b64decode(self.payloadBase64))
     try:
       task_pb.set_tag(self.tag)
     except AttributeError:


### PR DESCRIPTION
Google does not accept '/' or '+' in the payloadBase64 field.