### PR TITLE
Reduce schema disagreements

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3554,10 +3554,10 @@ class Djinn
         needed_nodes = needed_for_quorum(db_nodes,
                                          Integer(@options['replication']))
         if my_node.is_db_master?
-          start_db_master(clear_datastore, needed_nodes)
+          start_db_master(clear_datastore, needed_nodes, db_nodes)
           prime_database
         else
-          start_db_slave(clear_datastore, needed_nodes)
+          start_db_slave(clear_datastore, needed_nodes, db_nodes)
         end
       }
     end

--- a/AppController/lib/cassandra_helper.rb
+++ b/AppController/lib/cassandra_helper.rb
@@ -144,7 +144,7 @@ def start_cassandra(clear_datastore, needed, desired)
 
   # Wait longer for all the nodes. This reduces errors during table creation.
   begin
-    Timeout::timeout(60) {
+    Timeout.timeout(60) {
       while true
         ready = nodes_ready
         Djinn.log_debug("#{ready} nodes are up. #{desired} are desired.")

--- a/AppController/lib/cassandra_helper.rb
+++ b/AppController/lib/cassandra_helper.rb
@@ -79,6 +79,7 @@ end
 # Args:
 #   clear_datastore: Remove any pre-existent data in the database.
 #   needed: The number of nodes required for quorum.
+#   desired: The total number of database nodes.
 def start_db_master(clear_datastore, needed, desired)
   @state = "Starting up Cassandra seed node"
   Djinn.log_info(@state)
@@ -93,6 +94,7 @@ end
 # Args:
 #   clear_datastore: Remove any pre-existent data in the database.
 #   needed: The number of nodes required for quorum.
+#   desired: The total number of database nodes.
 def start_db_slave(clear_datastore, needed, desired)
   seed_node = get_db_master.private_ip
   @state = "Waiting for Cassandra seed node at #{seed_node} to start"

--- a/AppDB/cassandra_env/cassandra_interface.py
+++ b/AppDB/cassandra_env/cassandra_interface.py
@@ -702,7 +702,6 @@ class DatastoreProxy(AppDBInterface):
     if not isinstance(table_name, str): raise TypeError("Expected a str")
     if not isinstance(column_names, list): raise TypeError("Expected a list")
 
-    self.cluster.refresh_schema_metadata()
     statement = 'CREATE TABLE IF NOT EXISTS "{table}" ('\
         '{key} blob,'\
         '{column} text,'\

--- a/AppDB/cassandra_env/prime_cassandra.py
+++ b/AppDB/cassandra_env/prime_cassandra.py
@@ -27,6 +27,9 @@ from constants import LOG_FORMAT
 # The data layout version to set after removing the journal table.
 POST_JOURNAL_VERSION = 1.0
 
+# A policy that does not retry statements.
+NO_RETRIES = FallthroughRetryPolicy()
+
 
 def define_ua_schema(session):
   """ Populate the schema table for the UAServer.
@@ -74,8 +77,7 @@ def create_batch_tables(cluster, session):
       PRIMARY KEY ((app, transaction), namespace, path)
     )
   """
-  statement = SimpleStatement(create_table,
-                              retry_policy=FallthroughRetryPolicy)
+  statement = SimpleStatement(create_table, retry_policy=NO_RETRIES)
   try:
     session.execute(statement)
   except cassandra.OperationTimedOut:
@@ -94,8 +96,7 @@ def create_batch_tables(cluster, session):
       PRIMARY KEY ((app), transaction)
     )
   """
-  statement = SimpleStatement(create_table,
-                              retry_policy=FallthroughRetryPolicy)
+  statement = SimpleStatement(create_table, retry_policy=NO_RETRIES)
   try:
     session.execute(statement)
   except cassandra.OperationTimedOut:
@@ -159,8 +160,7 @@ def prime_cassandra(replication):
                key=ThriftColumn.KEY,
                column=ThriftColumn.COLUMN_NAME,
                value=ThriftColumn.VALUE)
-    statement = SimpleStatement(create_table,
-                                retry_policy=FallthroughRetryPolicy)
+    statement = SimpleStatement(create_table, retry_policy=NO_RETRIES)
 
     logging.info('Trying to create {}'.format(table))
     try:

--- a/AppDB/cassandra_env/prime_cassandra.py
+++ b/AppDB/cassandra_env/prime_cassandra.py
@@ -60,7 +60,6 @@ def create_batch_tables(cluster, session):
     session: A cassandra-driver session.
   """
   logging.info('Trying to create batches')
-  cluster.refresh_schema_metadata()
   create_table = """
     CREATE TABLE IF NOT EXISTS batches (
       app text,
@@ -76,7 +75,6 @@ def create_batch_tables(cluster, session):
   session.execute(create_table)
 
   logging.info('Trying to create batch_status')
-  cluster.refresh_schema_metadata()
   create_table = """
     CREATE TABLE IF NOT EXISTS batch_status (
       app text,
@@ -142,7 +140,6 @@ def prime_cassandra(replication):
                column=ThriftColumn.COLUMN_NAME,
                value=ThriftColumn.VALUE)
     logging.info('Trying to create {}'.format(table))
-    cluster.refresh_schema_metadata()
     session.execute(create_table)
 
   create_batch_tables(cluster, session)

--- a/AppTaskQueue/appscale/taskqueue/distributed_tq.py
+++ b/AppTaskQueue/appscale/taskqueue/distributed_tq.py
@@ -66,7 +66,6 @@ def create_pull_queue_tables(cluster, session):
       PRIMARY KEY ((app, queue, id))
     )
   """
-  cluster.refresh_schema_metadata()
   session.execute(create_table)
 
   logger.info('Trying to create pull_queue_tasks_index')
@@ -81,14 +80,12 @@ def create_pull_queue_tables(cluster, session):
       PRIMARY KEY ((app, queue, eta), id)
     )
   """
