### PR TITLE
Use RealRPC for API calls

### DIFF
--- a/AppServer/google/appengine/api/apiproxy_stub.py
+++ b/AppServer/google/appengine/api/apiproxy_stub.py
@@ -29,7 +29,7 @@
 from __future__ import with_statement
 
 
-import os
+
 import random
 import threading
 
@@ -84,7 +84,7 @@ class APIProxyStub(object):
     """
     return apiproxy_rpc.RealRPC(stub=self)
 
-  def MakeSyncCall(self, service, call, request, response, request_id=None, environ=None):
+  def MakeSyncCall(self, service, call, request, response, request_id=None):
     """The main RPC entry point.
 
     Args:
@@ -96,9 +96,6 @@ class APIProxyStub(object):
       request_id: A unique string identifying the request associated with the
           API call.
     """
-    if environ and service == 'urlfetch' and call == 'Fetch':
-      os.environ.update(environ)
-
     assert service == self.__service_name, ('Expected "%s" service name, '
                                             'was "%s"' % (self.__service_name,
                                                           service))

--- a/AppServer/google/appengine/api/urlfetch_stub.py
+++ b/AppServer/google/appengine/api/urlfetch_stub.py
@@ -420,11 +420,21 @@ class URLFetchServiceStub(apiproxy_stub.APIProxyStub):
           if not _CONNECTION_SUPPORTS_TIMEOUT:
             socket.setdefaulttimeout(orig_timeout)
           connection.close()
-      except (_fancy_urllib_InvalidCertException,
-              _fancy_urllib_SSLError), e:
+      except _fancy_urllib_InvalidCertException, e:
         raise apiproxy_errors.ApplicationError(
           urlfetch_service_pb.URLFetchServiceError.SSL_CERTIFICATE_ERROR,
           str(e))
+      except _fancy_urllib_SSLError, e:
+
+
+
+
+
+        app_error = (
+            urlfetch_service_pb.URLFetchServiceError.DEADLINE_EXCEEDED
+            if 'timed out' in e.message else
+            urlfetch_service_pb.URLFetchServiceError.SSL_CERTIFICATE_ERROR)
+        raise apiproxy_errors.ApplicationError(app_error, str(e))
       except socket.timeout, e:
         raise apiproxy_errors.ApplicationError(
           urlfetch_service_pb.URLFetchServiceError.DEADLINE_EXCEEDED, str(e))

--- a/AppServer/google/appengine/ext/remote_api/remote_api_stub.py
+++ b/AppServer/google/appengine/ext/remote_api/remote_api_stub.py
@@ -92,7 +92,7 @@ else:
   from google.appengine.runtime import apiproxy_errors
 
 from google.appengine.tools import appengine_rpc
-from google.appengine.api.urlfetch_stub import URLFetchServiceStub
+
 
 _REQUEST_ID_HEADER = 'HTTP_X_APPENGINE_REQUEST_ID'
 
@@ -239,7 +239,7 @@ class RemoteStub(object):
       response.ParseFromString(response_pb.response())
 
   def CreateRPC(self):
-    return apiproxy_rpc.RPC(stub=self)
+    return apiproxy_rpc.RealRPC(stub=self)
 
 
 class RemoteDatastoreStub(RemoteStub):
@@ -596,10 +596,6 @@ def ConfigureRemoteApiFromServer(server, path, app_id, services=None,
     services.remove('datastore_v3')
     datastore_stub = RemoteDatastoreStub(server, path)
     apiproxy_stub_map.apiproxy.RegisterStub('datastore_v3', datastore_stub)
-  if 'urlfetch' in services:
-    services.remove('urlfetch')
-    stub = URLFetchServiceStub()
-    apiproxy_stub_map.apiproxy.RegisterStub('urlfetch', stub)
   stub = RemoteStub(server, path)
   for service in services:
     apiproxy_stub_map.apiproxy.RegisterStub(service, stub)

--- a/AppServer/google/appengine/ext/remote_api/remote_api_stub.py
+++ b/AppServer/google/appengine/ext/remote_api/remote_api_stub.py
@@ -204,7 +204,10 @@ class RemoteStub(object):
   @classmethod
   def _GetRequestId(cls):
     """Returns the id of the request associated with the current thread."""
-    return cls._local.request_id
+    try:
+      return cls._local.request_id
+    except AttributeError:
+      return None
 
   @classmethod
   def _SetRequestId(cls, request_id):


### PR DESCRIPTION
This fixes error handling for the urlfetch API.