### PR TITLE
Obtain entity group lock during commit

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
+++ b/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
@@ -1070,8 +1070,8 @@ class DatastoreProxy(AppDBInterface):
     insert = self.session.prepare("""
       INSERT INTO transactions (txid_hash, operation, namespace, path, entity)
       VALUES (?, ?, ?, ?, ?)
-      USING TTL 120
-    """)
+      USING TTL {ttl}
+    """.format(ttl=dbconstants.MAX_TX_DURATION * 2))
 
     for key in entity_keys:
       # The None value overwrites previous puts.

--- a/AppDB/appscale/datastore/cassandra_env/schema.py
+++ b/AppDB/appscale/datastore/cassandra_env/schema.py
@@ -104,6 +104,24 @@ def create_batch_tables(cluster, session):
     raise
 
 
+def create_groups_table(session):
+  create_table = """
+    CREATE TABLE IF NOT EXISTS group_updates (
+      group blob PRIMARY KEY,
+      last_update int
+    )
+  """
+  statement = SimpleStatement(create_table, retry_policy=NO_RETRIES)
+  try:
+    session.execute(statement)
+  except cassandra.OperationTimedOut:
+    logging.warning(
+      'Encountered an operation timeout while creating group_updates table. '
+      'Waiting 1 minute for schema to settle.')
+    time.sleep(60)
+    raise
+
+
 def create_transactions_table(session):
   """ Create the table used for storing transaction metadata.
 
@@ -201,6 +219,7 @@ def prime_cassandra(replication):
       raise
 
   create_batch_tables(cluster, session)
+  create_groups_table(session)
   create_transactions_table(session)
   create_pull_queue_tables(cluster, session)
 

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -3141,7 +3141,8 @@ class DatastoreDistributed():
       A long representing a unique transaction ID.
     """
     txid = self.zookeeper.get_transaction_id(app_id, is_xg)
-    self.datastore_batch.start_transaction(app_id, txid, is_xg)
+    in_progress = self.zookeeper.get_current_transactions(app_id)
+    self.datastore_batch.start_transaction(app_id, txid, is_xg, in_progress)
     return txid
 
   def enqueue_transactional_tasks(self, app, tasks):

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -27,6 +27,7 @@ from .utils import get_kind_key
 from .utils import group_for_key
 from .utils import reference_property_to_reference
 from .utils import UnprocessedQueryCursor
+from .zkappscale import entity_lock
 from .zkappscale import zktransaction
 
 sys.path.append(APPSCALE_PYTHON_APPSERVER)
@@ -511,25 +512,44 @@ class DatastoreDistributed():
     current_values = self.datastore_batch.batch_get_entity(
       dbconstants.APP_ENTITY_TABLE, entity_keys, APP_ENTITY_SCHEMA)
 
+    by_group = {}
     for entity in entities:
-      prefix = self.get_table_prefix(entity)
-      entity_key = get_entity_key(prefix, entity.key().path())
-      root_key = self.get_root_key_from_entity_key(entity_key)
-      txn = txn_hash[root_key]
+      group_key = group_for_key(entity.key()).Encode()
+      if group_key not in by_group:
+        by_group[group_key] = []
+      by_group[group_key].append(entity)
 
-      current_value = None
-      if current_values[entity_key]:
-        current_value = entity_pb.EntityProto(
-          current_values[entity_key][APP_ENTITY_SCHEMA[0]])
+    for encoded_group_key, entity_list in by_group.iteritems():
+      group_key = entity_pb.Reference(encoded_group_key)
+      lock = entity_lock.EntityLock(self.zookeeper.handle, [group_key])
 
-      batch = cassandra_interface.mutations_for_entity(
-        entity, txn, current_value, composite_indexes)
+      txid = self.zookeeper.get_transaction_id(app, False)
+      try:
+        with lock:
+          for entity in entity_list:
+            prefix = self.get_table_prefix(entity)
+            entity_key = get_entity_key(prefix, entity.key().path())
 
-      entity_change = {'key': entity.key(),
-                       'old': current_value, 'new': entity}
-      self.datastore_batch.batch_mutate(app, batch, [entity_change], txn)
+            current_value = None
+            if current_values[entity_key]:
+              current_value = entity_pb.EntityProto(
+                current_values[entity_key][APP_ENTITY_SCHEMA[0]])
 
-  def delete_entities(self, app, keys, txn_hash, composite_indexes=()):
+            batch = cassandra_interface.mutations_for_entity(
+              entity, txid, current_value, composite_indexes)
+
+            batch.append({'table': 'group_updates',
+                          'key': bytearray(encoded_group_key),
+                          'last_update': txid})
+
+            entity_change = {'key': entity.key(),
+                             'old': current_value, 'new': entity}
+            self.datastore_batch.batch_mutate(
+              app, batch, [entity_change], txid)
+      finally:
+        self.zookeeper.remove_tx_node(app, txid)
+
+  def delete_entities(self, group, txid, keys, composite_indexes=()):
     """ Deletes the entities and the indexes associated with them.
 
     Args:
