### PR TITLE
Specify the google-api-python-client version

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -547,7 +547,7 @@ installpsutil()
 installapiclient()
 {
     # The InfrastructureManager requires the Google API client.
-    pipwrapper google-api-python-client
+    pipwrapper google-api-python-client==1.5.4
 }
 
 buildgo()


### PR DESCRIPTION
This matches the version that the tools installs.
