### PR TITLE
Appscale dashboard cron page

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -6132,4 +6132,17 @@ HOSTS
     return JSON.dump(all_stats)
   end
 
+
+  # Gets an application cron info.
+  #
+  # Args:
+  #   app_name: The application ID.
+  #   secret: The secret of this deployment.
+  # Returns:
+  #   An application cron info
+  def get_application_cron_info(app_name, secret)
+    return BAD_SECRET_MSG unless valid_secret?(secret)
+    content = CronHelper.get_application_cron_info(app_name)
+    return JSON.dump(content)
+  end
 end

--- a/AppController/djinnServer.rb
+++ b/AppController/djinnServer.rb
@@ -66,6 +66,7 @@ class DjinnServer < SOAP::RPC::HTTPServer
     add_method(@djinn, "status", "secret")
     add_method(@djinn, "get_stats", "secret")
     add_method(@djinn, "get_stats_json", "secret")
+    add_method(@djinn, "get_application_cron_info", "app_name", "secret")
     add_method(@djinn, "upload_app", "archived_file", "file_suffix", "email",
       "secret")
     add_method(@djinn, "get_app_upload_status", "reservation_id", "secret")

--- a/AppController/lib/app_controller_client.rb
+++ b/AppController/lib/app_controller_client.rb
@@ -71,6 +71,7 @@ class AppControllerClient
     @conn.add_method("set_apps_to_restart", "apps_to_restart", "secret")
     @conn.add_method("status", "secret")
     @conn.add_method("get_stats", "secret")
+    @conn.add_method("read_app_crontab", "app_name", "secret")
     @conn.add_method("upload_app", "archived_file", "file_suffix", "email", "secret")
     @conn.add_method("update", "app_names", "secret")
     @conn.add_method("stop_app", "app_name", "secret")    
@@ -172,6 +173,10 @@ class AppControllerClient
 
   def get_stats()
     make_call(10, RETRY_ON_FAIL, "get_stats") { @conn.get_stats(@secret) }
+  end
+
+  def read_app_crontab(app_name)
+    make_call(10, RETRY_ON_FAIL, "read_app_crontab") { @conn.read_app_crontab(app_name, @secret) }
   end
 
   def upload_app(archived_file, file_suffix, email)

--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -205,6 +205,21 @@ CRON
   end
 
 
+  # Gets an application cron info.
+  #
+  # Args:
+  #   app_name: A String that names the appid of this application.
+  def self.get_application_cron_info(app_name)
+    etc_crond_filename = "/etc/cron.d/appscale-#{app_name}"
+    etc_crond_file = File.exists?(etc_crond_filename) ? File.read(etc_crond_filename): ""
+    cron_yaml_filename = "#{HelperFunctions::APPLICATIONS_DIR}/#{app_name}/app/cron.yaml"
+    cron_yaml_file = YAML.load_file(cron_yaml_filename)
+    cron_yaml_file = cron_yaml_file ? cron_yaml_file: ""
+
+    return {"etc_crond_file" => etc_crond_file, "cron_yaml_file" => cron_yaml_file}
+  end
+
+
   # Converts the frequency of how often a Google App Engine cron job should run
   # to a format that cron understands.
   # TODO: This method does not correctly parse ordinals, as the ordinal
@@ -261,7 +276,7 @@ CRON
               "april" => "apr", "may" => "may", "june" => "jun",
               "july" => "jul", "august" => "aug", "september" => "sep",
               "october" => "oct", "november" => "nov",
-              "december" => "dec", "every" => "*" }
+              "december" => "dec", "every" => "*", "month" => "*"}
     result = []
     month_list = months.split(",")
     month_list.each{ |month|
@@ -269,7 +284,6 @@ CRON
     }
     return result.join(',')
   end
-
 
   # Takes a single cron line specified in the Google App Engine cron format
   # and converts it to one or more cron lines in standard cron format.
@@ -293,13 +307,14 @@ CRON
     # every monday 09:00
     # every monday of sep,oct,nov 17:00
     # every 5 minutes from 10:00 to 14:00
-    unless splitted.length == 3 || splitted.length == 5 || splitted.length == 7
+    unless splitted.length == 3 || splitted.length == 4 || splitted.length == 5 || splitted.length == 7
       Djinn.log_error("bad format, length = #{splitted.length}")
       return [""]
     end
 
     ord = splitted[0]
     days_of_week = splitted[1]