-  cluster.refresh_schema_metadata()
   session.execute(create_index_table)
 
   logger.info('Trying to create pull_queue_tags index')
   create_index = """
     CREATE INDEX IF NOT EXISTS pull_queue_tags ON pull_queue_tasks_index (tag);
   """
-  cluster.refresh_schema_metadata()
   session.execute(create_index)
 
   # This additional index is needed for groupByTag=true,tag=None queries
@@ -98,7 +95,6 @@ def create_pull_queue_tables(cluster, session):
     CREATE INDEX IF NOT EXISTS pull_queue_tag_exists
     ON pull_queue_tasks_index (tag_exists);
   """
-  cluster.refresh_schema_metadata()
   session.execute(create_index)
 
   logger.info('Trying to create pull_queue_leases')
@@ -110,7 +106,6 @@ def create_pull_queue_tables(cluster, session):
       PRIMARY KEY ((app, queue, leased))
     )
   """
-  cluster.refresh_schema_metadata()
   session.execute(create_leases_table)
 
 

--- a/AppTaskQueue/appscale/taskqueue/distributed_tq.py
+++ b/AppTaskQueue/appscale/taskqueue/distributed_tq.py
@@ -47,6 +47,9 @@ from cassandra_env.cassandra_interface import DatastoreProxy
 
 sys.path.append(TaskQueueConfig.CELERY_WORKER_DIR)
 
+# A policy that does not retry statements.
+NO_RETRIES = FallthroughRetryPolicy()
+
 
 def create_pull_queue_tables(cluster, session):
   """ Create the required tables for pull queues.
@@ -69,8 +72,7 @@ def create_pull_queue_tables(cluster, session):
       PRIMARY KEY ((app, queue, id))
     )
   """
-  statement = SimpleStatement(create_table,
-                              retry_policy=FallthroughRetryPolicy)
+  statement = SimpleStatement(create_table, retry_policy=NO_RETRIES)
   try:
     session.execute(statement)
   except OperationTimedOut:
@@ -92,8 +94,7 @@ def create_pull_queue_tables(cluster, session):
       PRIMARY KEY ((app, queue, eta), id)
     )
   """
-  statement = SimpleStatement(create_index_table,
-                              retry_policy=FallthroughRetryPolicy)
+  statement = SimpleStatement(create_index_table, retry_policy=NO_RETRIES)
   try:
     session.execute(statement)
   except OperationTimedOut:
@@ -127,8 +128,7 @@ def create_pull_queue_tables(cluster, session):
       PRIMARY KEY ((app, queue, leased))
     )
   """
-  statement = SimpleStatement(create_leases_table,
-                              retry_policy=FallthroughRetryPolicy)
+  statement = SimpleStatement(create_leases_table, retry_policy=NO_RETRIES)
   try:
     session.execute(statement)
   except OperationTimedOut:


### PR DESCRIPTION
Sometimes a `CREATE TABLE` statement will time out, and the driver will try to create it again before the cluster fully loads the first one. This branch is meant to make that situation much less likely.