@@ -550,9 +570,6 @@ class DatastoreDistributed():
     for key in entity_keys:
       if not current_values[key]:
         continue
-
-      root_key = self.get_root_key_from_entity_key(key)
-      txn = txn_hash[root_key]
 
       current_value = entity_pb.EntityProto(
         current_values[key][APP_ENTITY_SCHEMA[0]])
@@ -607,31 +624,15 @@ class DatastoreDistributed():
         root = entity.key().path().element(0)
         group.add_element().CopyFrom(root)
 
-    # This hash maps transaction IDs to root keys.
-    txn_hash = {}
-    try:
-      if put_request.has_transaction():
-        txn_hash = self.acquire_locks_for_trans(
-          entities, put_request.transaction().handle())
-        txid = put_request.transaction().handle()
-        self.datastore_batch.put_entities_tx(app_id, txid, entities)
-      else:
-        txn_hash = self.acquire_locks_for_nontrans(app_id, entities, 
-          retries=self.NON_TRANS_LOCK_RETRY_COUNT)
-        self.put_entities(app_id, entities, txn_hash,
-                          put_request.composite_index_list())
-        self.logger.debug('Updated {} entities'.format(len(entities)))
-        self.release_locks_for_nontrans(app_id, entities, txn_hash)
+    if put_request.has_transaction():
+      self.datastore_batch.put_entities_tx(
+        app_id, put_request.transaction().handle(), entities)
+    else:
+      self.put_entities(app_id, entities, '',
+                        put_request.composite_index_list())
+      self.logger.debug('Updated {} entities'.format(len(entities)))
 
-      put_response.key_list().extend([e.key() for e in entities])
-    except zktransaction.ZKTransactionException as zkte:
-      for root_key in txn_hash:
-        self.zookeeper.notify_failed_transaction(app_id, txn_hash[root_key])
-      raise zkte
-    except dbconstants.AppScaleDBConnectionError, dbce:
-      for root_key in txn_hash:
-        self.zookeeper.notify_failed_transaction(app_id, txn_hash[root_key])
-      raise dbce
+    put_response.key_list().extend([e.key() for e in entities])
 
   def get_root_key_from_entity_key(self, entity_key):
     """ Extract the root key from an entity key. We 
@@ -849,14 +850,6 @@ class DatastoreDistributed():
       self.logger.debug('Get: {} keys'.format(len(keys)))
 
     if get_request.has_transaction():
-      root_key = self.get_root_key_from_entity_key(keys[0])
-      txnid = get_request.transaction().handle()
-      try:
-        self.zookeeper.acquire_lock(app_id, txnid, root_key)
-      except zktransaction.ZKTransactionException as zkte:
-        self.logger.warning('Concurrent transaction: {}'.format(txnid))
-        self.zookeeper.notify_failed_transaction(app_id, txnid)
-        raise zkte
       results, row_keys = self.fetch_keys(keys)
       fetched_groups = {group_for_key(key).Encode() for key in keys}
       self.datastore_batch.record_reads(
@@ -866,7 +859,7 @@ class DatastoreDistributed():
 
     result_count = 0
     for r in row_keys:
-      group = get_response.add_entity() 
+      group = get_response.add_entity()
       if r in results and APP_ENTITY_SCHEMA[0] in results[r]:
         result_count += 1
         group.mutable_entity().CopyFrom(
@@ -890,13 +883,6 @@ class DatastoreDistributed():
       if last_path.type() not in ent_kinds:
         ent_kinds.append(last_path.type())
 
-    if delete_request.has_transaction():
-      txn_hash = self.acquire_locks_for_trans(keys, 
-        delete_request.transaction().handle())
-    else:
-      txn_hash = self.acquire_locks_for_nontrans(app_id, keys, 
-        retries=self.NON_TRANS_LOCK_RETRY_COUNT) 
-
     # We use the marked changes field to signify if we should 
     # look up composite indexes because delete request do not
     # include that information.
@@ -917,15 +903,31 @@ class DatastoreDistributed():
       txid = delete_request.transaction().handle()
       self.datastore_batch.delete_entities_tx(app_id, txid, keys)
     else:
-      self.delete_entities(
-        app_id,
-        keys,
-        txn_hash,
-        composite_indexes=filtered_indexes
-      )
-      self.logger.debug('Removed {} entities'.format(len(keys)))
-      self.release_locks_for_nontrans(app_id, keys, txn_hash)
- 
+      by_group = {}
+      for key in keys:
+        group_key = group_for_key(key).Encode()
+        if group_key not in by_group:
+          by_group[group_key] = []
+        by_group[group_key].append(key)
+
+      for encoded_group_key, key_list in by_group.iteritems():
+        group_key = entity_pb.Reference(encoded_group_key)
+        lock = entity_lock.EntityLock(
+          self.zookeeper.handle, [group_key])
+
+        txid = self.zookeeper.get_transaction_id(app_id, False)
+        try:
+          with lock:
+            self.delete_entities(
+              group_key,
+              txid,
+              key_list,
+              composite_indexes=filtered_indexes
+            )
+          self.logger.debug('Removed {} entities'.format(len(key_list)))
+        finally:
+          self.zookeeper.remove_tx_node(app_id, txid)
+
   def generate_filter_info(self, filters):
     """Transform a list of filters into a more usable form.
 