+    day_of_month = "*"
 
     multiple_cron_entries = false
     crons = Array.new
@@ -307,11 +322,17 @@ CRON
     if splitted.length == 3
       months_of_year = "every"
       time = splitted[2]
-      hour, min = time.split(":")
+      hour, min = time.split(":").map(&:to_i)
+    elsif splitted.length == 4
+      days_of_week = "day"
+      day_of_month = ord
+      months_of_year = splitted[2]
+      time = splitted[3]
+      hour, min = time.split(":").map(&:to_i)
     elsif splitted.length == 5
       months_of_year = splitted[3]
       time = splitted[4]
-      hour, min = time.split(":")
+      hour, min = time.split(":").map(&:to_i)
     else    # schedule length = 7, e.g. every 7 minutes from 10:00 to 14:00
       months_of_year = "every"
       days_of_week = "day"
@@ -371,53 +392,53 @@ CRON
         end
       else    # increment_type == minutes
         multiple_cron_entries = true
-        first_of_hour = m1    # First occurrence of the hour.
-        if h1 < h2            # minutes, h1 < h2
-          for h in (h1..h2)
-            remainder  = (60 - first_of_hour) % increment
-            if h == h2
-              last_of_hour = m2
-            else
-              last_of_hour = 60 - remainder
-            end
 
-            # Start the next entry at '0' since '60' is not a valid minute.
-            if last_of_hour == 60
-              last_of_hour = 59
-              remainder = increment
-            end
-
-            mins = (first_of_hour..last_of_hour).step(increment).to_a.join(',')
-            if !mins.empty?
-              crons.push({"hour" => "#{h}", "min" => mins})
-            end
-            first_of_hour = increment - remainder
+        if h1 < h2
+          if m1 < 59
+            mins = "#{m1}-59/#{increment}"
+            crons.push({"hour" => "#{h1}", "min" => mins})
           end
-        elsif h1 >= h2        # minutes, h1 >= h2
-          [{"fh" => h1, "lh" => 23},   # Batch 1 - before midnight
-           {"fh" => 0, "lh" => h2},    # Batch 2 - after midnight
-          ].each do |batch|
-            for h in (batch["fh"]..batch["lh"])
-              remainder = (60 - first_of_hour) % increment
-              last_of_hour = 60 - remainder
-              if last_of_hour == 60
-                last_of_hour = 59
-              end
-              if batch["fh"] == 0 && h == batch["lh"]
-                last_of_hour = m2
-              end
-
-              mins = (first_of_hour..last_of_hour).step(increment).to_a.join(',')
-              if !mins.empty?
-                crons.push({"hour" => "#{h}", "min" => mins})
-              end
-
-              # Set up next loop.
-              first_of_hour = 0   # If no remainder, start at the top.
-              if remainder != 0
-                first_of_hour = increment - remainder
-              end
+          if h2 - h1 == 1
+            if m2 > 0
+              mins = "0-#{m2}/#{increment}"
+              crons.push({"hour" => "#{h1}", "min" => mins})
             end
+          else
+            mins = "*/#{increment}"
+            fh = h1 + 1
+            lh = h2 - 1
+            crons.push({"hour" => "#{fh}-#{lh}", "min" => mins})
+
+            if m2 > 0
+              mins = "0-#{m2}/#{increment}"
+              crons.push({"hour" => "#{h2}", "min" => mins})
+            end
+          end
+        elsif h1 == h2        # minutes, h1 >= h2
+          if m1 > m2
+            if m2 > 0
+              crons.push({"hour" => "*", "min" => "0-#{m2}/#{increment}"})
+            end
+            if m1 < 59
+              crons.push({"hour" => "*", "min" => "#{m1}-59/#{increment}"})
+            end
+          else
+            crons.push({"hour" => "#{h1}", "min" => "#{m1}-#{m2}/#{increment}"})
+          end
+        else
+          if m1 < 59
+            crons.push({"hour" => "h1", "min" => "#{m1}-59/#{increment}"})
+          end
+          if h1 != 23
+            crons.push({"hour" => "#{h1}-23", "min" => "*/#{increment}"})
+          end
+
+          if m2 > 0
+            crons.push({"hour" => "#{h2}", "min" => "0-#{m2}/#{increment}"})
+          end
+          if h2 > 0
+            lh = h2 - 1
+            crons.push({"hour" => "0-#{lh}", "min" => "*/#{increment}"})
           end
         end
       end
