### PR TITLE
Don't log info-level message after successful call

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1860,7 +1860,12 @@ class Djinn
       tqc = TaskQueueClient.new(my_node.private_ip)
       begin
         result = tqc.reload_worker(app)
-        Djinn.log_info("Checking TaskQueue worker for app #{app}: #{result}")
+        message = "Checking TaskQueue worker for app #{app}: #{result}"
+        if result.key?('error') && result['error'] == false
+          Djinn.log_debug(message)
+        else
+          Djinn.log_warn(message)
+        end
       rescue FailedNodeException
         Djinn.log_warn("Failed to reload TaskQueue workers for app #{app}")
       end


### PR DESCRIPTION
When not in verbose mode, this message dominates the controller log.