### PR TITLE
Set property

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3590,7 +3590,7 @@ class Djinn
         if my_node.is_zookeeper?
           configure_zookeeper(@nodes, @my_index)
           begin
-            start_zookeeper(@options['clear_datastore'].downcase == "true")
+            start_zookeeper(false)
           rescue FailedZooKeeperOperationException
             @state = "Couldn't start Zookeeper."
             HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
@@ -3616,15 +3616,14 @@ class Djinn
 
       threads << Thread.new {
         Djinn.log_info("Starting database services.")
-        clear_datastore = @options['clear_datastore'].downcase == "true"
         db_nodes = @nodes.count{|node| node.is_db_master? or node.is_db_slave?}
         needed_nodes = needed_for_quorum(db_nodes,
                                          Integer(@options['replication']))
         if my_node.is_db_master?
-          start_db_master(clear_datastore, needed_nodes, db_nodes)
+          start_db_master(false, needed_nodes, db_nodes)
           prime_database
         else
-          start_db_slave(clear_datastore, needed_nodes, db_nodes)
+          start_db_slave(false, needed_nodes, db_nodes)
         end
       }
     end
@@ -3807,13 +3806,12 @@ class Djinn
   end
 
   def start_search_role()
-    Search.start_master(@options['clear_datastore'].downcase == "true")
+    Search.start_master(false)
   end
 
   def start_taskqueue_master()
-    clear_datastore = @options['clear_datastore'].downcase == "true"
     verbose = @options['verbose'].downcase == "true"
-    TaskQueue.start_master(clear_datastore, verbose)
+    TaskQueue.start_master(false, verbose)
     return true
   end
 
@@ -3825,9 +3823,8 @@ class Djinn
       master_ip = node.private_ip if node.is_taskqueue_master?
     }
 
-    clear_datastore = @options['clear_datastore'].downcase == "true"
     verbose = @options['verbose'].downcase == "true"
-    TaskQueue.start_slave(master_ip, clear_datastore, verbose)
+    TaskQueue.start_slave(master_ip, false, verbose)
     return true
   end
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1405,12 +1405,10 @@ class Djinn
     return BAD_SECRET_MSG unless valid_secret?(secret)
 
     properties = {}
