### PR TITLE
Use json instead of simplejson

### DIFF
--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -12,6 +12,7 @@ Engine applications.
 import cgi
 import datetime
 import jinja2
+import json
 import logging
 import os
 import re
@@ -19,13 +20,6 @@ import sys
 import time
 import urllib
 import webapp2
-
-
-try:
-  import json
-except ImportError:
-  import simplejson as json
-
 
 from google.appengine.api import memcache
 from google.appengine.api import taskqueue

--- a/SearchService/solr_interface.py
+++ b/SearchService/solr_interface.py
@@ -2,7 +2,7 @@
 import calendar
 import logging
 import os
-import simplejson
+import json
 import sys
 import urllib2
 
@@ -57,7 +57,7 @@ class Solr():
     solr_url = "http://{0}:{1}/solr/update?commit=true".format(self._search_location,
       self.SOLR_SERVER_PORT)
     logging.debug("SOLR URL: {0}".format(solr_url))
-    json_request = simplejson.dumps(solr_request)
+    json_request = json.dumps(solr_request)
     logging.debug("SOLR JSON: {0}".format(json_request))
     try:
       req = urllib2.Request(solr_url, data=json_request)
@@ -65,7 +65,7 @@ class Solr():
       conn = urllib2.urlopen(req) 
       if conn.getcode() != HTTP_OK:
         raise search_exceptions.InternalError("Malformed response from SOLR.")
-      response = simplejson.load(conn)
+      response = json.load(conn)
       status = response['responseHeader']['status'] 
       logging.debug("Response: {0}".format(response))
     except ValueError, exception:
@@ -101,7 +101,7 @@ class Solr():
       conn = urllib2.urlopen(solr_url)
       if conn.getcode() != HTTP_OK:
         raise search_exceptions.InternalError("Malformed response from SOLR.")
