### PR TITLE
Ensure monit stays up

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2082,6 +2082,12 @@ class Djinn
 
     check_health = nil
     until @kill_sig_received do
+      # We want to ensure monit stays up all the time, since we rely on
+      # it for services and AppServers.
+      unless MonitInterface.start_monit()
+        Djinn.log_warn("Monit was not running: restarted it.")
+      end
+
       write_database_info()
       update_firewall()
       write_memcache_locations()

--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -32,7 +32,9 @@ module MonitInterface
   MONIT = "/usr/bin/monit"
 
   def self.start_monit()
-    self.run_cmd("service monit start")
+    ret = system("service --status-all 2> /dev/null | grep monit | grep + > /dev/null")
+    self.run_cmd("service monit start") unless ret
+    return ret
   end
   
   def self.start(watch, start_cmd, stop_cmd, ports, env_vars, match_cmd, mem,


### PR DESCRIPTION
Since we rely on Monit for most of our AppServers and Services, we need
to make the best effort to keep it running in spite of OOM and similar
conditions.