### PR TITLE
Put /usr/local/bin first on the PATH

### DIFF
--- a/AppController/scripts/appcontroller
+++ b/AppController/scripts/appcontroller
@@ -18,7 +18,7 @@ DAEMON_USER=root
 PIDFILE=/var/run/$DAEMON_NAME.pid
 SECRET_FILE=/etc/appscale/secret.key
 LOG_FILE=/var/log/appscale/controller-17443.log
-PATH=$PATH:/usr/local/bin
+PATH=/usr/local/bin:$PATH
 . /lib/lsb/init-functions
 
 do_start()


### PR DESCRIPTION
This ensures that the controller uses the updated pip binary instead of the one that was installed by the package manager.