### PR TITLE
Don't check for file system changes

### DIFF
--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -580,7 +580,8 @@ def create_python27_start_cmd(app_name,
     "--datastore_path " + db_location + ":"\
       + str(constants.DB_SERVER_PORT),
     "/var/apps/" + app_name + "/app",
-    "--host " + appscale_info.get_private_ip()]
+    "--host " + appscale_info.get_private_ip(),
+    "--automatic_restart", "no"]
 
   if app_name in TRUSTED_APPS:
     cmd.extend([TRUSTED_FLAG])


### PR DESCRIPTION
This reduces the likelihood of AppServer errors when an application's directory is replaced during a gentle restart.