### PR TITLE
Ensure Celery 4 is not installed

### DIFF
--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -184,7 +184,7 @@ module TaskQueue
     start_cmd << ' --verbose' if verbose
     stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
           "#{TASKQUEUE_SERVER_SCRIPT} /usr/bin/python2"
-    env_vars = {}
+    env_vars = {:PATH => '$PATH:/usr/local/bin'}
     MonitInterface.start(:taskqueue, start_cmd, stop_cmd,
                          [TASKQUEUE_SERVER_INTERNAL_PORT], env_vars, start_cmd,
                          nil, nil, nil)

--- a/AppTaskQueue/appscale/taskqueue/distributed_tq.py
+++ b/AppTaskQueue/appscale/taskqueue/distributed_tq.py
@@ -13,6 +13,7 @@ import sys
 import time
 import tq_lib
 
+from distutils.spawn import find_executable
 from queue import InvalidLeaseRequest
 from queue import PullQueue
 from queue import PushQueue
@@ -395,7 +396,8 @@ class DistributedTaskQueue():
       return json.dumps({'error': True, 'reason': config_error.message})
    
     log_file = self.LOG_DIR + app_id + ".log"
-    command = ["/usr/local/bin/celery",
+    celery_bin = find_executable('celery')
+    command = [celery_bin,
                "worker",
                "--app=" + \
                     TaskQueueConfig.get_celery_worker_module_name(app_id),

--- a/AppTaskQueue/setup.py
+++ b/AppTaskQueue/setup.py
@@ -10,7 +10,12 @@ setup(
   license='Apache License 2.0',
   keywords='appscale google-app-engine python',
   platforms='Posix',
-  install_requires=['cassandra-driver', 'celery', 'PyYaml', 'tornado'],
+  install_requires=[
+    'cassandra-driver',
+    'celery<4.0.0',
+    'PyYaml',
+    'tornado'
+  ],
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',

--- a/AppTaskQueue/setup.py
+++ b/AppTaskQueue/setup.py
@@ -16,6 +16,7 @@ setup(
     'PyYaml',
     'tornado'
   ],
+  extras_require={'celery_gui': ['flower']},
   classifiers=[
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',

--- a/debian/appscale_install.sh
+++ b/debian/appscale_install.sh
@@ -51,7 +51,6 @@ case "$1" in
         installcassandra
         postinstallcassandra
         postinstallrabbitmq
-        installcelery
         installsolr
         installservice
         postinstallservice

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -438,14 +438,6 @@ postinstallzookeeper()
     fi
 }
 
-installcelery()
-{
-    if [ "$DIST" = "precise" ]; then
-        pipwrapper celery==3.1.23
-    fi
-    pipwrapper Flower
-}
-
 postinstallrabbitmq()
 {
     # After install it starts up, shut it down.
@@ -548,7 +540,7 @@ buildgo()
 
 installtaskqueue()
 {
-    (cd ${APPSCALE_HOME}/AppTaskQueue && python setup.py install)
+    pip install ${APPSCALE_HOME}/AppTaskQueue[celery_gui]
 }
 
 prepdashboard()

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -540,6 +540,9 @@ buildgo()
 
 installtaskqueue()
 {
+    pip install --upgrade --no-deps ${APPSCALE_HOME}/AppTaskQueue[celery_gui]
+    # Fill in new dependencies.
+    # See pip.pypa.io/en/stable/user_guide/#only-if-needed-recursive-upgrade.
     pip install ${APPSCALE_HOME}/AppTaskQueue[celery_gui]
 }
 
@@ -551,10 +554,8 @@ prepdashboard()
 
 upgradepip()
 {
-    # Pip 1.0 in Precise does not have --target, which is needed for preparing
-    # the dashboard. Pip 1.0 and 1.1 (Precise and Wheezy) upgrade a package's
-    # dependencies when --upgrade is specified. This is problematic for flower,
-    # which will fetch a newer version of celery than desired.
+    # Versions older than Pip 7 did not correctly parse install commands for
+    # local packages with optional dependencies.
     case "$DIST" in
         precise|wheezy|trusty)
             pipwrapper pip

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -556,7 +556,7 @@ upgradepip()
     # dependencies when --upgrade is specified. This is problematic for flower,
     # which will fetch a newer version of celery than desired.
     case "$DIST" in
-        precise|wheezy)
+        precise|wheezy|trusty)
             pipwrapper pip
             # Account for the change in the path to the pip binary.
             hash -r


### PR DESCRIPTION
This will fix the build by allowing the system celery package to meet the taskqueue dependency requirement.

This requires https://github.com/AppScale/appscale-tools/pull/546.