@@ -1221,15 +1223,6 @@ class DatastoreDistributed():
     txn_id = 0
     if query.has_transaction():
       txn_id = query.transaction().handle()   
-      root_key = self.get_root_key_from_entity_key(ancestor)
-      try:
-        prefix = self.get_table_prefix(query)
-        self.zookeeper.acquire_lock(clean_app_id(query.app()), txn_id, root_key)
-      except zktransaction.ZKTransactionException as zkte:
-        self.logger.warning('Concurrent transaction: {}'.format(txn_id))
-        self.zookeeper.notify_failed_transaction(clean_app_id(query.app()), 
-          txn_id)
-        raise zkte
 
     startrow = path
     endrow = path + self._TERM_STRING
@@ -1278,14 +1271,6 @@ class DatastoreDistributed():
     txn_id = 0
     if query.has_transaction(): 
       txn_id = query.transaction().handle()   
-      root_key = self.get_root_key_from_entity_key(ancestor)
-      try:
-        self.zookeeper.acquire_lock(clean_app_id(query.app()), txn_id, root_key)
-      except zktransaction.ZKTransactionException as zkte:
-        self.logger.warning('Concurrent transaction: {}'.format(txn_id))
-        self.zookeeper.notify_failed_transaction(clean_app_id(query.app()), 
-          txn_id)
-        raise zkte
 
     startrow = path
     endrow = path + self._TERM_STRING
@@ -3220,49 +3205,67 @@ class DatastoreDistributed():
     composite_indices = [entity_pb.CompositeIndex(index)
                          for index in self.datastore_batch.get_indices(app)]
 
-    # Fetch current values so we can remove old indices.
-    entity_table_keys = [encode_entity_table_key(key)
-                         for key, _ in metadata['puts'].iteritems()]
-    entity_table_keys.extend([encode_entity_table_key(key)
-                              for key in metadata['deletes']])
-    current_values = self.datastore_batch.batch_get_entity(
-      dbconstants.APP_ENTITY_TABLE, entity_table_keys, APP_ENTITY_SCHEMA)
+    # Give multi-group entity locks a transaction ID for deadlock resolution.
+    lock_id = None
+    if len(tx_groups) > 1:
+      lock_id = txn
+    decoded_groups = (entity_pb.Reference(group) for group in tx_groups)
+    lock = entity_lock.EntityLock(
+      self.zookeeper.handle, decoded_groups, lock_id)
 
