### PR TITLE
Don't retry delete entry from zookeeper

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2264,17 +2264,16 @@ class Djinn
       Djinn.log_warn("The #{appname} app was still found at #{location}.")
     end
 
-    RETRIES.downto(0) {
-      begin
-        ZKInterface.remove_app_entry(appname, my_node.private_ip)
-        return true
-      rescue FailedZooKeeperOperationException => except
-        Djinn.log_warn("not_hosting_app: got exception talking to " +
-          "zookeeper: #{except.message}.")
-      end
-      Kernel.sleep(SMALL_WAIT)
-    }
-    Djinn.log_warn("Failed to notify zookeeper this node doesn't host #{appname}.")
+    begin
+      ZKInterface.remove_app_entry(appname, my_node.private_ip)
+      return true
+    rescue FailedZooKeeperOperationException => except
+      # We just warn here and don't retry, since the shadow may have
+      # already cleaned up the hosters.
+      Djinn.log_warn("not_hosting_app: got exception talking to " +
+        "zookeeper: #{except.message}.")
+    end
+
     return false
   end
 


### PR DESCRIPTION
Since the headnode may have already cleared the app-hosters list in
zookeeper, there is no need to retry deleting this node from the
app-hosters.