### PR TITLE
Check status code when fetching public IP

### DIFF
--- a/AppController/lib/helperfunctions.rb
+++ b/AppController/lib/helperfunctions.rb
@@ -5,6 +5,7 @@
 require 'base64'
 require 'digest/sha1'
 require 'fileutils'
+require 'net/http'
 require 'openssl'
 require 'socket'
 require 'timeout'
@@ -1385,15 +1386,23 @@ module HelperFunctions
   #   A String containing the public IP that traffic can be sent to that
   #   reaches this machine.
   def self.get_public_ip_from_metadata_service()
-    aws_ip = `curl -L -s #{AWS_METADATA}/public-ipv4`
-    unless aws_ip.empty?
-      Djinn.log_debug("Detected AWS public ip: #{aws_ip}.")
-      return aws_ip
+    url = URI.parse("#{AWS_METADATA}/public-ipv4")
+    request = Net::HTTP::Get.new(url.path)
+    response = Net::HTTP.start(url.host) { |http| http.request(request) }
+    if response.code == '200'
+      Djinn.log_debug("Detected AWS public ip: #{response.body}.")
+      return response.body
     end
-    gce_ip = `curl -L -s #{GCE_METADATA}/network-interfaces/0/access-configs/0/external-ip`
-    unless gce_ip.empty?
-      Djinn.log_debug("Detected GCE public ip: #{gce_ip}.")
-      return gce_ip
+
+    url = URI.parse(
+      "#{GCE_METADATA}/network-interfaces/0/access-configs/0/external-ip")
+    request = Net::HTTP::Get.new(url.path)
+    # Google requires an extra header when requesting metadata.
+    request.add_field('Metadata-Flavor', 'Google')
+    response = Net::HTTP.start(url.host) { |http| http.request(request) }
+    if response.code == '200'
+      Djinn.log_debug("Detected GCE public ip: #{response.body}.")
+      return response.body
     end
   end
 

--- a/AppController/lib/helperfunctions.rb
+++ b/AppController/lib/helperfunctions.rb
@@ -140,8 +140,8 @@ module HelperFunctions
 
 
   # Metadata service for Google and AWS
-  GCE_METADATA = "http://169.254.169.254/computeMetadata/v1/instance/"
-  AWS_METADATA = "http://169.254.169.254/latest/meta-data/"
+  GCE_METADATA = "http://169.254.169.254/computeMetadata/v1/instance"
+  AWS_METADATA = "http://169.254.169.254/latest/meta-data"
 
   def self.shell(cmd)
     return `#{cmd}`


### PR DESCRIPTION
This was previously using the 404 template returned by Google as the IP address when trying to fetch AWS's metadata URL.