-    batch = []
-    entity_changes = []
-    for encoded_key, encoded_entity in metadata['puts'].iteritems():
-      key = entity_pb.Reference(encoded_key)
-      entity_table_key = encode_entity_table_key(key)
-      current_value = None
-      if current_values[entity_table_key]:
+    with lock:
+      group_txids = self.datastore_batch.group_updates(metadata['reads'])
+      for group_txid in group_txids:
+        if group_txid in metadata['in_progress'] or group_txid > txn:
+          raise dbconstants.ConcurrentModificationException(
+            'A group was modified after this transaction was started.')
+
+      # Fetch current values so we can remove old indices.
+      entity_table_keys = [encode_entity_table_key(key)
+                           for key, _ in metadata['puts'].iteritems()]
+      entity_table_keys.extend([encode_entity_table_key(key)
+                                for key in metadata['deletes']])
+      current_values = self.datastore_batch.batch_get_entity(
+        dbconstants.APP_ENTITY_TABLE, entity_table_keys, APP_ENTITY_SCHEMA)
+
+      batch = []
+      entity_changes = []
+      for encoded_key, encoded_entity in metadata['puts'].iteritems():
+        key = entity_pb.Reference(encoded_key)
+        entity_table_key = encode_entity_table_key(key)
+        current_value = None
+        if current_values[entity_table_key]:
+          current_value = entity_pb.EntityProto(
+            current_values[entity_table_key][APP_ENTITY_SCHEMA[0]])
+
+        entity = entity_pb.EntityProto(encoded_entity)
+        mutations = cassandra_interface.mutations_for_entity(
+          entity, txn, current_value, composite_indices)
+        batch.extend(mutations)
+
+        entity_changes.append({'key': key, 'old': current_value,
+                               'new': entity})
+
+      for key in metadata['deletes']:
+        entity_table_key = encode_entity_table_key(key)
+        if not current_values[entity_table_key]:
+          continue
+
         current_value = entity_pb.EntityProto(
           current_values[entity_table_key][APP_ENTITY_SCHEMA[0]])
 
-      entity = entity_pb.EntityProto(encoded_entity)
-      mutations = cassandra_interface.mutations_for_entity(
-        entity, txn, current_value, composite_indices)
-      batch.extend(mutations)
+        deletions = cassandra_interface.deletions_for_entity(
+          current_value, composite_indices)
+        batch.extend(deletions)
 
-      entity_changes.append({'key': key, 'old': current_value, 'new': entity})
+        entity_changes.append({'key': key, 'old': current_value, 'new': None})
 
-    for key in metadata['deletes']:
-      entity_table_key = encode_entity_table_key(key)
-      if not current_values[entity_table_key]:
-        continue
-
-      current_value = entity_pb.EntityProto(
-        current_values[entity_table_key][APP_ENTITY_SCHEMA[0]])
-
-      deletions = cassandra_interface.deletions_for_entity(
-        current_value, composite_indices)
-      batch.extend(deletions)
-      entity_changes.append({'key': key, 'old': current_value, 'new': None})
       for group in groups_mutated:
         batch.append(
           {'table': 'group_updates', 'key': bytearray(group),
            'last_update': txn})
 
-    self.datastore_batch.batch_mutate(app, batch, entity_changes, txn)
+      self.datastore_batch.batch_mutate(app, batch, entity_changes, txn)
 
     # Process transactional tasks.
     if metadata['tasks']:
@@ -3291,29 +3294,18 @@ class DatastoreDistributed():
                             format(http_request_data))
       return (commitres_pb.Encode(), datastore_pb.Error.INTERNAL_ERROR,
               'Datastore connection error on Commit request.')
+    except dbconstants.ConcurrentModificationException as error:
+      return (commitres_pb.Encode(), datastore_pb.Error.CONCURRENT_TRANSACTION,
+              str(error))
+    except dbconstants.TooManyGroupsException as error:
+      return (commitres_pb.Encode(), datastore_pb.Error.BAD_REQUEST,
+              str(error))
+    except entity_lock.LockTimeout as error:
+      return (commitres_pb.Encode(), datastore_pb.Error.TIMEOUT,
+              str(error))
 
