### PR TITLE
Include the cursor as part of the queryResult

### DIFF
--- a/AppServer_Java/src/com/google/appengine/api/datastore/dev/LocalDatastoreService.java
+++ b/AppServer_Java/src/com/google/appengine/api/datastore/dev/LocalDatastoreService.java
@@ -893,6 +893,7 @@ public final class LocalDatastoreService extends AbstractLocalRpcService
         }
         else{
           liveQuery.setCompiledCursor(queryResult.getCompiledCursor());
+          queryResult.setCursor(request.getCursor());
         }
         return queryResult;
     }


### PR DESCRIPTION
While the compiled cursor is used by the datastore, the (other) cursor in this case is used by the API Proxy to keep track of which LiveQuery object to use.