-    instance_variables.each { |name|
-      name_without_at_sign = name[1..name.length-1]
+    @options.keys{ |key|
       begin
-        if name_without_at_sign =~ /\A#{property_regex}\Z/
-          value = instance_variable_get(name)
-          properties[name_without_at_sign] = value
+        if key =~ /\A#{property_regex}\Z/
+          properties[key] = @options[key]
         end
       rescue RegexpError
         Djinn.log_warn("get_property: got invalid regex (#{property_regex}).")

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -458,7 +458,6 @@ class Djinn
     'controller_logs_to_dashboard' => [ TrueClass, 'False' ],
     'appengine' => [ Fixnum, '2' ],
     'autoscale' => [ TrueClass, 'True' ],
-    'clear_datastore' => [ TrueClass, 'False' ],
     'client_secrets' => [ String, nil ],
     'disks' => [ String, nil ],
     'ec2_access_key' => [ String, nil ],
@@ -5469,9 +5468,12 @@ HOSTS
   def get_scaling_info_for_app(app_name, update_dashboard=true)
     # Let's make sure we have the minimum number of AppServers running.
     Djinn.log_debug("Evaluating app #{app_name} for scaling.")
-    if (@app_info_map[app_name]['appengine'].nil? ||
-        @app_info_map[app_name]['appengine'].length <
-        Integer(@options['appengine']))
+    if @app_info_map[app_name]['appengine'].nil?
+      num_appengines = 0
+    else
+      num_appengines = @app_info_map[app_name]['appengine'].length unless
+    end
+    if num_appengines < Integer(@options['appengine'])
       Djinn.log_info("App #{app_name} doesn't have enough AppServers.")
       @last_decision[app_name] = 0
       return :scale_up

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1498,10 +1498,6 @@ class Djinn
       if key == "keyname"
         Djinn.log_warn("Changing keyname can break your deployment!")
       end
-      if key == "flower_password"
-        Djinn.log_warn("flower_password cannot be changed at runtime.")
-        next
-      end
       if key == "max_memory"
         Djinn.log_warn("max_memory will be enforced on new appservers only.")
       end

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -817,7 +817,7 @@ class Djinn
       raise AppScaleException.new(msg)
     end
     all_roles = []
-    locations.each{ |node|
+    locations.each { |node|
       if node.class != Hash
         msg = "Error: node structure is not a Hash."
         Djinn.log_error(msg)
@@ -850,11 +850,12 @@ class Djinn
     # deployment.
     all_roles.uniq!
     ['appengine', 'shadow', 'load_balancer', 'login', 'zookeeper',
-      'memcache', 'db_master', 'taskqueue_master'].each{ |role|
+      'memcache', 'db_master', 'taskqueue_master'].each { |role|
       unless all_roles.include?(role)
         msg = "Error: layout is missing role #{role}."
         Djinn.log_error(msg)
         raise AppScaleException.new(msg)
+      end
     }
 
     # Transform the hash into DjinnJobData and return it.
@@ -997,7 +998,7 @@ class Djinn
     end
 
     # Let's validate we have the needed options defined.
-    ['keyname', 'login', 'table'].each{ |key|
+    ['keyname', 'login', 'table'].each { |key|
       unless @options[key]
         msg = "Error: cannot find #{key} in options!" unless @options[key]
         Djinn.log_error(msg)
@@ -1117,7 +1118,7 @@ class Djinn
         else
           running = 0
           pending = 0
-          @app_info_map[app_name]['appengine'].each{ |location|
+          @app_info_map[app_name]['appengine'].each { |location|
              _host, port = location.split(":")
              if Integer(port) > 0
                running += 1
@@ -1453,7 +1454,7 @@ class Djinn
     end
 
     # Some options may require special actions.
-    newopts.each{ |key, val|
+    newopts.each { |key, val|
       if key == "keyname"
         Djinn.log_warn("Changing keyname can break your deployment!")
       end
@@ -1589,7 +1590,7 @@ class Djinn
       return NOT_READY unless lock_obtained
       output = `"#{NODETOOL}" status`
       ready = false
-      output.split("\n").each{ |line|
+      output.split("\n").each { |line|
         ready = true if line.start_with?('UN') && line.include?(primary_ip)
       }
       return "#{ready}"
@@ -1863,7 +1864,7 @@ class Djinn
       Djinn.log_debug("Apps to restart are #{apps_to_restart}.")
 
       # Next, check if the language of the application is correct.
-      apps.each{ |app|
+      apps.each { |app|
         if @app_info_map[app] && @app_info_map[app]['language'] &&
           @app_info_map[app]['language'] != get_app_language(app)
           failed_apps << app
@@ -5214,7 +5215,7 @@ HOSTS
 
         # Make sure we have the variables to look into: if we catch an app
         # early on, it may not have them.
-        %w(nginx nginx_https haproxy).each{ |key|
+        %w(nginx nginx_https haproxy).each { |key|
           next unless info[key]
           begin
             in_use = true if possibly_free_port == Integer(info[key])
@@ -5265,7 +5266,7 @@ HOSTS
       next if node_ip == my_node.private_ip
       healthy = false
 
-      @all_stats.each{ |stats|
+      @all_stats.each { |stats|
         if stats['private_ip'] == node_ip
           healthy = true
           break
@@ -6159,7 +6160,7 @@ HOSTS
               reqs_enqueued = 0
             else
 
-              @app_info_map[app_name]['appengine'].each{ |location|
+              @app_info_map[app_name]['appengine'].each { |location|
                 host, port = location.split(":")
                 if Integer(port) > 0
                   appservers += 1

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5469,7 +5469,7 @@ HOSTS
     if @app_info_map[app_name]['appengine'].nil?
       num_appengines = 0
     else
-      num_appengines = @app_info_map[app_name]['appengine'].length unless
+      num_appengines = @app_info_map[app_name]['appengine'].length
     end
     if num_appengines < Integer(@options['appengine'])
       Djinn.log_info("App #{app_name} doesn't have enough AppServers.")

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -454,7 +454,7 @@ class Djinn
   PARAMETERS_AND_CLASS = {
     'controller_logs_to_dashboard' => [ TrueClass, 'False' ],
     'appengine' => [ Fixnum, '2' ],
-    'autoscale' => [ TrueClass, nil ],
+    'autoscale' => [ TrueClass, 'True' ],
     'clear_datastore' => [ TrueClass, 'False' ],
     'client_secrets' => [ String, nil ],
     'disks' => [ String, nil ],
@@ -2099,7 +2099,7 @@ class Djinn
 
       # Print stats in the log recurrently; works as a heartbeat mechanism.
       if last_print < (Time.now.to_i - 60 * PRINT_STATS_MINUTES)
-        if my_node.is_shadow? and @options['autoscale'].downcase != "true"
+        if my_node.is_shadow? && @options['autoscale'].downcase != "true"
           Djinn.log_info("--- This deployment has autoscale disabled.")
         end
         stats = JSON.parse(get_all_stats(secret))

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -936,8 +936,8 @@ class Djinn
         rescue
           msg = "Warning: cannot convert '" + key + "' to string. Removing it."
           Djinn.log_warn(msg)
+          next
         end
-        next
       end
 
       # Strings may need to be sanitized.
@@ -1405,11 +1405,12 @@ class Djinn
   def get_property(property_regex, secret)
     return BAD_SECRET_MSG unless valid_secret?(secret)
 
+    Djinn.log_info("Received request to get properties matching #{property_regex}.")
     properties = {}
-    @options.keys{ |key|
+    @options.each{ |key, val|
       begin
         if key =~ /\A#{property_regex}\Z/
-          properties[key] = @options[key]
+          properties[key] = val
         end
       rescue RegexpError
         Djinn.log_warn("get_property: got invalid regex (#{property_regex}).")
@@ -1437,7 +1438,7 @@ class Djinn
   #     - BAD_SECRET_MSG if the caller could not be authenticated.
   def set_property(property_name, property_value, secret)
     return BAD_SECRET_MSG unless valid_secret?(secret)
-    if property_name.class != String or property_value != String
+    if property_name.class != String or property_value.class != String
       Djinn.log_warn("set_property: received non String parameters.")
       return KEY_NOT_FOUND
     end
@@ -1445,11 +1446,11 @@ class Djinn
     Djinn.log_info("Received request to change #{property_name} to #{property_value}.")
     opts = {}
     opts[property_name] = property_value
-    newops = check_options(opts)
+    newopts = check_options(opts)
 
     # If we don't have any option to set, property was invalid.
     if newopts.length == 0
-      Djinn.log_info("Failed to set #{property_name}")
+      Djinn.log_info("Failed to set property '#{property_name}'.")
       return KEY_NOT_FOUND
     end
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5372,8 +5372,6 @@ HOSTS
   # that each application has received as well as the number of requests that
   # are sitting in haproxy's queue, waiting to be served.
   def scale_appservers_within_nodes
-    return if @options['autoscale'].downcase != "true"
-
     @apps_loaded.each { |app_name|
       initialize_scaling_info_for_app(app_name)
 
@@ -5478,6 +5476,10 @@ HOSTS
       @last_decision[app_name] = 0
       return :scale_up
     end
+
+    # We only run @options['appengine'] AppServers per application if
+    # austoscale is disabled.
+    return :no_change if @options['autoscale'].downcase != "true"
 
     # We need the haproxy stats to decide upon what to do.
     total_requests_seen, total_req_in_queue, time_requests_were_seen = get_haproxy_stats(app_name)

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -962,8 +962,8 @@ class Djinn
 
   def enforce_options()
     # Set the proper log level.
-    new.level = Logger::INFO
-    new.level = Logger::DEBUG if @options['verbose'].downcase == "true"
+    new_level = Logger::INFO
+    new_level = Logger::DEBUG if @options['verbose'].downcase == "true"
     @@log.level = new_level if @@log.level != new_level
 
     # Make sure flower is running with the proper password.

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -971,13 +971,14 @@ class Djinn
     TaskQueue.start_flower(@options['flower_password']) if my_node.is_shadow?
   end
 
-  # Validates and sets the instance variables that Djinn needs before it can
-  # begin configuring and deploying services on a given node (and if it is the
-  # first Djinn, starting up the other Djinns).
+  # This is the method needed to get the current layout and options for
+  # this deployment. The first AppController to receive this call is the
+  # shadow node. It will then forward these information to all other
+  # nodes.
   #
   # Args:
-  #   layout: this is a JSON structure containing the nodes
-  #     informations (IPs, roles, instance ID etc...). These are the nodes
+  #   layout: this is a JSON structure containing the node
+  #     information (IPs, roles, instance ID etc...). These are the nodes
   #     specified in the AppScalefile at startup time.
   #   options: this is a Hash containing all the options and credentials
   #     (for autoscaling) pertinent to this deployment.

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1000,7 +1000,7 @@ class Djinn
       return msg
     end
     if opts.nil? || opts.empty?
-      Djinn.log_warn("Empty options: using defaults (autoscale is not enabled).")
+      Djinn.log_info("Empty options: using defaults.")
     elsif opts.class != Hash
       msg = "Error: options is not a Hash."
       Djinn.log_error(msg)

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1029,6 +1029,13 @@ class Djinn
       end
     }
 
+    # Set the proper log level.
+    if @options['verbose'].downcase == "true"
+      @@log.level = Logger::DEBUG
+    else
+      @@log.level = Logger::INFO
+    end
+
     # From here on we do more logical checks on the values we received.
     # The first one is to check that max and min are set appropriately.
     # Max and min needs to be at least the number of started nodes, it
@@ -1056,8 +1063,6 @@ class Djinn
       @options['ec2_secret_key'] = @options['EC2_SECRET_KEY']
       @options['ec2_url'] = @options['EC2_URL']
     end
-
-    @@log.level = Logger::DEBUG if @options['verbose'].downcase == "true"
 
     begin
       @options['zone'] = JSON.load(@options['zone'])
@@ -1454,8 +1459,8 @@ class Djinn
       return KEY_NOT_FOUND
     end
 
-    # Some options may require special actions.
     newopts.each { |key, val|
+      # We give some extra information to the user about some properties.
       if key == "keyname"
         Djinn.log_warn("Changing keyname can break your deployment!")
       end
@@ -1470,7 +1475,6 @@ class Djinn
         unless is_cloud?
           Djinn.log_warn("min_images is not used in non-cloud infrastructures.")
         end
-        Djinn.log_warn("min_images shouldn't be changed at runtime.")
       end
       if key == "max_images"
         unless is_cloud?
@@ -1482,6 +1486,16 @@ class Djinn
         next
       end
       @options[key] = val
+
+      # Some options may require special actions.
+      if key == "verbose"
+        if @options['verbose'].downcase == "true"
+          @@log.level = Logger::DEBUG
+        else
+          @@log.level = Logger::INFO
+        end
+      end
+
       Djinn.log_info("Successfully set #{key} to #{val}.")
     }
 
@@ -3466,9 +3480,6 @@ class Djinn
   end
 
   def parse_options
-    # Set the proper log level.
-    @@log.level = Logger::DEBUG if @options['verbose'].downcase == "true"
-
     keypath = @options['keyname'] + ".key"
     Djinn.log_debug("Keypath is #{keypath}, keyname is #{@options['keyname']}")
     my_key_dir = "#{APPSCALE_CONFIG_DIR}/keys/#{my_node.cloud}"

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1456,8 +1456,21 @@ class Djinn
 
     # Some options may require special actions.
     newopts.each{ |key, val|
+      if key == "keyname"
+        Djinn.log_warn("Changing keyname can break your deployment!")
+      end
+      if key == "flower_password"
+        Djinn.log_warn("flower_password cannot be changed at runtime.")
+        next
+      end
       if key == "max_memory"
         Djinn.log_warn("max_memory will be enforced on new appservers only.")
+      end
+      if key == "min_images"
+        unless is_cloud?
+          Djinn.log_warn("min_images is not used in non-cloud infrastructures.")
+        end
+        Djinn.log_warn("min_images shouldn't be changed at runtime.")
       end
       if key == "max_images"
         unless is_cloud?
@@ -1466,7 +1479,7 @@ class Djinn
       end
       if key == "replication"
         Djinn.log_warn("replication cannot be changed at runtime.")
-        return
+        next
       end
       @options[key] = val
       Djinn.log_info("Successfully set #{key} to #{val}.")

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -1277,7 +1277,7 @@ class TestDjinn < Test::Unit::TestCase
     empty_hash = JSON.dump({})
     assert_equal(empty_hash, djinn.get_property("not-a-variable-name", @secret))
     expected_result = JSON.dump({'verbose' => 'True'})
-    assert_equal(expected_result, djinn.get_property('version', @secret))
+    assert_equal(expected_result, djinn.get_property('verbose', @secret))
   end
 
 
@@ -1317,7 +1317,7 @@ class TestDjinn < Test::Unit::TestCase
     # results in subsequent get calls seeing the correct value.
     assert_equal('OK', djinn.set_property('verbose', 'True', @secret))
     expected_result = JSON.dump({'verbose' => 'True'})
-    assert_equal(expected_result, djinn.get_property('version', @secret))
+    assert_equal(expected_result, djinn.get_property('verbose', @secret))
   end
 
 

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -178,6 +178,7 @@ class TestDjinn < Test::Unit::TestCase
 
     djinn = Djinn.new
     flexmock(djinn).should_receive(:find_me_in_locations).and_raise(Exception)
+    flexmock(djinn).should_receive(:enforce_options).and_return()
     assert_raises(Exception) {
       djinn.set_parameters(one_node_info, credentials, @secret)
     }
@@ -189,6 +190,7 @@ class TestDjinn < Test::Unit::TestCase
 
     flexmock(Djinn).new_instances { |instance|
       instance.should_receive(:valid_secret?).and_return(true)
+      instance.should_receive("enforce_options").and_return()
     }
     djinn = Djinn.new
 
@@ -1247,6 +1249,7 @@ class TestDjinn < Test::Unit::TestCase
   def test_get_property
     flexmock(Djinn).new_instances { |instance|
       instance.should_receive(:valid_secret?).and_return(true)
+      instance.should_receive("enforce_options").and_return()
     }
     djinn = Djinn.new()
 
@@ -1284,6 +1287,7 @@ class TestDjinn < Test::Unit::TestCase
   def test_set_property
     flexmock(Djinn).new_instances { |instance|
       instance.should_receive(:valid_secret?).and_return(true)
+      instance.should_receive("enforce_options").and_return()
     }
     djinn = Djinn.new()
 

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -1278,7 +1278,7 @@ class TestDjinn < Test::Unit::TestCase
     # Verify that setting a property that we allow users to set
     # results in subsequent get calls seeing the correct value.
     assert_equal('OK', djinn.set_property('verbose', 'true', @secret))
-    result = djinn.get_property('verbose' @secret)
+    result = djinn.get_property('verbose', @secret)
     assert_equal('true', result)
   end
 

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -145,9 +145,11 @@ class TestDjinn < Test::Unit::TestCase
 
     # Try passing in params that aren't the required type
     result_1 = djinn.set_parameters([], [], @secret)
-    assert_equal(true, result_1.include?("Error: layout wasn't a String"))
+    assert_equal(true, result_1.include?("Error: options wasn't a String"))
 
-    result_2 = djinn.set_parameters("", "", @secret)
+    better_credentials = JSON.dump({'keyname' => '0123', 'login' =>
+      '1.1.1.1', 'table' => 'cassandra'})
+    result_2 = djinn.set_parameters("", better_credentials,  @secret)
     assert_equal(true, result_2.include?("Error: layout is empty"))
 
     # Now try credentials with an even number of items, but not all the
@@ -171,7 +173,8 @@ class TestDjinn < Test::Unit::TestCase
     one_node_info = JSON.dump([{
       'public_ip' => 'public_ip',
       'private_ip' => 'private_ip',
-      'jobs' => ['some_role'],
+      'jobs' => ['appengine', 'shadow', 'taskqueue_master', 'db_master',
+        'load_balancer', 'login', 'zookeeper', 'memcache'],
       'instance_id' => 'instance_id'
     }])
 
@@ -200,7 +203,8 @@ class TestDjinn < Test::Unit::TestCase
     one_node_info = JSON.dump([{
       'public_ip' => 'public_ip',
       'private_ip' => '1.2.3.4',
-      'jobs' => ['some_role'],
+      'jobs' => ['appengine', 'shadow', 'taskqueue_master', 'db_master',
+        'load_balancer', 'login', 'zookeeper', 'memcache'],
       'instance_id' => 'instance_id'
     }])
 
@@ -1273,12 +1277,9 @@ class TestDjinn < Test::Unit::TestCase
 
     # Verify that setting a property that we allow users to set
     # results in subsequent get calls seeing the correct value.
-    djinn.state = "AppController is taking it easy today"
-    new_state = "AppController is back to work"
-    assert_equal('OK', djinn.set_property('state', new_state, @secret))
-
-    state_only = JSON.dump({'state' => new_state})
-    assert_equal(state_only, djinn.get_property('state', @secret))
+    assert_equal('OK', djinn.set_property('verbose', 'true', @secret))
+    result = djinn.get_property('verbose' @secret)
+    assert_equal('true', result)
   end
 
 


### PR DESCRIPTION
This PR enables the ability to change properties set in the AppScalefile (for example verbose) at run time. At this time some of these changes won't be in effect (for example changing the flower_password would require a restart of flower, and we don't handle that yet), but the basics ones works.

We also enabled an old flag not in function: autoscale. By default is on, but if turned off, the AC won't add or remove appservers anylonger.