### PR TITLE
Ensure we have the correct path in monit

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4511,6 +4511,7 @@ HOSTS
     Djinn.log_debug("Configuring AppController monit.")
     env = {
       'HOME' => '/root',
+      'PATH' => '$PATH:/usr/local/bin',
       'APPSCALE_HOME' => APPSCALE_HOME,
       'EC2_HOME' => ENV['EC2_HOME'],
       'JAVA_HOME' => ENV['JAVA_HOME']


### PR DESCRIPTION
if/when the appcontroller crash or is killed, the path in monit doesn't
consider /usr/local/bin, creating the possibility of some of the scripts
to be unreachable.