### PR TITLE
Give the Java AppServer a max heap size

### DIFF
--- a/AppManager/test/unit/test_app_manager_server.py
+++ b/AppManager/test/unit/test_app_manager_server.py
@@ -234,7 +234,9 @@ class TestAppManager(unittest.TestCase):
     flexmock(app_manager_server).should_receive('locate_dir').\
       and_return('/path/to/dir/')
     app_id = 'testapp'
-    cmd = app_manager_server.create_java_start_cmd(app_id, '20000', '127.0.0.2')
+    max_heap = 260
+    cmd = app_manager_server.create_java_start_cmd(
+      app_id, '20000', '127.0.0.2', max_heap)
     assert app_id in cmd
 
   def test_create_java_stop_cmd(self): 


### PR DESCRIPTION
The max heap size is set to 140MB less than the app's max memory. In practice, the process tends to use about 120MB more (according to monit) than the max heap size given to Java.

Previously, the default heap size was used, which was normally ~1GB. This change should prevent monit from killing the Java AppServer processes. Instead, the app will encounter an OutOfMemoryError if it tries to allocate more than the max heap size allows.