@@ -434,6 +455,8 @@ CRON
       crons.each { |cron|
         cron_lines.push("#{cron["min"]} #{cron["hour"]} * #{months_of_year} #{days_of_week}")
       }
+    elsif ord != "every" && !multiple_cron_entries
+      cron_lines.push("#{min} #{hour} #{day_of_month} #{months_of_year} #{days_of_week}")
     else    # Complex case, not implemented yet.
       Djinn.log_error("Cannot set up cron route with ordinals, as AppScale" +
         " does not support it. Ordinal was: #{ord}")
@@ -528,6 +551,4 @@ CRON
       nil
     end
   end
-
-
 end

--- a/AppController/test/tc_cron_helper.rb
+++ b/AppController/test/tc_cron_helper.rb
@@ -191,7 +191,19 @@ class TestCronHelper < Test::Unit::TestCase
     actual = CronHelper.convert_messy_format(schedule)
     self.assert_equal(expected, actual)
 
-    # every 65 hours
+    # 1 of month 01:00
+    schedule = "1 of month 01:00"
+    expected = ["0 1 1 * *"]
+    actual = CronHelper.convert_messy_format(schedule)
+    self.assert_equal(expected, actual)
+
+    # 2 of may 00:00
+    schedule = "2 of may 00:00"
+    expected = ["0 0 2 may *"]
+    actual = CronHelper.convert_messy_format(schedule)
+    self.assert_equal(expected, actual)
+
+    # every 65 minutes
     schedule = "every 65 minutes from 12:26 to 03:10"
     expected = ["26 12 * * *",
                 "31 13 * * *",

--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -10,6 +10,8 @@ Engine applications.
 # pylint: disable-msg=W0613
 
 import cgi
+from collections import defaultdict
+import crontab
 import datetime
 import jinja2
 import json
@@ -20,6 +22,7 @@ import sys
 import time
 import urllib
 import webapp2
+import yaml
 
 from google.appengine.api import memcache
 from google.appengine.api import taskqueue
@@ -42,7 +45,7 @@ jinja_environment = jinja2.Environment(
   loader=jinja2.FileSystemLoader(os.path.dirname(__file__) + \
                                  os.sep + 'templates'))
 
-# The maximum number of datapoints we send to be rendered in a graph 
+# The maximum number of datapoints we send to be rendered in a graph
 # charting requests per second.
 MAX_REQUESTS_DATA_POINTS = 100
 
@@ -76,7 +79,7 @@ class AppDashboard(webapp2.RequestHandler):
 
   def __init__(self, request, response):
     """ Constructor.
-    
+
     Args:
       request: The webapp2.Request object that contains information about the
         current web request.
@@ -90,7 +93,7 @@ class AppDashboard(webapp2.RequestHandler):
   def render_template(self, template_file, values=None):
     """ Renders a template file with all variables loaded.
 
-    Args: 
+    Args:
       template_file: A str with the relative path to template file.
       values: A dict with key/value pairs used as variables in the jinja
         template files.
@@ -505,7 +508,7 @@ class AuthorizePage(AppDashboard):
 
   def parse_update_user_permissions(self):
     """ Update authorization matrix from form submission.
-    
+
     Returns:
       A str with message to be displayed to the user.
     """
@@ -927,7 +930,7 @@ class LogUploadPage(webapp2.RequestHandler):
       if key_name in entities_to_store:
         log_line = entities_to_store[key_name]
       else:
-        # Grab it from the datastore. 
+        # Grab it from the datastore.
         log_line = RequestLogLine.get_by_id(id=key_name)
       if not log_line:
         # This is the first log for this timestamp.
@@ -980,6 +983,106 @@ class LogDownloader(AppDashboard):
     })
 
 
