### PR TITLE
Add missing redirection for centralized application logs

### DIFF
--- a/lib/templates/monit_template_syslog.conf
+++ b/lib/templates/monit_template_syslog.conf
@@ -1,4 +1,4 @@
 check process {watch}-{port} matching "^(/usr/bin/python |/usr/bin/python2)?{match}"
   group {watch}
-  start program = "/bin/bash -c '{env} {start} | tee -a /var/log/appscale/{watch}-{port}.log | logger -t {watch} -u /tmp/ignored -n {syslog_server} -P 514'"
+  start program = "/bin/bash -c '{env} {start} 2>&1 | tee -a /var/log/appscale/{watch}-{port}.log | logger -t {watch} -u /tmp/ignored -n {syslog_server} -P 514'"
   stop program = "{stop}"


### PR DESCRIPTION
Fixes missing centralized app log (example of empty log [here](https://ocd.appscale.com:8080/job/Hawkeye/8965/artifact/logs-appscale-testing-6b933c23-a91e-408b-ba21-948a4b0fe6ed/192.168.103.111/appscale/app___hawkeyepython27-20001.log/*view*/)).

Proper behavior shown [here](https://ocd.appscale.com:8080/job/Hawkeye/8984/artifact/logs-appscale-testing-225d89e6-049d-4b06-a273-1deaebbc1377/192.168.101.19/appscale/app___hawkeyepython27.log/*view*/).