### PR TITLE
Prevent multiple large batches for a transaction

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
+++ b/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
@@ -607,7 +607,10 @@ class DatastoreProxy(AppDBInterface):
       WHERE app = %(app)s AND transaction = %(transaction)s
     """
     parameters = {'app': app, 'transaction': txn}
-    self.session.execute(clear_batch, parameters)
+    try:
+      self.session.execute(clear_batch, parameters)
+    except dbconstants.TRANSIENT_CASSANDRA_ERRORS:
+      logging.exception('Unable to clear batch log')
 
   def batch_mutate(self, app, mutations, entity_changes, txn):
     """ Insert or delete multiple rows across tables in an atomic statement.

--- a/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
+++ b/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
@@ -580,7 +580,7 @@ class DatastoreProxy(AppDBInterface):
       execute_concurrent(self.session, statements_and_params,
                          raise_on_first_error=True)
     except dbconstants.TRANSIENT_CASSANDRA_ERRORS:
-      message = 'Exception during large batch'
+      message = 'Unable to write large batch log'
       logging.exception(message)
       raise AppScaleDBConnectionError(message)
 

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -506,8 +506,7 @@ class DatastoreDistributed():
       txn_hash: A mapping of root keys to transaction IDs.
       composite_indexes: A list or tuple of CompositeIndex objects.
     """
-    self.logger.debug('Inserting {} entities with transaction hash {}'.
-                      format(len(entities), txn_hash))
+    self.logger.debug('Inserting {} entities'.format(len(entities)))
     entity_keys = []
     for entity in entities:
       prefix = self.get_table_prefix(entity)
@@ -3298,8 +3297,7 @@ class DatastoreDistributed():
     except dbconstants.TxTimeoutException as timeout:
       return commitres_pb.Encode(), datastore_pb.Error.TIMEOUT, str(timeout)
     except dbconstants.AppScaleDBConnectionError:
-      self.logger.exception('DB connection error during {}'.
-                            format(http_request_data))
+      self.logger.exception('DB connection error during commit')
       return (commitres_pb.Encode(), datastore_pb.Error.INTERNAL_ERROR,
               'Datastore connection error on Commit request.')
     except dbconstants.ConcurrentModificationException as error:

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -496,14 +496,13 @@ class DatastoreDistributed():
 
     return prev + 1, current
 
-  def put_entities(self, app, entities, txn_hash, composite_indexes=()):
+  def put_entities(self, app, entities, composite_indexes=()):
     """ Updates indexes of existing entities, inserts new entities and 
         indexes for them.
 
     Args:
       app: A string containing the application ID.
       entities: List of entities.
-      txn_hash: A mapping of root keys to transaction IDs.
       composite_indexes: A list or tuple of CompositeIndex objects.
     """
     self.logger.debug('Inserting {} entities'.format(len(entities)))
@@ -631,8 +630,7 @@ class DatastoreDistributed():
       self.datastore_batch.put_entities_tx(
         app_id, put_request.transaction().handle(), entities)
     else:
-      self.put_entities(app_id, entities, '',
-                        put_request.composite_index_list())
+      self.put_entities(app_id, entities, put_request.composite_index_list())
       self.logger.debug('Updated {} entities'.format(len(entities)))
 
     put_response.key_list().extend([e.key() for e in entities])

--- a/AppDB/appscale/datastore/scripts/datastore.py
+++ b/AppDB/appscale/datastore/scripts/datastore.py
@@ -360,7 +360,7 @@ class MainHandler(tornado.web.RequestHandler):
               datastore_pb.Error.CONCURRENT_TRANSACTION, 
               "Concurrent transaction exception on put.")
     except dbconstants.AppScaleDBConnectionError:
-      logger.exception('DB connection error during {}'.format(query))
+      logger.exception('DB connection error during query')
       clone_qr_pb.set_more_results(False)
       return (clone_qr_pb.Encode(),
              datastore_pb.Error.INTERNAL_ERROR,
@@ -391,7 +391,7 @@ class MainHandler(tornado.web.RequestHandler):
       index_id = datastore_access.create_composite_index(app_id, request)
       response.set_value(index_id)
     except dbconstants.AppScaleDBConnectionError:
-      logger.exception('DB connection error during {}'.format(request))
+      logger.exception('DB connection error during index creation')
       response.set_value(0)
       return (response.Encode(),
               datastore_pb.Error.INTERNAL_ERROR,
@@ -456,7 +456,7 @@ class MainHandler(tornado.web.RequestHandler):
     try: 
       datastore_access.delete_composite_index_metadata(app_id, request)
     except dbconstants.AppScaleDBConnectionError:
-      logger.exception('DB connection error during {}'.format(request))
+      logger.exception('DB connection error during index deletion')
       return (response.Encode(),
               datastore_pb.Error.INTERNAL_ERROR,
               "Datastore connection error on delete index request.")
@@ -476,7 +476,7 @@ class MainHandler(tornado.web.RequestHandler):
     response = datastore_pb.CompositeIndices()
     try:
       indices = datastore_access.datastore_batch.get_indices(app_id)
-    except dbconstants.AppScaleDBConnectionError, dbce:
+    except dbconstants.AppScaleDBConnectionError:
       logger.exception('DB connection error while fetching indices for '
         '{}'.format(app_id))
       return (response.Encode(),
@@ -581,7 +581,7 @@ class MainHandler(tornado.web.RequestHandler):
               datastore_pb.Error.CONCURRENT_TRANSACTION, 
               "Concurrent transaction exception on put.")
     except dbconstants.AppScaleDBConnectionError:
-      logger.exception('DB connection error during {}'.format(putreq_pb))
+      logger.exception('DB connection error during put')
       return (putresp_pb.Encode(),
               datastore_pb.Error.INTERNAL_ERROR,
               "Datastore connection error on put.")
@@ -618,7 +618,7 @@ class MainHandler(tornado.web.RequestHandler):
               datastore_pb.Error.CONCURRENT_TRANSACTION, 
               "Concurrent transaction exception on get.")
     except dbconstants.AppScaleDBConnectionError:
-      logger.exception('DB connection error during {}'.format(getreq_pb))
+      logger.exception('DB connection error during get')
       return (getresp_pb.Encode(),
               datastore_pb.Error.INTERNAL_ERROR,
               "Datastore connection error on get.")
@@ -665,7 +665,7 @@ class MainHandler(tornado.web.RequestHandler):
               datastore_pb.Error.CONCURRENT_TRANSACTION, 
               "Concurrent transaction exception on delete.")
     except dbconstants.AppScaleDBConnectionError:
-      logger.exception('DB connection error during {}'.format(delreq_pb))
+      logger.exception('DB connection error during delete')
       return (delresp_pb.Encode(),
               datastore_pb.Error.INTERNAL_ERROR,
               "Datastore connection error on delete.")

--- a/AppDB/appscale/datastore/scripts/datastore.py
+++ b/AppDB/appscale/datastore/scripts/datastore.py
@@ -365,7 +365,7 @@ class MainHandler(tornado.web.RequestHandler):
       return (clone_qr_pb.Encode(),
              datastore_pb.Error.INTERNAL_ERROR,
              "Datastore connection error on run_query request.")
-    return (clone_qr_pb.Encode(), 0, "")
+    return clone_qr_pb.Encode(), 0, ""
 
   def create_index_request(self, app_id, http_request_data):
     """ High level function for creating composite indexes.
