### PR TITLE
Use load balancers

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4157,7 +4157,6 @@ class Djinn
     my_public = my_node.public_ip
     my_private = my_node.private_ip
 
-
     # Populate the appropriate list.
     @nodes.each { |node|
       all_ips << node.private_ip
@@ -4199,11 +4198,11 @@ class Djinn
       Djinn.log_info("All private IPs: #{all_ips}.")
       HelperFunctions.write_file("#{APPSCALE_CONFIG_DIR}/all_ips", all_ips_content)
 
-      Djinn.log_info("Load Balancers location: #{load_balancer_ips}.")
+      Djinn.log_info("Load balancer location(s): #{load_balancer_ips}.")
       load_balancer_file = "#{APPSCALE_CONFIG_DIR}/load_balancer_ips"
       HelperFunctions.write_file(load_balancer_file, load_balancer_content)
 
-      Djinn.log_info("Deployment public name/IP(s): #{login_ips}.")
+      Djinn.log_info("Deployment public name(s)/IP(s): #{login_ips}.")
       login_file = "#{APPSCALE_CONFIG_DIR}/login_ip"
       HelperFunctions.write_file(login_file, login_content)
 
@@ -4214,7 +4213,7 @@ class Djinn
       Djinn.log_info("Taskqueue locations: #{taskqueue_ips}.")
       HelperFunctions.write_file(TASKQUEUE_FILE,  taskqueue_content)
 
-      Djinn.log_info("Master is at #{master_ips}, slaves are at #{slave_ips}.")
+      Djinn.log_info("Database master is at #{master_ips}, slaves are at #{slave_ips}.")
       HelperFunctions.write_file("#{APPSCALE_CONFIG_DIR}/masters", "#{master_content}")
       HelperFunctions.write_file("#{APPSCALE_CONFIG_DIR}/slaves", "#{slaves_content}")
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4190,6 +4190,8 @@ class Djinn
 
     # If nothing changed since last time we wrote locations file(s), skip it.
     if new_content != @locations_content
+      @locations_content = new_content
+
       # For the taskqueue, let's shuffle the entries, and then put
       # ourselves as first option, if we are a taskqueue node.
       taskqueue_ips.shuffle!
@@ -4230,8 +4232,6 @@ class Djinn
 
       Djinn.log_info("Search service locations: #{search_ips}.")
       HelperFunctions.write_file(Search::SEARCH_LOCATION_FILE, search_content)
-
-      @locations_content = new_content
     end
   end
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2058,8 +2058,8 @@ class Djinn
     end
     parse_options()
 
-    # load datastore helper
-    # TODO: this should be the class or module
+    # Load datastore helper.
+    # TODO: this should be the class or module.
     @state = "Setting up database configuration files"
     table = @options['table']
     # require db_file
@@ -4236,12 +4236,6 @@ class Djinn
   end
 
   def setup_config_files()
-    head_node_ip = get_shadow.public_ip
-    HelperFunctions.write_file("#{APPSCALE_CONFIG_DIR}/head_node_ip", "#{head_node_ip}\n")
-
-    login_ip = @options['login']
-    HelperFunctions.write_file("#{APPSCALE_CONFIG_DIR}/login_ip", "#{login_ip}\n")
-
     update_hosts_info()
 
     # use iptables to lock down outside traffic
@@ -4295,14 +4289,14 @@ class Djinn
       HelperFunctions.write_file(load_balancers_file, load_balancers_content)
 
       Djinn.log_info("Deployment public name/IP(s): #{login_ips}.")
-      login_file = "#{APPSCALE_CONFIG_DIR}/appdashboard_public_ip"
+      login_file = "#{APPSCALE_CONFIG_DIR}/login_ip"
       HelperFunctions.write_file(login_file, login_content)
 
-      Djinn.log_info("Memcache locations: #{load_balancers_ips}.")
+      Djinn.log_info("Memcache locations: #{memcache_content}.")
       memcache_file = "#{APPSCALE_CONFIG_DIR}/memcache_ips"
-      HelperFunctions.write_file(memcache_file, memcache_content)
+      HelperFunctions.write_file(memcache_file, memcache_ips)
 
-      Djinn.log_info("Taskqueue locations: #{load_balancers_ips}.")
+      Djinn.log_info("Taskqueue locations: #{taskqueue_ips}.")
       HelperFunctions.write_file(TASKQUEUE_FILE,  taskqueue_content)
 
       Djinn.log_info("Master is at #{master_ip}, slaves are at #{slave_ips.join(', ')}")

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2737,19 +2737,6 @@ class Djinn
     HelperFunctions.log_and_crash(@state, WAIT_TO_CRASH)
   end
 
-  def self.get_db_master_ip()
-    masters_file = File.expand_path("#{APPSCALE_CONFIG_DIR}/masters")
-    master_ip = HelperFunctions.read_file(masters_file)
-    return master_ip
-  end
-
-  def self.get_db_slave_ips()
-    slaves_file = File.expand_path("#{APPSCALE_CONFIG_DIR}/slaves")
-    slave_ips = File.open(slaves_file).readlines.map { |f| f.chomp! }
-    slave_ips = [] if slave_ips == [""]
-    return slave_ips
-  end
-
   def get_all_appengine_nodes()
     ae_nodes = []
     @nodes.each { |node|
@@ -4191,8 +4178,8 @@ class Djinn
     memcache_ips << '\n'
     slave_ips << '\n'
     taskqueue_ips << '\n'
-    search_ips << '\n'
     slave_ips << master_ips[0] if slave_ips.empty?
+    search_ips << '\n'
     slave_ips << '\n'
 
     # Turn the arrays into string.

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4197,6 +4197,7 @@ class Djinn
         taskqueue_ips.delete(my_private)
         taskqueue_ips.unshift(my_private)
       end
+      taskqueue_content = taskqueue_ips.join("\n") + "\n"
 
       Djinn.log_info("All private IPs: #{all_ips}.")
       HelperFunctions.write_file("#{APPSCALE_CONFIG_DIR}/all_ips", all_ips_content)

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4184,8 +4184,7 @@ class Djinn
       master_content + memcache_content + my_public + my_private +
       num_of_nodes + taskqueue_content + search_content + slaves_content
 
-    # If nothing changes since last time we wrote the locations file, we
-    # skip it.
+    # If nothing changed since last time we wrote locations file(s), skip it.
     if new_content != @locations_content
       # For the taskqueue, let's shuffle the entries, and then put
       # ourselves as first option, if we are a taskqueue node.

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4171,16 +4171,15 @@ class Djinn
     }
 
     # Add an end-of-line so the file is more readable.
-    all_ips << '\n'
-    load_balancer_ips << '\n'
-    login_ips << '\n'
-    master_ips << '\n'
-    memcache_ips << '\n'
-    slave_ips << '\n'
-    taskqueue_ips << '\n'
+    all_ips << "\n"
+    load_balancer_ips << "\n"
+    login_ips << "\n"
+    master_ips << "\n"
+    memcache_ips << "\n"
+    taskqueue_ips << "\n"
+    search_ips << "\n"
     slave_ips << master_ips[0] if slave_ips.empty?
-    search_ips << '\n'
-    slave_ips << '\n'
+    slave_ips << "\n"
 
     # Turn the arrays into string.
     all_ips_content = all_ips.join("\n")

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4169,27 +4169,17 @@ class Djinn
       taskqueue_ips << node.private_ip if node.is_taskqueue_master? ||
         node.is_taskqueue_slave?
     }
