### PR TITLE
Restart flower only when using set_property

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -934,10 +934,6 @@ class Djinn
     new_level = Logger::INFO
     new_level = Logger::DEBUG if @options['verbose'].downcase == "true"
     @@log.level = new_level if @@log.level != new_level
-
-    # Make sure flower is running with the proper password.
-    TaskQueue.stop_flower
-    TaskQueue.start_flower(@options['flower_password']) if my_node.is_shadow?
   end
 
   # This is the method needed to get the current layout and options for
@@ -1474,6 +1470,10 @@ class Djinn
         unless is_cloud?
           Djinn.log_warn("max_images is not used in non-cloud infrastructures.")
         end
+      end
+      if key == "flower_password"
+        TaskQueue.stop_flower
+        TaskQueue.start_flower(@options['flower_password']) if my_node.is_shadow?
       end
       if key == "replication"
         Djinn.log_warn("replication cannot be changed at runtime.")

--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -238,6 +238,11 @@ module TaskQueue
   # Args:
   #   flower_password: A String that is used as the password to log into flower.
   def self.start_flower(flower_password)
+    if flower_password.nil? || flower_password.empty?
+      Djinn.log_info("Flower password is empty: don't start flower.")
+      return
+    end
+
     flower_cmd = `which flower`.chomp
     start_cmd = "#{flower_cmd} --basic_auth=appscale:#{flower_password}"
     stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +


### PR DESCRIPTION
This is to prevent issues on slower cloud provision services.