### PR TITLE
Decrease gc_grace_seconds on ephemeral data

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/schema.py
+++ b/AppDB/appscale/datastore/cassandra_env/schema.py
@@ -143,7 +143,7 @@ def create_transactions_table(session):
       entity blob,
       task blob,
       PRIMARY KEY (txid_hash, operation, namespace, path)
-    )
+    ) WITH gc_grace_seconds = 120
   """
   statement = SimpleStatement(create_table, retry_policy=NO_RETRIES)
   try:

--- a/AppTaskQueue/appscale/taskqueue/distributed_tq.py
+++ b/AppTaskQueue/appscale/taskqueue/distributed_tq.py
@@ -88,7 +88,7 @@ def create_pull_queue_tables(cluster, session):
       tag text,
       tag_exists boolean,
       PRIMARY KEY ((app, queue, eta), id)
-    )
+    ) WITH gc_grace_seconds = 120
   """
   statement = SimpleStatement(create_index_table, retry_policy=NO_RETRIES)
   try:
@@ -122,7 +122,7 @@ def create_pull_queue_tables(cluster, session):
       queue text,
       leased timestamp,
       PRIMARY KEY ((app, queue, leased))
-    )
+    ) WITH gc_grace_seconds = 120
   """
   statement = SimpleStatement(create_leases_table, retry_policy=NO_RETRIES)
   try:


### PR DESCRIPTION
The downside of decreasing this value is that it's possible for data to be (unintentionally) undeleted if a node goes offline and the tombstones were not replicated.

For ephemeral tables like transactions and pull_queue_leases (used for stats), this downside is not relevant since all data is inserted with a TTL.

For pull_queue_tasks_index, undeleted index entries will not affect correctness, and it will barely affect performance.

The major benefit is reduced disk space usage (for the transactions table in particular) and increased performance for pull queue index lookups since tombstones will be deleted earlier.