+class CronConsolePage(AppDashboard):
+    TEMPLATE = "cron/console.html"
+
+    def get(self):
+        is_cloud_admin = self.helper.is_user_cloud_admin()
+        if is_cloud_admin:
+            apps_user_is_admin_on = self.dstore.get_application_info().keys()
+        else:
+            apps_user_is_admin_on = self.helper.get_owned_apps()
+
+        apps_with_cron_yaml = []
+        for app_id in apps_user_is_admin_on:
+          cron_info = self.helper.get_application_cron_info(app_id)
+          if cron_info.get("etc_crond_file", {}):
+            apps_with_cron_yaml.append(app_id)
+
+        self.render_app_page(page='cron', values={
+            'apps_with_cron_yaml': apps_with_cron_yaml,
+            'page_content': self.TEMPLATE
+        })
+
+
+class CronViewPage(AppDashboard):
+    PATH = "/cron/view"
+    TEMPLATE = "cron/viewer.html"
+    CROND_TEMPLATE = "/etc/cron.d/appscale-{app_id}"
+    CRON_YAML_PATH = "/var/apps/{0}/app/cron.yaml"
+
+    def get(self):
+        app_id = self.request.get("appid")
+
+        mail_to = []
+        cron_jobs = []
+        warnings = []
+
+        cron_info = self.helper.get_application_cron_info(app_id)
+
+        yaml_file = cron_info.get("cron_yaml_file", [])
+        etc_crond_file = cron_info.get("etc_crond_file", "")
+        try:
+            crond_file = crontab.CronTab(tab=etc_crond_file, user=False)
+        except IOError as ioe:
+            logging.error(ioe)
+        else:
+            logging.info("TEST")
+            crond_records = defaultdict(list)
+            yaml_records = {}
+            for yaml_entry in yaml_file["cron"]:
+                url = yaml_entry["url"]
+                yaml_records[url] = yaml_entry
+                for crond_entry in crond_file:
+                    if url in crond_entry.command:
+                        crond_records[url].append(crond_entry)
+                        logging.info(crond_entry)
+
+            if len(yaml_records) != len(crond_records):
+                warnings.append(
+                    "One of the cron jobs from cron.yaml is missing in crond file for appid {0}."
+                    "Look at controller logs for more information at /var/log/appscale/".format(app_id)
+                )
+                logging.info(warnings)
+
+            for url, entries in crond_records.iteritems():
+                yaml_record = yaml_records.get(url, {})
+                query_params = {"url": url, "appid": app_id}
+                url_command = "/cron/run?" + urllib.urlencode(query_params)
+                cron_jobs.append(
+                    {"url": url,
+                     "frequency": yaml_record.get("schedule", ""),
+                     "frequency_cron_format": ", ".join(str(e.slices) for e in entries),
+                     "description": yaml_record.get("description", ""),
+                     "url_command": url_command}
+                )
+
+        logging.info(cron_jobs)
+
+        self.render_app_page(page='cron', values={
+            'mail_to': mail_to,
+            'cron_jobs': cron_jobs,
+            'warnings': warnings,
+            'page_content': self.TEMPLATE
+        })
+
+
+class CronRun(AppDashboard):
+    def get(self):
+        """ Instructs the AppController to collect logs across all machines, place
+        it in this app's static file directory, and renders a page that will wait
+        for the logs to become available before downloading it.
+        """
+        api_url = urllib.unquote(self.request.get("url"))
+        app_id = urllib.unquote(self.request.get("appid"))
+        if not api_url or not app_id:
+            return
+
+        app_url = self.dstore.get_application_info()[app_id][1]
+        response = urllib.urlopen(app_url + api_url)
+        self.redirect("/cron/view?" + urllib.urlencode({"appid": app_id}), response)
+
+
 class AppConsolePage(AppDashboard):
   # The template to use for the app console page.
   TEMPLATE = "apps/console.html"
@@ -991,7 +1094,7 @@ class AppConsolePage(AppDashboard):
 
 
 class DatastoreStats(AppDashboard):