-      response = simplejson.load(conn)
+      response = json.load(conn)
       logging.debug("Response: {0}".format(response))
     except ValueError, exception:
       logging.error("Unable to decode json from SOLR server: {0}".format(
@@ -137,14 +137,14 @@ class Solr():
 
     solr_url = "http://{0}:{1}/solr/schema/fields".format(
       self._search_location, self.SOLR_SERVER_PORT)
-    json_request = simplejson.dumps(field_list)
+    json_request = json.dumps(field_list)
     try:
       req = urllib2.Request(solr_url, data=json_request)
       req.add_header('Content-Type', 'application/json')
       conn = urllib2.urlopen(req) 
       if conn.getcode() != HTTP_OK:
         raise search_exceptions.InternalError("Malformed response from SOLR.")
-      response = simplejson.load(conn)
+      response = json.load(conn)
       status = response['responseHeader']['status'] 
       logging.debug("Response: {0}".format(response))
     except ValueError, exception:
@@ -199,7 +199,7 @@ class Solr():
     """
     docs = []
     docs.append(hash_map)
-    json_payload = simplejson.dumps(docs)
+    json_payload = json.dumps(docs)
     solr_url = "http://{0}:{1}/solr/update/json?commit=true".format(
       self._search_location, self.SOLR_SERVER_PORT)
     try:
@@ -210,7 +210,7 @@ class Solr():
         logging.error("Got code {0} with URL {1} and payload {2}".format(
         conn.getcode(), solr_url, json_payload))
         raise search_exceptions.InternalError("Bad request sent to SOLR.")
-      response = simplejson.load(conn)
+      response = json.load(conn)
       status = response['responseHeader']['status'] 
       logging.debug("Response: {0}".format(response))
     except ValueError, exception:
@@ -357,7 +357,7 @@ class Solr():
         logging.error("Got code {0} with URL {1}.".format(
           conn.getcode(), solr_url))
         raise search_exceptions.InternalError("Bad request sent to SOLR.")
-      response = simplejson.load(conn)
+      response = json.load(conn)
       status = response['responseHeader']['status'] 
       logging.debug("Response: {0}".format(response))
     except ValueError, exception:

--- a/SearchService/test/unit/test_solr_interface.py
+++ b/SearchService/test/unit/test_solr_interface.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-import simplejson
+import json
 import sys
 import unittest
 import urllib2
@@ -68,20 +68,20 @@ class TestSolrInterface(unittest.TestCase):
     urllib2.should_receive("urlopen").and_return(FakeConnection(False))
     self.assertRaises(search_exceptions.InternalError, solr.get_index, "app_id", "ns", "name")
 
-    # Test the case of ValueError on a simplejson.load.
+    # Test the case of ValueError on a json.load.
     urllib2.should_receive("urlopen").and_return(FakeConnection(True))
-    flexmock(simplejson)
-    simplejson.should_receive("load").and_raise(ValueError)
+    flexmock(json)
+    json.should_receive("load").and_raise(ValueError)
     self.assertRaises(search_exceptions.InternalError, solr.get_index, "app_id", "ns", "name")
 
     # Test a bad status from SOLR.
     dictionary = {'responseHeader':{'status': 1}}
-    simplejson.should_receive("load").and_return(dictionary)
+    json.should_receive("load").and_return(dictionary)
     self.assertRaises(search_exceptions.InternalError, solr.get_index, "app_id", "ns", "name")
 
     fields = [{'name':"index_ns_name_"}]
     dictionary = {'responseHeader':{'status': 0}, "fields": fields}
-    simplejson.should_receive("load").and_return(dictionary)
+    json.should_receive("load").and_return(dictionary)
     index = solr.get_index("app_id", "ns", "name")
     self.assertEquals(index.schema.fields[0]['name'], "index_ns_name_")
 
@@ -96,17 +96,17 @@ class TestSolrInterface(unittest.TestCase):
     self.assertRaises(search_exceptions.InternalError, solr.update_schema, updates)
 
     updates = [{'name': 'name1', 'type':'type1'}]
-    flexmock(simplejson)
-    simplejson.should_receive("load").and_raise(ValueError)
+    flexmock(json)
+    json.should_receive("load").and_raise(ValueError)
     urllib2.should_receive("urlopen").and_return(FakeConnection(True))
     self.assertRaises(search_exceptions.InternalError, solr.update_schema, updates)
 
     dictionary = {"responseHeader":{"status":1}}
-    simplejson.should_receive("load").and_return(dictionary)
+    json.should_receive("load").and_return(dictionary)
     self.assertRaises(search_exceptions.InternalError, solr.update_schema, updates)
     
     dictionary = {"responseHeader":{"status":0}}
-    simplejson.should_receive("load").and_return(dictionary)
+    json.should_receive("load").and_return(dictionary)
     solr.update_schema(updates)
 
   def test_to_solr_hash_map(self):
@@ -120,23 +120,23 @@ class TestSolrInterface(unittest.TestCase):
     appscale_info.should_receive("get_search_location").and_return("somelocation")
     solr = solr_interface.Solr()
     
-    flexmock(simplejson)
-    simplejson.should_receive("loads").and_return({})
+    flexmock(json)
+    json.should_receive("loads").and_return({})
 
     flexmock(urllib2)
     urllib2.should_receive("urlopen").and_return(FakeConnection(False))
     self.assertRaises(search_exceptions.InternalError, solr.commit_update, {})
 
-    simplejson.should_receive("load").and_raise(ValueError)
+    json.should_receive("load").and_raise(ValueError)
     urllib2.should_receive("urlopen").and_return(FakeConnection(True))
     self.assertRaises(search_exceptions.InternalError, solr.commit_update, {})
 
     dictionary = {'responseHeader':{'status': 1}}
-    simplejson.should_receive("load").and_return(dictionary).once()
+    json.should_receive("load").and_return(dictionary).once()
     self.assertRaises(search_exceptions.InternalError, solr.commit_update, {})
 
     dictionary = {'responseHeader':{'status': 0}}
-    simplejson.should_receive("load").and_return(dictionary).once()
+    json.should_receive("load").and_return(dictionary).once()
     solr.commit_update({})
 
   def test_update_document(self):


### PR DESCRIPTION
Our build broke because simplejson was not installed.

Apparently, we had it installed by accident for one of our dependencies. Now that it's no longer installed, I think it's preferable to use the native json library. The only downside is that Python < 2.6 will not be supported, but we require that anyway for the tools.