-
-    # Add an end-of-line so the file is more readable.
-    all_ips << "\n"
-    load_balancer_ips << "\n"
-    login_ips << "\n"
-    master_ips << "\n"
-    memcache_ips << "\n"
-    taskqueue_ips << "\n"
-    search_ips << "\n"
     slave_ips << master_ips[0] if slave_ips.empty?
-    slave_ips << "\n"
 
     # Turn the arrays into string.
-    all_ips_content = all_ips.join("\n")
-    memcache_content = memcache_ips.join("\n")
-    load_balancer_content = load_balancer_ips.join("\n")
-    taskqueue_content = taskqueue_ips.join("\n")
-    login_content = login_ips.join("\n")
-    master_content = master_ips.join("\n")
-    search_content = slave_ips.join("\n")
-    slaves_content = slave_ips.join("\n")
+    all_ips_content = all_ips.join("\n") + "\n"
+    memcache_content = memcache_ips.join("\n") + "\n"
+    load_balancer_content = load_balancer_ips.join("\n") + "\n"
+    taskqueue_content = taskqueue_ips.join("\n") + "\n"
+    login_content = login_ips.join("\n") + "\n"
+    master_content = master_ips.join("\n") + "\n"
+    search_content = slave_ips.join("\n") + "\n"
+    slaves_content = slave_ips.join("\n") + "\n"
 
     new_content = all_ips_content + login_content + load_balancer_content +
       master_content + memcache_content + my_public + my_private +
@@ -4217,14 +4207,14 @@ class Djinn
       login_file = "#{APPSCALE_CONFIG_DIR}/login_ip"
       HelperFunctions.write_file(login_file, login_content)
 