-  """ Class that returns datastore statistics in JSON such as the number of 
+  """ Class that returns datastore statistics in JSON such as the number of
   a certain entity kind and the amount of total bytes.
   """
   # The most number of data points we pass back to render in the dashboard.
@@ -1001,7 +1104,7 @@ class DatastoreStats(AppDashboard):
   MAX_DAYS_BACK = 30
 
   def get(self):
-    """ Handler for GET request for the datastore statistics. 
+    """ Handler for GET request for the datastore statistics.
 
     Returns:
       The JSON output for testing.
@@ -1026,7 +1129,7 @@ class DatastoreStats(AppDashboard):
 
   def convert_to_json(self, kind_entities):
     """ Converts KindStat entities to a json string.
-  
+
     Args:
       kind_entities: A list of stats.KindStat.
     Returns:
@@ -1041,7 +1144,7 @@ class DatastoreStats(AppDashboard):
 
 
 class RequestsStats(AppDashboard):
-  """ Class that returns request statistics in JSON relating to the number 
+  """ Class that returns request statistics in JSON relating to the number
   of requests an application gets per second.
   """
 
@@ -1060,13 +1163,13 @@ class RequestsStats(AppDashboard):
 
   @staticmethod
   def fetch_request_info(app_id):
-    """ Fetches request per second information from the datastore for 
+    """ Fetches request per second information from the datastore for
     a given application.
-  
+
     Args:
       app_id: A str, the application identifier.
     Returns:
-      A list of dictionaries filled with timestamps and number of 
+      A list of dictionaries filled with timestamps and number of
       requests per second.
     """
     query = RequestInfo.query(RequestInfo.app_id == app_id)
@@ -1288,6 +1391,9 @@ dashboard_pages = [
   ('/logs/upload', LogUploadPage),
   ('/logs/(.+)/(.+)', LogServiceHostPage),
   ('/logs/(.+)', LogServicePage),
+  ('/cron', CronConsolePage),
+  ('/cron/view', CronViewPage),
+  ('/cron/run', CronRun),
   ('/gather-logs', LogDownloader),
   ('/groomer', RunGroomer),
   ('/change-password', ChangePasswordPage),

--- a/AppDashboard/lib/app_dashboard_data.py
+++ b/AppDashboard/lib/app_dashboard_data.py
@@ -206,6 +206,9 @@ class AppDashboardData():
                   "link": self.get_monit_url()},
         "taskqueue": {"title": "TaskQueue",
                       "link": self.get_flower_url()},
+        "cron": {"title": "Cron",
+                 "link": "/cron",
+                 "template": "cron/console.html"},
         "app_console": {"title": "Application Statistics",
                         "template": "apps/console.html",
                         "link": "/apps/"}
@@ -233,7 +236,9 @@ class AppDashboardData():
                                                 {"logging": lookup_dict[
                                                   "logging"]},
                                                 {"app_console": lookup_dict[
-                                                    "app_console"]}]}
+                                                    "app_console"]},
+                                                {"cron": lookup_dict[
+                                                  "cron"]}]}
       return lookup_dict
     else:
       return {}
@@ -461,7 +466,7 @@ class AppDashboardData():
   def get_application_info(self):
     """ Retrieves a list of Google App Engine applications running in this
       AppScale deployment, along with the URL that users can access them at.
-    
+
     Returns:
       A dict, where each key is a str indicating the name of a Google App Engine
       application, and each value is either a str, indicating the URL where the

--- a/AppDashboard/lib/app_dashboard_helper.py
+++ b/AppDashboard/lib/app_dashboard_helper.py
@@ -217,6 +217,22 @@ class AppDashboardHelper(object):
       logging.exception(err)
       return []
 
+  def get_application_cron_info(self, app_name):
+    """ Get an application cron info
+
+    Args:
+      app_name: A str containing the name of the app to be removed.
+    Returns:
+      A dict that contains the cron.yaml and /etc/cron.d/appscale-#app_id files content
+    """
+    try:
+      acc = self.get_appcontroller_client()
+      cron_info = acc.get_application_cron_info(app_name)
+    except Exception as err:
+      logging.exception(err)
+      return {}
+    return cron_info
+
   def get_host_with_role(self, role):
     """ Queries the AppController to find a host running the named role.
 

