### PR TITLE
Check to make sure $HOME is set to /root

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,6 +36,13 @@ if [ "$(id -u)" != "0" ]; then
 fi
 echo "Success"
 
+echo -n "Checking to make sure \$HOME is /root..."
+if [ "$HOME" != "/root" ]; then
+   echo "Failed"
+   exit 1
+fi
+echo "Success"
+
 set -e
 
 # Let's get the  command line arguments.


### PR DESCRIPTION
There are many places that directly reference files in /root. This makes sure that the appscale won't install if the user has a different `$HOME` set.

See https://github.com/AppScale/appscale/issues/2308.