-      Djinn.log_info("Memcache locations: #{memcache_content}.")
+      Djinn.log_info("Memcache locations: #{memcache_ips}.")
       memcache_file = "#{APPSCALE_CONFIG_DIR}/memcache_ips"
-      HelperFunctions.write_file(memcache_file, memcache_ips)
+      HelperFunctions.write_file(memcache_file, memcache_content)
 
       Djinn.log_info("Taskqueue locations: #{taskqueue_ips}.")
       HelperFunctions.write_file(TASKQUEUE_FILE,  taskqueue_content)
 
-      Djinn.log_info("Master is at #{master_ips}, slaves are at #{slave_ips.join(', ')}.")
+      Djinn.log_info("Master is at #{master_ips}, slaves are at #{slave_ips}.")
       HelperFunctions.write_file("#{APPSCALE_CONFIG_DIR}/masters", "#{master_content}")
       HelperFunctions.write_file("#{APPSCALE_CONFIG_DIR}/slaves", "#{slaves_content}")
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4167,10 +4167,6 @@ class Djinn
     my_public = my_node.public_ip
     my_private = my_node.private_ip
 
-    # Put ourselves as first option, if we are a taskqueue node.
-    if my_node.is_taskqueue_master? || my_node.is_taskqueue_slave?
-      taskqueue_ips << my_private
-    end
 
     # Populate the appropriate list.
     @nodes.each { |node|
@@ -4185,6 +4181,12 @@ class Djinn
       taskqueue_ips << node.private_ip if (node.is_taskqueue_master? ||
         node.is_taskqueue_slave?) && !taskqueue_ips.include?(node.private_ip)
     }
+    # For the taskqueue, let's shuffle the entries, and then put ourselves
+    # as first option, if we are a taskqueue node.
+    taskqueue_ips.shuffle!
+    if my_node.is_taskqueue_master? || my_node.is_taskqueue_slave?
+      taskqueue_ips.unshift(my_private)
+    end
 
     # Add an end-of-line so the file is more readable.
     all_ips << '\n'

--- a/AppController/lib/taskqueue_client.rb
+++ b/AppController/lib/taskqueue_client.rb
@@ -22,12 +22,9 @@ class TaskQueueClient
   # The port that the TaskQueue Server binds to.
   SERVER_PORT = 17446
 
-  # Location of where the nearest taskqueue server is.
-  NEAREST_TQ_LOCATION = '/etc/appscale/rabbitmq_ip'
-
   # Initialization function for TaskQueueClient
-  def initialize()
-    @ip = HelperFunctions.read_file(NEAREST_TQ_LOCATION)
+  def initialize(which_ip)
+    @ip = which_ip
   end
 
 

--- a/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
+++ b/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
@@ -110,7 +110,7 @@ class TaskQueueServiceStub(apiproxy_stub.APIProxyStub):
       tq_file.close()
     else:
       raise apiproxy_errors.ApplicationError(
-          taskqueue_service_pb.TaskQueueServiceError.INTERNAL_ERROR)
+        taskqueue_service_pb.TaskQueueServiceError.INTERNAL_ERROR)
 
     location += ":" + str(TASKQUEUE_SERVER_PORT)
     return location

--- a/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
+++ b/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
@@ -109,7 +109,8 @@ class TaskQueueServiceStub(apiproxy_stub.APIProxyStub):
       location = ips[0]
       tq_file.close()
     else:
-      location = "localhost"
+      raise apiproxy_errors.ApplicationError(
+          taskqueue_service_pb.TaskQueueServiceError.INTERNAL_ERROR)
 
     location += ":" + str(TASKQUEUE_SERVER_PORT)
     return location

--- a/AppServer/google/appengine/api/taskqueue/test/test_taskqueue_distributed.py
+++ b/AppServer/google/appengine/api/taskqueue/test/test_taskqueue_distributed.py
@@ -96,7 +96,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
   def test_taskqueue_service_stub(self):
     """ Test the constructor. """
     tqd = flexmock(taskqueue_distributed.TaskQueueServiceStub)
-    tqd.should_receive("__GetTQLocations").and_return(["some_location"])
+    tqd.should_receive("_GetTQLocations").and_return(["some_location"])
     taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname", 12345)
 
   def test_dynamic_add(self):
@@ -106,7 +106,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
     taskqueue_service_pb.should_receive("TaskQueueBulkAddResponse").\
       and_return(FakeBulkAddResponse())
     tqd = flexmock(taskqueue_distributed.TaskQueueServiceStub)
