### PR TITLE
Reduce taskqueue multiplier

### DIFF
--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -67,7 +67,7 @@ module TaskQueue
   OPTIONAL_FEATURES = ['celery_gui']
 
   # TaskQueue server processes per core.
-  MULTIPLIER = 4
+  MULTIPLIER = 2
 
   # If we fail to get the number of processors we set our default number of
   # taskqueue servers to this value.


### PR DESCRIPTION
This gives single-node deployments more memory to work with.