### PR TITLE
Use client-defined value when allocating IDs

### DIFF
--- a/AppDB/appscale/datastore/zkappscale/inspectable_counter.py
+++ b/AppDB/appscale/datastore/zkappscale/inspectable_counter.py
@@ -1,0 +1,98 @@
+""" A ZooKeeper counter that returns the new value when incremented. """
+
+from kazoo.exceptions import BadVersionError
+from kazoo.retry import ForceRetryError
+
+
+class InspectableCounter(object):
+  """ A ZooKeeper counter that returns the new value when incremented.
+
+  This is based off the Kazoo Counter recipe.
+  """
+  def __init__(self, client, path, default=0):
+    """ Create an InspectableCounter.
+
+    Args:
+      client: A KazooClient object.
+      path: A string containing the ZooKeeper path to use for the counter.
+      default: An integer containing the default counter value.
+    """
+    self.client = client
+    self.path = path
+    self.default = default
+    self.default_type = type(default)
+    self._ensured_path = False
+
+  def _ensure_node(self):
+    """ Make sure the ZooKeeper path that stores the counter value exists. """
+    if not self._ensured_path:
+      self.client.ensure_path(self.path)
+      self._ensured_path = True
+
+  def _value(self):
+    """ Retrieve the current value and node version from ZooKeeper.
+
+    Returns:
+      A tuple consisting of the current count and node version.
+    """
+    self._ensure_node()
+    old, stat = self.client.get(self.path)
+    old = old.decode('ascii') if old != b'' else self.default
+    version = stat.version
+    data = self.default_type(old)
+    return data, version
+
+  @property
+  def value(self):
+    """ Retrive the current value from ZooKeeper.
+
+    Returns:
+      An integer containing the current count.
+    """
+    return self._value()[0]
+
+  def _change(self, value):
+    """ Add a value to the counter.
+
+    Args:
+      value: An integer specifying how much to add.
+    Returns:
+      An integer indicating the new count after the change.
+    """
+    if not isinstance(value, self.default_type):
+      raise TypeError('Invalid type for value change')
+
+    return self.client.retry(self._inner_change, value)
+
+  def _inner_change(self, value):
+    """ Add a value to the counter.
+
+    Args:
+      value: An integer specifying how much to add.
+    Returns:
+      An integer indicating the new count after the change.
+    """
+    data, version = self._value()
+    new_value = data + value
+    new_data = repr(new_value).encode('ascii')
+    try:
+      self.client.set(self.path, new_data, version=version)
+      return new_value
+    except BadVersionError:
+      raise ForceRetryError()
+
+  def __add__(self, value):
+    """ Add value to counter.
+
+    Returns:
+      An integer indicating the new count after the change.
+    """
+    return self._change(value)
+
+  def __sub__(self, value):
+    """ Subtract value from counter.
+
+    Returns:
+      An integer indicating the new count after the change.
+    """
+    return self._change(-value)

--- a/AppDB/appscale/datastore/zkappscale/inspectable_counter.py
+++ b/AppDB/appscale/datastore/zkappscale/inspectable_counter.py
@@ -44,7 +44,7 @@ class InspectableCounter(object):
 
   @property
   def value(self):
-    """ Retrive the current value from ZooKeeper.
+    """ Retrieve the current value from ZooKeeper.
 
     Returns:
       An integer containing the current count.

--- a/AppDB/appscale/datastore/zkappscale/zktransaction.py
+++ b/AppDB/appscale/datastore/zkappscale/zktransaction.py
@@ -12,6 +12,7 @@ import threading
 import time
 import urllib
 
+from .inspectable_counter import InspectableCounter
 from ..cassandra_env import cassandra_interface
 from ..cassandra_env.large_batch import (FailedBatch,
                                          LargeBatch)
@@ -253,11 +254,10 @@ class ZKTransaction:
       if path in self.__counter_cache:
         counter = self.__counter_cache[path]
       else:
-        counter = self.handle.Counter(path)
+        counter = InspectableCounter(self.handle, path)
         self.__counter_cache[path] = counter
 
-      counter.__add__(value) 
-      new_value = counter.value
+      new_value = counter + value
       return new_value - value, new_value
     except kazoo.exceptions.ZookeeperError as zoo_exception:
       self.logger.exception(zoo_exception)

--- a/AppDB/appscale/datastore/zkappscale/zktransaction.py
+++ b/AppDB/appscale/datastore/zkappscale/zktransaction.py
@@ -243,30 +243,19 @@ class ZKTransaction:
     if self.needs_connection or not self.handle.connected:
       self.reestablish_connection()
 
-    def clear_counter_from_cache():
-      """ Deletes a counter from the cache due to an exception being raised.
-      """
-      if path in self.__counter_cache:
-        del self.__counter_cache[path]
+    if path not in self.__counter_cache:
+      self.__counter_cache[path] = InspectableCounter(self.handle, path)
 
-    try: 
-      counter = None
-      if path in self.__counter_cache:
-        counter = self.__counter_cache[path]
-      else:
-        counter = InspectableCounter(self.handle, path)
-        self.__counter_cache[path] = counter
-
+    counter = self.__counter_cache[path]
+    try:
       new_value = counter + value
       return new_value - value, new_value
     except kazoo.exceptions.ZookeeperError as zoo_exception:
       self.logger.exception(zoo_exception)
-      clear_counter_from_cache()
       raise ZKTransactionException("Couldn't increment path {0} by value {1}" \
         .format(path, value))
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      clear_counter_from_cache()
       raise ZKTransactionException(
         "Couldn't increment path {0} with value {1}" \
         .format(path, value))

--- a/AppDB/test/unit/test_zookeeper.py
+++ b/AppDB/test/unit/test_zookeeper.py
@@ -11,6 +11,8 @@ import unittest
 from appscale.datastore.dbconstants import MAX_GROUPS_FOR_XG
 from appscale.datastore.zkappscale import zktransaction as zk
 from appscale.datastore.zkappscale.zktransaction import ZKTransactionException
+from appscale.datastore.zkappscale.inspectable_counter import \
+  InspectableCounter
 from flexmock import flexmock
 
 
@@ -34,11 +36,7 @@ class TestZookeeperTransaction(unittest.TestCase):
     fake_zookeeper.should_receive('start')
     fake_zookeeper.should_receive('retry').and_return(None)
 
-    fake_counter = flexmock(name='fake_counter', value='value')
-    fake_counter.value = 1
-    fake_counter.should_receive('__add__').and_return(2)
-    fake_zookeeper.should_receive("Counter").and_return(fake_counter)
-    # mock out deleting the zero id we get the first time around
+    flexmock(InspectableCounter).should_receive('__add__').and_return(1)
 
     flexmock(kazoo.client)
     kazoo.client.should_receive('KazooClient').and_return(fake_zookeeper)


### PR DESCRIPTION
Previously, we had a check-and-set problem where we would first modify the counter and then make another call to ZooKeeper to retrieve the (now possibly changed) value to use for an ID.