-    tqd.should_receive("__GetTQLocations").and_return(["some_location"])
+    tqd.should_receive("_GetTQLocations").and_return(["some_location"])
     tqd.should_receive("_RemoteSend").and_return()
     tqd.should_receive("_Dynamic_BulkAdd").and_return()
 
@@ -120,7 +120,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
       and_return(FakeBulkAddRequest())
     taskqueue_service_pb.should_receive("TaskQueueBulkAddResponse").\
       and_return(FakeBulkAddResponse())
-    tqd.should_receive("__GetTQLocations").and_return(["some_location"])
+    tqd.should_receive("_GetTQLocations").and_return(["some_location"])
     tqd.should_receive("_RemoteSend").and_return()
     tqd = taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname", 12345)
      
@@ -128,7 +128,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
 
   def test_add_transactional_bulk_task(self):
     tqd = flexmock(taskqueue_distributed.TaskQueueServiceStub)
-    tqd.should_receive("__GetTQLocations").and_return(["some_location"])
+    tqd.should_receive("_GetTQLocations").and_return(["some_location"])
     tqd.should_receive("_RemoteSend").and_return()
     flexmock(apiproxy_stub_map)
     apiproxy_stub_map.should_receive("MakeSyncCall")

--- a/AppServer/google/appengine/api/taskqueue/test/test_taskqueue_distributed.py
+++ b/AppServer/google/appengine/api/taskqueue/test/test_taskqueue_distributed.py
@@ -96,7 +96,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
   def test_taskqueue_service_stub(self):
     """ Test the constructor. """
     tqd = flexmock(taskqueue_distributed.TaskQueueServiceStub)
-    tqd.should_receive("__GetTQLocation").and_return("some_location")
+    tqd.should_receive("__GetTQLocations").and_return(["some_location"])
     taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname", 12345)
 
   def test_dynamic_add(self):
@@ -106,7 +106,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
     taskqueue_service_pb.should_receive("TaskQueueBulkAddResponse").\
       and_return(FakeBulkAddResponse())
     tqd = flexmock(taskqueue_distributed.TaskQueueServiceStub)
-    tqd.should_receive("__GetTQLocation").and_return("some_location")
+    tqd.should_receive("__GetTQLocations").and_return(["some_location"])
     tqd.should_receive("_RemoteSend").and_return()
     tqd.should_receive("_Dynamic_BulkAdd").and_return()
 
@@ -120,7 +120,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
       and_return(FakeBulkAddRequest())
     taskqueue_service_pb.should_receive("TaskQueueBulkAddResponse").\
       and_return(FakeBulkAddResponse())
-    tqd.should_receive("__GetTQLocation").and_return("some_location")
+    tqd.should_receive("__GetTQLocations").and_return(["some_location"])
     tqd.should_receive("_RemoteSend").and_return()
     tqd = taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname", 12345)
      
@@ -128,7 +128,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
 
   def test_add_transactional_bulk_task(self):
     tqd = flexmock(taskqueue_distributed.TaskQueueServiceStub)
-    tqd.should_receive("__GetTQLocation").and_return("some_location")
+    tqd.should_receive("__GetTQLocations").and_return(["some_location"])
     tqd.should_receive("_RemoteSend").and_return()
     flexmock(apiproxy_stub_map)
     apiproxy_stub_map.should_receive("MakeSyncCall")

--- a/AppServer/google/appengine/tools/appengine_rpc.py
+++ b/AppServer/google/appengine/tools/appengine_rpc.py
@@ -40,7 +40,7 @@ logger = logging.getLogger('google.appengine.tools.appengine_rpc')
 
 # The location of the file which contains the public IP of the AppScale 
 # Dashboard.
-APPSCALE_DASHBOARD_IP_LOC = "/etc/appscale/appdashboard_public_ip"
+APPSCALE_LOGIN_IP = "/etc/appscale/login_ip"
 
 def GetPlatformToken(os_module=os, sys_module=sys, platform=sys.platform):
   """Returns a 'User-agent' token for the host system platform.
@@ -268,9 +268,11 @@ class AbstractRpcServer(object):
       The IP address where the AppDashboard can be contacted.
     """
     try:
-      file_handle = open(APPSCALE_DASHBOARD_IP_LOC)
-      ip = file_handle.read()
+      file_handle = open(APPSCALE_LOGIN_IP)
+      raw_ips = file_handle.read()
       file_handle.close()
+      ips = raw_ips.split('\n')
+      ip = ips[0]
     except IOError:
       logger.info("Saw an IOError when trying to get the AppDashboard's" + \
         "public IP, returning localhost instead")