@@ -396,7 +396,7 @@ class MainHandler(tornado.web.RequestHandler):
       return (response.Encode(),
               datastore_pb.Error.INTERNAL_ERROR,
               "Datastore connection error on create index request.")
-    return (response.Encode(), 0, "")
+    return response.Encode(), 0, ""
 
   def update_index_request(self, app_id, http_request_data):
     """ High level function for updating a composite index.
@@ -460,7 +460,7 @@ class MainHandler(tornado.web.RequestHandler):
       return (response.Encode(),
               datastore_pb.Error.INTERNAL_ERROR,
               "Datastore connection error on delete index request.")
-    return (response.Encode(), 0, "")
+    return response.Encode(), 0, ""
     
   def get_indices_request(self, app_id):
     """ Gets the indices of the given application.
@@ -485,7 +485,7 @@ class MainHandler(tornado.web.RequestHandler):
     for index in indices:
       new_index = response.add_index()
       new_index.ParseFromString(index)
-    return (response.Encode(), 0, "")
+    return response.Encode(), 0, ""
 
   def allocate_ids_request(self, app_id, http_request_data):
     """ High level function for getting unique identifiers for entities.
@@ -539,7 +539,7 @@ class MainHandler(tornado.web.RequestHandler):
 
     response.set_start(start)
     response.set_end(end)
-    return (response.Encode(), 0, "")
+    return response.Encode(), 0, ""
 
   def put_request(self, app_id, http_request_data):
     """ High level function for doing puts.
@@ -623,7 +623,7 @@ class MainHandler(tornado.web.RequestHandler):
               datastore_pb.Error.INTERNAL_ERROR,
               "Datastore connection error on get.")
 
-    return (getresp_pb.Encode(), 0, "")
+    return getresp_pb.Encode(), 0, ""
 
   def delete_request(self, app_id, http_request_data):
     """ High level function for doing deletes.

--- a/AppDB/appscale/datastore/zkappscale/entity_lock.py
+++ b/AppDB/appscale/datastore/zkappscale/entity_lock.py
@@ -337,7 +337,7 @@ class EntityLock(object):
     for path in self.paths:
       try:
         self.client.delete(path)
-      except NotEmptyError:
+      except (NotEmptyError, NoNodeError):
         pass
     return
 

--- a/AppDB/appscale/datastore/zkappscale/zktransaction.py
+++ b/AppDB/appscale/datastore/zkappscale/zktransaction.py
@@ -24,6 +24,7 @@ from cassandra.policies import FallthroughRetryPolicy
 from kazoo.exceptions import (NoNodeError,
                               KazooException,
                               ZookeeperError)
+from kazoo.retry import RetryFailedError
 
 sys.path.append(APPSCALE_PYTHON_APPSERVER)
 from google.appengine.datastore import entity_pb
@@ -910,6 +911,9 @@ class ZKTransaction:
       self.run_with_retry(self.handle.delete, txpath, -1, True)
     except NoNodeError:
       return
+    except RetryFailedError:
+      raise ZKInternalException(
+        'Unable to remove transaction for {}'.format(txid))
 
 
   def release_lock(self, app_id, txid):

--- a/AppDB/test/unit/test_datastore_server.py
+++ b/AppDB/test/unit/test_datastore_server.py
@@ -378,14 +378,11 @@ class TestDatastoreServer(unittest.TestCase):
     db_batch.should_receive('batch_mutate')
     dd = DatastoreDistributed(db_batch, self.get_zookeeper())
 
-    # Make sure it does not throw an exception
-    txn_hash = {entity_key1: 1, entity_key2: 1}
-
     entity_lock = flexmock(EntityLock)
     entity_lock.should_receive('acquire')
     entity_lock.should_receive('release')
 
-    dd.put_entities(app_id, entity_list, txn_hash)
+    dd.put_entities(app_id, entity_list)
 
   def test_acquire_locks_for_trans(self):
     db_batch = flexmock()


### PR DESCRIPTION
Each transaction should be atomic.