### PR TITLE
Fix identifying search ip as an array instead of string

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4199,7 +4199,7 @@ class Djinn
       load_balancer_ips << node.private_ip if node.is_load_balancer?
       master_ips << node.private_ip if node.is_db_master?
       memcache_ips << node.private_ip if node.is_memcache?
-      search_ips = node.private_ip if node.is_search?
+      search_ips << node.private_ip if node.is_search?
       slave_ips << node.private_ip if node.is_db_slave?
       taskqueue_ips << node.private_ip if node.is_taskqueue_master? ||
         node.is_taskqueue_slave?


### PR DESCRIPTION
Search ip was identified as a string that caused that error
```
/root/appscale/AppController/djinn.rb:4216:in `write_locations': undefined method `join' for "192.168.103.250":String (NoMethodError)
        from /root/appscale/AppController/djinn.rb:2949:in `update_firewall'
        from /root/appscale/AppController/djinn.rb:2071:in `job_start'
        from /root/appscale/AppController/djinnServer.rb:168:in `<main>'
```