-    try:
-      self.zookeeper.release_lock(app_id, txn_id)
-      return (commitres_pb.Encode(), 0, "")
-    except zktransaction.ZKBadRequest as zkie:
-      self.logger.exception('Unable to commit transaction {} for {}'.
-        format(transaction_pb, app_id))
-      return (commitres_pb.Encode(),
-              datastore_pb.Error.BAD_REQUEST, 
-              "Illegal arguments for transaction. {0}".format(str(zkie)))
-    except zktransaction.ZKInternalException:
-      self.logger.exception('ZKInternalException during {} for {}'.
-        format(transaction_pb, app_id))
-      return (commitres_pb.Encode(),
-              datastore_pb.Error.INTERNAL_ERROR, 
-              "Internal error with ZooKeeper connection.")
-    except zktransaction.ZKTransactionException as zkte:
-      self.logger.exception('Concurrent transaction during {} for {}'.
-        format(transaction_pb, app_id))
-      self.zookeeper.notify_failed_transaction(app_id, txn_id)
-      return (commitres_pb.Encode(), 
-              datastore_pb.Error.PERMISSION_DENIED, 
-              "Unable to commit for this transaction {0}".format(zkte))
+    self.zookeeper.remove_tx_node(app_id, txn_id)
+    return commitres_pb.Encode(), 0, ""
 
   def rollback_transaction(self, app_id, http_request_data):
     """ Handles the rollback phase of a transaction.

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -553,9 +553,9 @@ class DatastoreDistributed():
     """ Deletes the entities and the indexes associated with them.
 
     Args:
-      app: A string containing the application ID.
-      keys: A list of keys to be deleted.
-      txn_hash: A mapping of root keys to transaction IDs.
+      group: An entity group Reference object.
+      txid: An integer specifying a transaction ID.
+      keys: An interable containing entity Reference objects.
       composite_indexes: A list or tuple of CompositeIndex objects.
     """
     entity_keys = []

--- a/AppDB/appscale/datastore/dbconstants.py
+++ b/AppDB/appscale/datastore/dbconstants.py
@@ -208,6 +208,10 @@ class AppScaleBadArg(Exception):
   def __str__(self):
     return repr(self.value)
 
+class ConcurrentModificationException(Exception):
+  """ Indicates that an entity fetched during a transaction has changed. """
+  pass
+
 class TooManyGroupsException(Exception):
   """ Indicates that there are too many groups involved in a transaction. """
   pass

--- a/AppDB/appscale/datastore/utils.py
+++ b/AppDB/appscale/datastore/utils.py
@@ -1,7 +1,6 @@
 import itertools
 import logging
 import mmh3
-import re
 import struct
 import sys
 import time
@@ -21,9 +20,6 @@ from google.appengine.datastore import appscale_stub_util
 from google.appengine.datastore import datastore_pb
 from google.appengine.datastore import entity_pb
 from google.appengine.datastore import sortable_pb_encoder
-
-# A regex that matches entity IDs that were likely generated automatically.
-PATH_ELEMENT_ID_RE = re.compile('^[0-9]{10}$')
 
 
 def clean_app_id(app_id):

--- a/AppDB/appscale/datastore/utils.py
+++ b/AppDB/appscale/datastore/utils.py
@@ -562,11 +562,17 @@ def group_for_key(key):
   """
   if not isinstance(key, entity_pb.Reference):
     key = entity_pb.Reference(key)
+
   first_element = key.path().element(0)
-  key.path().clear_element()
-  element = key.path().add_element()
+
+  # Avoid modifying the original object.
+  key_copy = entity_pb.Reference()
+  key_copy.CopyFrom(key)
+
+  key_copy.path().clear_element()
+  element = key_copy.path().add_element()
   element.MergeFrom(first_element)
-  return key
+  return key_copy
 
 
 def tx_partition(app, txid):