--- a/AppDashboard/templates/cron/console.html
+++ b/AppDashboard/templates/cron/console.html
@@ -1,0 +1,27 @@
+<!-- FILE:templates/apps/new.html -->
+<!--Body content-->
+<div id="content" class="clearfix">
+    <div class="contentwrapper"><!--Content wrapper-->
+        <!-- Build page from here: -->
+        <div class="row-fluid">
+          <div class="span12">
+            <div class="page-header">
+                <h1>Cron Console</h1>
+            </div><!--close header-->
+              <div class="row-fluid">
+                <div class="offset1 span8">
+                    <ul style="list-style:none;">
+                  {% if apps_with_cron_yaml %}
+                    {% for app_id in apps_with_cron_yaml %}
+                      <li><a class="btn btn-large" href="/cron/view?appid={{ app_id }}">{{ app_id }}</a></li>
+                    {% endfor %}
+                  {% else %}
+                      <li>No apps are currently uploaded that contain cron.yaml.</li>
+                  {% endif %}
+                    </ul>
+                </div>
+              </div>
+        </div><!--close span6 -->
+        </div> <!-- end row fluid -->
+    </div> <!-- end content wrapper -->
+</div> <!--end content-->

--- a/AppDashboard/templates/cron/view.html
+++ b/AppDashboard/templates/cron/view.html
@@ -1,0 +1,37 @@
+<!-- FILE:templates/cron/cron.html -->
+<!--Body content-->
+<style>
+   table {border-collapse:collapse; table-layout:fixed;}
+   table td {border:solid 5px #fab; word-wrap:break-word; border-color:gray}
+</style>
+
+<div id="content">
+    <div class="heading">
+        <h3>Cron viewer</h3>
+    </div>
+    <div class="row-fluid">
+        <div class="page-header">
+            <h1>View cron tasks:</h1>
+            <table>
+                <tr>
+                    <th>Cron job</th>
+                    <th>Description</th>
+                    <th>Frequency</th>
+                </tr>
+                {% for cron_job in cron_jobs%}
+                    <tr>
+                        <td id="command" width="30%">{{cron_job['url']}}</td>
+                        <td>{{cron_job['description']}}</td>
+                        <td>{{cron_job['frequency']}} | {{cron_job['frequency_cron_format']}}</td>
+                        <td><a class="btn btn-small" href="{{cron_job['url_command']}}">Run</a></td>
+                    </tr>
+                {% endfor %}
+            </table>
+            <div>
+                {% for warning in warnings%}
+                    {{warning}}<br>
+                {% endfor %}
+            </div>
+        </div><!--close header-->
+    </div> <!-- end row fluid -->
+</div>

--- a/AppServer/google/appengine/api/appcontroller_client.py
+++ b/AppServer/google/appengine/api/appcontroller_client.py
@@ -239,6 +239,15 @@ class AppControllerClient():
     return json.loads(self.call(self.MAX_RETRIES, self.server.get_stats_json,
       self.secret))
 
+  def get_application_cron_info(self, app_id):
+    """Queries the AppController to get application cron info (from cron.yaml and /etc/cron.d/).
+
+    Returns:
+      A dict that contains the cron.yaml and /etc/cron.d/appscale-#app_id files content
+    """
+    return json.loads(self.call(self.MAX_RETRIES, self.server.get_application_cron_info,
+      app_id, self.secret))
+
 
   def is_initialized(self):
     """Queries the AppController to see if it has started up all of the API

--- a/AppServer/google/appengine/tools/dev_appserver_import_hook.py
+++ b/AppServer/google/appengine/tools/dev_appserver_import_hook.py
@@ -788,6 +788,7 @@ class HardenedModulesHook(object):
       'bz2',
       'cmath',
       'collections',
+      'crontab',
       'crypt',
       'cStringIO',
       'datetime',
@@ -801,6 +802,7 @@ class HardenedModulesHook(object):
       'posix',
       'posixpath',
       'pyexpat',
+      'pwd',
       'sha',
       'struct',
       'strxor',
@@ -855,12 +857,6 @@ class HardenedModulesHook(object):
     'future_builtins',
     'parser',
     'strop',
-
-
-
-
-
-
   ]
 
 
@@ -1570,17 +1566,6 @@ class HardenedModulesHook(object):
 
     try:
       try:
-
-
-
-
-
-
-
-
-
-
-
         return self._imp.load_module(submodule_fullname,
                                      source_file,
                                      pathname,

--- a/AppServer/google/appengine/tools/devappserver2/python/sandbox.py
+++ b/AppServer/google/appengine/tools/devappserver2/python/sandbox.py
@@ -122,18 +122,20 @@ def enable_sandbox(config):
   for path in sys.path:
     if any(module_path.startswith(path) for module_path in module_paths):
       python_lib_paths.append(path)
+
   python_lib_paths.extend(_enable_libraries(config.libraries))
   for name in list(sys.modules):
     if not _should_keep_module(name):
       _removed_modules.append(sys.modules[name])
       del sys.modules[name]
+
   path_override_hook = PathOverrideImportHook(
       set(_THIRD_PARTY_LIBRARY_NAME_OVERRIDES.get(lib.name, lib.name)
           for lib in config.libraries).intersection(_C_MODULES))
   python_lib_paths.extend(path_override_hook.extra_sys_paths)
-  stubs.FakeFile.set_allowed_paths(config.application_root,
-                                   python_lib_paths[1:] +
-                                   path_override_hook.extra_accessible_paths)
+
+  allowed_paths = python_lib_paths[1:] + path_override_hook.extra_accessible_paths
+  stubs.FakeFile.set_allowed_paths(config.application_root, allowed_paths)
   stubs.FakeFile.set_skip_files(config.skip_files)
   stubs.FakeFile.set_static_files(config.static_files)
   __builtin__.file = stubs.FakeFile
@@ -188,7 +190,7 @@ def _find_shared_object_c_module():
 def _should_keep_module(name):
   """Returns True if the module should be retained after sandboxing."""
   return (name in ('__builtin__', 'sys', 'codecs', 'encodings', 'site',
-                   'google') or
+                   'google', 'crontab', 'pwd') or
           name.startswith('google.') or name.startswith('encodings.') or
 
           # Making mysql available is a hack to make the CloudSQL functionality
@@ -756,6 +758,7 @@ _WHITE_LIST_C_MODULES = [
     '_codecs_kr',
     '_codecs_tw',
     '_collections',  # Python 2.6 compatibility
+    'crontab',
     'crypt',
     'cPickle',
     'cStringIO',
@@ -785,6 +788,7 @@ _WHITE_LIST_C_MODULES = [
     'parser',
     'posix',  # Only indirectly through the os module.
     'pyexpat',
+    'pwd',
     '_random',
     '_sha256',  # Python2.5 compatibility
     '_sha512',  # Python2.5 compatibility
@@ -819,8 +823,7 @@ class BuiltinImportHook(object):
   """
 
   def find_module(self, fullname, unused_path=None):
-    if (fullname in sys.builtin_module_names and
-        fullname not in _WHITE_LIST_C_MODULES):
+    if fullname in sys.builtin_module_names and fullname not in _WHITE_LIST_C_MODULES:
       return self
     return None
 

--- a/debian/appscale_build.sh
+++ b/debian/appscale_build.sh
@@ -59,7 +59,7 @@ if grep docker /proc/1/cgroup > /dev/null ; then
     # Make sure we have default locale.
     locale-gen en_US en_US.UTF-8
     # Docker images miss the following.
-    mkdir /var/run/sshd
+    mkdir -p /var/run/sshd
     chmod 755 /var/run/sshd
 fi
 

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -553,6 +553,7 @@ prepdashboard()
 {
     rm -rf ${APPSCALE_HOME}/AppDashboard/vendor
     pip install -t ${APPSCALE_HOME}/AppDashboard/vendor SOAPpy
+    pip install -t ${APPSCALE_HOME}/AppDashboard/vendor python-crontab
 }
 
 upgradepip()


### PR DESCRIPTION
Hi!
I implemented basic system to view/run cron jobs from Appscale dashboard. It looks like this:
![cron_console](https://cloud.githubusercontent.com/assets/2128080/20801563/6fcdefce-b7fa-11e6-8466-4e397cf7f1ae.png)
![cron_tasks](https://cloud.githubusercontent.com/assets/2128080/20801562/6fccca68-b7fa-11e6-92bd-64dffb5f2a62.png)

What do you think about it?

I still have one issue about how to give an access to /etc/cron.d/ and /var/apps/ directories for appscaledashboard application. I did this through by modifying the file  
`AppServer/google/appengine/tools/devappserver2/python/sandbox.py`. 

Peter