### PR TITLE
Use HelperFunctions.scp to copy app tarball

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -6016,7 +6016,7 @@ HOSTS
       tries = 3
       loop {
         Djinn.log_debug("Trying #{ip}:#{app_path} for the application.")
-        Djinn.log_run("scp -o StrictHostkeyChecking=no -i #{ssh_key} #{ip}:#{app_path} #{app_path}")
+        HelperFunctions.scp_file(app_path, app_path, ip, ssh_key, true)
         if File.exists?(app_path)
           Djinn.log_info("Got a copy of #{appname} from #{ip}.")
           return true

--- a/AppController/lib/helperfunctions.rb
+++ b/AppController/lib/helperfunctions.rb
@@ -440,7 +440,7 @@ module HelperFunctions
   # Returns:
   #   true  if the tarball is correct, false otherwise.
   def self.check_tarball(tar_gz_location)
-    cmd = "tar -ztf #{tar_gz_location}"
+    cmd = "tar -ztf #{tar_gz_location} > /dev/null 2> /dev/null"
     case system(cmd)
     when nil
       Djinn.log_warn("Couldn't execute #{cmd}!")


### PR DESCRIPTION
This PR modifies the scp helper funtion to be able to copy files from a
remote host, in order to use it to copy the tarball application.