--- a/AppDB/appscale/datastore/zkappscale/entity_lock.py
+++ b/AppDB/appscale/datastore/zkappscale/entity_lock.py
@@ -17,7 +17,7 @@ from kazoo.retry import (
 # The ZooKeeper node that contains lock entries for an entity group.
 LOCK_PATH_TEMPLATE = '/appscale/apps/{project}/locks/{namespace}/{group}'
 
-# The number of seconds to wait before
+# The number of seconds to wait for a lock before raising a timeout error.
 LOCK_TIMEOUT = 10
 
 
@@ -97,7 +97,7 @@ class EntityLock(object):
     self.wake_event.set()
 
   def acquire(self):
-    """ Acquire the lock. By defaults blocks and waits forever.
+    """ Acquire the lock. By default blocks and waits forever.
 
     Returns:
       A boolean indicating whether or not the lock was acquired.

--- a/AppDB/appscale/datastore/zkappscale/entity_lock.py
+++ b/AppDB/appscale/datastore/zkappscale/entity_lock.py
@@ -1,0 +1,362 @@
+import uuid
+
+from kazoo.exceptions import (
+  CancelledError,
+  KazooException,
+  LockTimeout,
+  NoNodeError,
+  NotEmptyError
+)
+
+from kazoo.retry import (
+  ForceRetryError,
+  KazooRetry,
+  RetryFailedError
+)
+
+# The ZooKeeper node that contains lock entries for an entity group.
+LOCK_PATH_TEMPLATE = '/appscale/apps/{project}/locks/{namespace}/{group}'
+
+# The number of seconds to wait before
+LOCK_TIMEOUT = 10
+
+
+def zk_group_path(key):
+  """ Retrieve the ZooKeeper lock path for a given entity key.
+
+  Args:
+    key: An entity Reference object.
+  Returns:
+    A string containing the location of a ZooKeeper path.
+  """
+  project = key.app()
+  if key.name_space():
+    namespace = key.name_space()
+  else:
+    namespace = ':default'
+
+  first_element = key.path().element(0)
+  kind = first_element.type()
+
+  # Differentiate between types of identifiers.
+  if first_element.has_id():
+    suffix = ':{}'.format(first_element.id())
+  else:
+    suffix = '::{}'.format(first_element.name())
+
+  return LOCK_PATH_TEMPLATE.format(project=project, namespace=namespace,
+                                   group=kind + suffix)
+
+
+class EntityLock(object):
+  """ A ZooKeeper-based entity lock that allows test-and-set operations.
+
+  This is based on kazoo's lock recipe, and has been modified to lock multiple
+  entity groups. This lock is not re-entrant. Repeated calls after already
+  acquired will block.
+  """
+  _NODE_NAME = '__lock__'
+
+  def __init__(self, client, keys, txid=None):
+    """ Create an entity lock.
+
+    Args:
+      client: A kazoo client.
+      keys: A list of entity Reference objects.
+      txid: An integer specifying the transaction ID.
+    """
+    self.client = client
+    self.paths = [zk_group_path(key) for key in keys]
+
+    # The txid is written to the contender nodes for deadlock resolution.
+    self.data = str(txid or '')
+
+    self.wake_event = client.handler.event_object()
+
+    # Give the contender nodes a uniquely identifiable prefix in case its
+    # existence is in question.
+    self.prefix = uuid.uuid4().hex + self._NODE_NAME
+
+    self.create_paths = [path + '/' + self.prefix for path in self.paths]
+
+    self.create_tried = False
+    self.is_acquired = False
+    self.cancelled = False
+    self._retry = KazooRetry(max_tries=None,
+                             sleep_func=client.handler.sleep_func)
+    self._lock = client.handler.lock_object()
+
+  def _ensure_path(self):
+    """ Make sure the ZooKeeper lock paths have been created. """
+    for path in self.paths:
+      self.client.ensure_path(path)
+
+  def cancel(self):
+    """ Cancel a pending lock acquire. """
+    self.cancelled = True
+    self.wake_event.set()
+
+  def acquire(self):
+    """ Acquire the lock. By defaults blocks and waits forever.
+
+    Returns:
+      A boolean indicating whether or not the lock was acquired.
+    """
+
+    def _acquire_lock():
+      """ Acquire a kazoo thread lock. """
+      got_it = self._lock.acquire(False)
+      if not got_it:
+        raise ForceRetryError()
+      return True
+
+    retry = self._retry.copy()
+    retry.deadline = LOCK_TIMEOUT
+
+    # Prevent other threads from acquiring the lock at the same time.
+    locked = self._lock.acquire(False)
+    if not locked:
+      try:
+        retry(_acquire_lock)
+      except RetryFailedError:
+        return False
+
+    already_acquired = self.is_acquired
+    try:
+      gotten = False
+      try:
+        gotten = retry(self._inner_acquire)
+      except RetryFailedError:
+        if not already_acquired:
+          self._best_effort_cleanup()
+      except KazooException:
+        if not already_acquired:
+          self._best_effort_cleanup()
+          self.cancelled = False
+        raise
+      if gotten:
+        self.is_acquired = gotten
+      if not gotten and not already_acquired:
+        self._delete_nodes(self.nodes)
+      return gotten
+    finally:
+      self._lock.release()
+
+  def _watch_session(self, state):
+    """ A callback function for handling connection state changes.
+
+    Args:
+      state: The new connection state.
+    """
+    self.wake_event.set()
+    return True
+
+  def _resolve_deadlocks(self, children_list):
+    """ Check if there are any concurrent cross-group locks.
+
+    Args:
+      children_list: A list of current transactions for each group.
+    """
+    current_txid = int(self.data)
+    for index, children in enumerate(children_list):
+      our_index = children.index(self.nodes[index])
+
+      # Skip groups where this lock already has the earliest contender.
+      if our_index == 0:
+        continue
+
+      # Get transaction IDs for earlier contenders.
+      for child in children[:our_index - 1]:
+        try:
+          data, _ = self.client.get(
+            self.paths[index] + '/' + child)
+        except NoNodeError:
+          continue
+
+        # If data is not set, it doesn't belong to a cross-group
+        # transaction.
+        if not data:
+          continue
+
+        child_txid = int(data)
+        # As an arbitrary rule, require later transactions to
+        # resolve deadlocks.
+        if current_txid > child_txid:
+          # TODO: Implement a more graceful deadlock detection.
+          self.client.retry(self._delete_nodes(self.nodes))
+          raise ForceRetryError()
+
+  def _inner_acquire(self):
+    """ Create contender node(s) and wait until the lock is acquired. """
+
+    # Make sure the group lock node exists.
+    self._ensure_path()
+
+    nodes = [None for _ in self.paths]
+    if self.create_tried:
+      nodes = self._find_nodes()
+    else:
+      self.create_tried = True
+
+    for index, node in enumerate(nodes):
+      if node is not None:
+        continue
+
+      # The entity group lock root may have been deleted, so try a few times.
+      try_num = 0
+      while True:
+        try:
+          node = self.client.create(
+            self.create_paths[index], self.data, ephemeral=True,
+            sequence=True)
+          break
+        except NoNodeError:
+          self.client.ensure_path(self.paths[index])
+          if try_num > 3:
+            raise ForceRetryError()
+        try_num += 1
+
+      # Strip off path to node.
+      node = node[len(self.paths[index]) + 1:]
+      nodes[index] = node
+
+    self.nodes = nodes
+
+    while True:
+      self.wake_event.clear()
+
+      # Bail out with an exception if cancellation has been requested.
+      if self.cancelled:
+        raise CancelledError()
+
+      children_list = self._get_sorted_children()
+
+      predecessors = []
+      for index, children in enumerate(children_list):
+        try:
+          our_index = children.index(nodes[index])
+        except ValueError:
+          raise ForceRetryError()
+
+        # If the lock for this group hasn't been acquired, get the predecessor.
+        if our_index != 0:
+          predecessors.append(
+            self.paths[index] + "/" + children[our_index - 1])
+
+      if not predecessors:
+        return True
+
+      if len(nodes) > 1:
+        self._resolve_deadlocks(children_list)
+
+      # Wait for predecessor to be removed.
+      # TODO: Listen for all at the same time.
+      for index, predecessor in enumerate(predecessors):
+        self.client.add_listener(self._watch_session)
+        try:
+          if self.client.exists(predecessor, self._watch_predecessor):
+            self.wake_event.wait(LOCK_TIMEOUT)
+            if not self.wake_event.isSet():
+              error = 'Failed to acquire lock on {} after {} '\
+                'seconds'.format(self.paths, LOCK_TIMEOUT * (index + 1))
+              raise LockTimeout(error)
+        finally:
+          self.client.remove_listener(self._watch_session)
+
+  def _watch_predecessor(self, event):
+    """ A callback function for handling contender deletions.
+
+    Args:
+      event: A ZooKeeper event.
+    """
+    self.wake_event.set()
+
+  def _get_sorted_children(self):
+    """ Retrieve a list of sorted contenders for each group.
+
+    Returns:
+      A list of contenders for each group.
+    """
+    children = []
+    for path in self.paths:
+      try:
+        children.append(self.client.get_children(path))
+      except NoNodeError:
+        children.append([])
+
+    # Ignore lock path prefix when sorting contenders.
+    lockname = self._NODE_NAME
+    for child_list in children:
+      child_list.sort(key=lambda c: c[c.find(lockname) + len(lockname):])
+    return children
+
+  def _find_nodes(self):
+    """ Retrieve a list of paths this lock has created.
+
+    Returns:
+      A list of ZooKeeper paths.
+    """
+    nodes = []
+    for path in self.paths:
+      try:
+        children = self.client.get_children(path)
+      except NoNodeError:
+        children = []
+
+      node = None
+      for child in children:
+        if child.startswith(self.prefix):
+          node = child
+      nodes.append(node)
+    return nodes
+
+  def _delete_nodes(self, nodes):
+    """ Remove ZooKeeper nodes.
+
+    Args:
+      nodes: A list of nodes to delete.
+    """
+    for index, node in enumerate(nodes):
+      if node is None:
+        continue
+      self.client.delete(self.paths[index] + "/" + node)
+
+  def _best_effort_cleanup(self):
+    """ Attempt to delete nodes that this lock has created. """
+    try:
+      nodes = self._find_nodes()
+      self._delete_nodes(nodes)
+    except KazooException:
+      pass
+
+  def release(self):
+    """ Release the lock immediately. """
+    self.client.retry(self._inner_release)
+
+    # Try to clean up the group lock path.
+    for path in self.paths:
+      try:
+        self.client.delete(path)
+      except NotEmptyError:
+        pass
+    return
+
+  def _inner_release(self):
+    """ Release the lock by removing created nodes. """
+    if not self.is_acquired:
+      return False
+
+    try:
+      self._delete_nodes(self.nodes)
+    except NoNodeError:
+      pass
+
+    self.is_acquired = False
+    self.nodes = [None for _ in self.paths]
+    return True
+
+  def __enter__(self):
+    self.acquire()
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    self.release()

--- a/AppDB/appscale/datastore/zkappscale/zktransaction.py
+++ b/AppDB/appscale/datastore/zkappscale/zktransaction.py
@@ -16,9 +16,10 @@ from ..cassandra_env import cassandra_interface
 from ..dbconstants import (MAX_GROUPS_FOR_XG,
                            MAX_TX_DURATION)
 from ..unpackaged import APPSCALE_PYTHON_APPSERVER
-from kazoo.exceptions import NoNodeError
-from kazoo.exceptions import KazooException
-from kazoo.exceptions import ZookeeperError
+
+from kazoo.exceptions import (NoNodeError,
+                              KazooException,
+                              ZookeeperError)
 
 sys.path.append(APPSCALE_PYTHON_APPSERVER)
 from google.appengine.datastore import entity_pb

--- a/AppDB/appscale/datastore/zkappscale/zktransaction.py
+++ b/AppDB/appscale/datastore/zkappscale/zktransaction.py
@@ -1580,3 +1580,20 @@ class ZKTransaction:
         self.reestablish_connection()
         return 
     self.logger.debug('Lock GC took {} seconds.'.format(time.time() - start))
+
+  def get_current_transactions(self, project):
+    """ Fetch a list of open transactions for a given project.
+
+    Args:
+      project: A string containing a project ID.
+    Returns:
+      A list of integers specifying transaction IDs.
+    """
+    project_path = PATH_SEPARATOR.join([APPS_PATH, project])
+    txrootpath = PATH_SEPARATOR.join([project_path, APP_TX_PATH])
+    try:
+      txlist = self.run_with_retry(self.handle.get_children, txrootpath)
+    except kazoo.exceptions.NoNodeError:
+      # there is no transaction yet.
+      return []
+    return [int(txid.lstrip(APP_TX_PREFIX)) for txid in txlist]

--- a/AppDB/appscale/datastore/zkappscale/zktransaction.py
+++ b/AppDB/appscale/datastore/zkappscale/zktransaction.py
@@ -16,6 +16,7 @@ from ..cassandra_env import cassandra_interface
 from ..dbconstants import (MAX_GROUPS_FOR_XG,
                            MAX_TX_DURATION)
 from ..unpackaged import APPSCALE_PYTHON_APPSERVER
+from kazoo.exceptions import NoNodeError
 from kazoo.exceptions import KazooException
 from kazoo.exceptions import ZookeeperError
 
@@ -893,6 +894,20 @@ class ZKTransaction:
       self.reestablish_connection()
       raise ZKTransactionException("Couldn't get updated key list for appid " \
         "{0}, txid {1}".format(app_id, txid))
+
+  def remove_tx_node(self, app_id, txid):
+    """ Remove a transaction's sequence node.
+
+    Args:
+      app_id: A string specifying an application ID.
+      txid: An integer specifying a transaction ID.
+    """
+    txpath = self.get_transaction_path(app_id, txid)
+    try:
+      self.run_with_retry(self.handle.delete, txpath, -1, True)
+    except NoNodeError:
+      return
+
 
   def release_lock(self, app_id, txid):
     """ Releases all locks acquired during this transaction.


### PR DESCRIPTION
This avoids long-running locks obtained during the course of a transaction. It limits concurrency errors to commit operations.