### PR TITLE
Handle Java chunk size parameter

### DIFF
--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -126,7 +126,7 @@ class DatastoreDistributed():
     # zookeeper instance for accesing ZK functionality.
     self.zookeeper = zookeeper
 
-    # Maintain a stub object for each project using transactinal tasks.
+    # Maintain a stub object for each project using transactional tasks.
     self.taskqueue_stubs = {}
 
   def get_limit(self, query):

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -138,8 +138,12 @@ class DatastoreDistributed():
       An int, the limit to be used when accessing the datastore.
     """
     limit = self._MAXIMUM_RESULTS
+    if query.has_count():
+      limit = min(query.count(), self._MAXIMUM_RESULTS)
+
     if query.has_limit():
-      limit = min(query.limit(), self._MAXIMUM_RESULTS)
+      limit = min(query.limit(), limit)
+
     if query.has_offset():
       limit = limit + min(query.offset(), self._MAXIMUM_RESULTS)
     # We can not scan with 0 or less, hence we set it to one.

--- a/AppServer_Java/src/com/google/appengine/api/datastore/dev/LocalDatastoreService.java
+++ b/AppServer_Java/src/com/google/appengine/api/datastore/dev/LocalDatastoreService.java
@@ -1184,15 +1184,7 @@ public final class LocalDatastoreService extends AbstractLocalRpcService
             this.offset = offset;
 
             this.lastCursor.copyFrom(cursor);
-            if (query.hasCount()) {
-              this.totalCount = Integer.valueOf(this.query.getCount());
-              if (query.hasLimit()) {
-                  int limit = Integer.valueOf(this.query.getLimit());
-                  if (limit < this.totalCount)
-                    this.totalCount = limit;
-              }
-            }
-            else if (query.hasLimit()) {
+            if (query.hasLimit()) {
               this.totalCount = Integer.valueOf(this.query.getLimit());
             }
             else {


### PR DESCRIPTION
The Java datastore API allows the app to specify a chunk size when fetching results for a query. Previously, we were ignoring this parameter and always fetching all the results, which is not efficient when using an iterator.