--- a/AppServer/google/appengine/tools/devappserver2/python/runtime.py
+++ b/AppServer/google/appengine/tools/devappserver2/python/runtime.py
@@ -129,7 +129,9 @@ def main():
 
   nginx_host = None
   with open('/etc/appscale/login_ip') as file_handle:
-    nginx_host = file_handle.read().strip()
+    raw_ips = file_handle.read()
+    ips = raw_ips.split('\n')
+    nginx_host = ips[0]
 
   if debugging_app:
     server = wsgi_server.WsgiServer(

--- a/AppServer_Java/src/com/google/appengine/api/taskqueue/dev/AppScaleTaskQueueClient.java
+++ b/AppServer_Java/src/com/google/appengine/api/taskqueue/dev/AppScaleTaskQueueClient.java
@@ -42,7 +42,7 @@ public class AppScaleTaskQueueClient {
     private final String SERVICE_NAME = "taskqueue";
     private final String PROTOCOL_BUFFER_HEADER = "ProtocolBufferType";
     private final String PROTOCOL_BUFFER_VALUE = "Request";
-    private final String TASKQUEUE_IP_FILE = "/etc/appscale/rabbitmq_ip";
+    private final String TASKQUEUE_IP_FILE = "/etc/appscale/taskqueue_nodes";
     private DefaultHttpClient client = null;
     private String url = null;
     private String appId = null;

--- a/AppTaskQueue/appscale/taskqueue/brokers/rabbitmq.py
+++ b/AppTaskQueue/appscale/taskqueue/brokers/rabbitmq.py
@@ -8,18 +8,21 @@ sys.path.append(APPSCALE_LIB_DIR)
 import file_io
 
 # The FS location which contains the nearest RabbitMQ server
-RABBITMQ_LOCATION_FILE = '/etc/appscale/rabbitmq_ip' 
+RABBITMQ_LOCATION_FILE = '/etc/appscale/taskqueue_nodes'
 
 # The port required to connect to RabbitMQ
 RABBITMQ_PORT = 5672
 
 def get_connection_string():
-  """ Reads from the local FS to get the RabbitMQ location to 
+  """ Reads from the local FS to get the RabbitMQ location to
       connect to.
 
   Returns:
     A string representing the location of RabbitMQ.
   """
-  rabbitmq_ip = file_io.read(RABBITMQ_LOCATION_FILE)
+  raw_ips = file_io.read(RABBITMQ_LOCATION_FILE)
+  ips = raw_ips.split('\n')
+  rabbitmq_ip = ips[0]
+
   return 'amqp://guest:guest@' + rabbitmq_ip + ':' + \
          str(RABBITMQ_PORT) + '//'

--- a/lib/appscale_info.py
+++ b/lib/appscale_info.py
@@ -52,7 +52,7 @@ def get_all_ips():
 def get_login_ip():
   """ Get the public IP of the head node. Since there can be more then one
   public IP for this deployment, we return the first one. NOTE: it can
-  change if nodes crashes.
+  change if node crashes.
 
   Returns:
     String containing the public IP of the head node.

--- a/lib/appscale_info.py
+++ b/lib/appscale_info.py
@@ -26,8 +26,9 @@ def read_file_contents(path):
 
 def get_appcontroller_client():
   """ Returns an AppControllerClient instance for this deployment. """
-  head_node_ip_file = '/etc/appscale/head_node_ip'
-  head_node = read_file_contents(head_node_ip_file).rstrip('\n')
+  raw_ips = file_io.read('/etc/appscale/load_balancer_ips')
+  ips = raw_ips.split('\n')
+  head_node = ips[0]
 
   secret_file = '/etc/appscale/secret.key'
   secret = read_file_contents(secret_file)

--- a/lib/appscale_info.py
+++ b/lib/appscale_info.py
@@ -49,12 +49,16 @@ def get_all_ips():
   return filter(None, nodes)
 
 def get_login_ip():
-  """ Get the public IP of the head node.
+  """ Get the public IP of the head node. Since there can be more then one
+  public IP for this deployment, we return the first one. NOTE: it can
+  change if nodes crashes.
 
   Returns:
     String containing the public IP of the head node.
   """
-  return file_io.read(constants.LOGIN_IP_LOC).rstrip()
+  raw_ips = file_io.read(constants.LOGIN_IP_LOC)
+  ips = raw_ips.split('\n')
+  return ips[0]
 
 def get_private_ip():
   """ Get the private IP of the current machine.


### PR DESCRIPTION
This PR puts the file we write for the various services into a single method (AC related). Quite a few services uses to write the address of their members (say the taskqueues nodes) into a file for the stubs to find. This PR avoid the blindly re-write of all of those files each duty cycle, but write them only upon changes.