### PR TITLE
AppServer restarts after new code is deployed

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1492,9 +1492,11 @@ class Djinn
       # We give some extra information to the user about some properties.
       if key == "keyname"
         Djinn.log_warn("Changing keyname can break your deployment!")
-      elsif key == "max_memory"
+      end
+      if key == "max_memory"
         Djinn.log_warn("max_memory will be enforced on new AppServers only.")
-      elsif key == "min_images"
+      end
+      if key == "min_images"
         unless is_cloud?
           Djinn.log_warn("min_images is not used in non-cloud infrastructures.")
         end
@@ -1502,7 +1504,8 @@ class Djinn
           Djinn.log_warn("Invalid input: cannot lower min_images!")
           return "min_images cannot be less than the nodes defined in ips_layout"
         end
-      elsif key == "max_images"
+      end
+      if key == "max_images"
         unless is_cloud?
           Djinn.log_warn("max_images is not used in non-cloud infrastructures.")
         end
@@ -1510,18 +1513,14 @@ class Djinn
           Djinn.log_warn("Invalid input: max_images is smaller than min_images!")
           return "max_images is smaller than min_images."
         end
-      elsif key == "flower_password"
+      end
+      if key == "flower_password"
         TaskQueue.stop_flower
         TaskQueue.start_flower(@options['flower_password'])
-      elsif key == "replication"
+      end
+      if key == "replication"
         Djinn.log_warn("replication cannot be changed at runtime.")
         next
-      elsif key == "login"
-        Djinn.log_info("Restarting applications since public IP changed.")
-        @apps_loaded.each { |appid|
-          notify_restart_app_to_nodes(appid)
-        }
-
       end
       @options[key] = val
       Djinn.log_info("Successfully set #{key} to #{val}.")

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1492,11 +1492,9 @@ class Djinn
       # We give some extra information to the user about some properties.
       if key == "keyname"
         Djinn.log_warn("Changing keyname can break your deployment!")
-      end
-      if key == "max_memory"
+      elsif key == "max_memory"
         Djinn.log_warn("max_memory will be enforced on new AppServers only.")
-      end
-      if key == "min_images"
+      elsif key == "min_images"
         unless is_cloud?
           Djinn.log_warn("min_images is not used in non-cloud infrastructures.")
         end
@@ -1504,8 +1502,7 @@ class Djinn
           Djinn.log_warn("Invalid input: cannot lower min_images!")
           return "min_images cannot be less than the nodes defined in ips_layout"
         end
-      end
-      if key == "max_images"
+      elsif key == "max_images"
         unless is_cloud?
           Djinn.log_warn("max_images is not used in non-cloud infrastructures.")
         end
@@ -1513,14 +1510,18 @@ class Djinn
           Djinn.log_warn("Invalid input: max_images is smaller than min_images!")
           return "max_images is smaller than min_images."
         end
-      end
-      if key == "flower_password"
+      elsif key == "flower_password"
         TaskQueue.stop_flower
         TaskQueue.start_flower(@options['flower_password'])
-      end
-      if key == "replication"
+      elsif key == "replication"
         Djinn.log_warn("replication cannot be changed at runtime.")
         next
+      elsif key == "login"
+        Djinn.log_info("Restarting applications since public IP changed.")
+        @apps_loaded.each { |appid|
+          notify_restart_app_to_nodes(appid)
+        }
+
       end
       @options[key] = val
       Djinn.log_info("Successfully set #{key} to #{val}.")

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -700,22 +700,20 @@ class Djinn
     port_file = "#{APPSCALE_CONFIG_DIR}/port-#{appid}.txt"
     HelperFunctions.write_file(port_file, http_port)
 
-    Thread.new {
-      # Notify the UAServer about the new ports.
-      uac = UserAppClient.new(my_node.private_ip, @@secret)
-      success = uac.add_instance(appid, my_public, http_port, https_port)
-      unless success
-        Djinn.log_warn("Failed to store relocation ports for #{appid} via the uaserver.")
-        return
-      end
+    # Notify the UAServer about the new ports.
+    uac = UserAppClient.new(my_node.private_ip, @@secret)
+    success = uac.add_instance(appid, my_public, http_port, https_port)
+    unless success
+      Djinn.log_warn("Failed to store relocation ports for #{appid} via the uaserver.")
+      return
+    end
 
-      # Notify nodes, and remove any running AppServer of the application.
-      notify_restart_app_to_nodes([appid])
+    # Notify nodes, and remove any running AppServer of the application.
+    notify_restart_app_to_nodes([appid])
 
-      # Once we've relocated the app, we need to tell the XMPPReceiver about the
-      # app's new location.
-      MonitInterface.restart("xmpp-#{appid}")
-    }
+    # Once we've relocated the app, we need to tell the XMPPReceiver about the
+    # app's new location.
+    MonitInterface.restart("xmpp-#{appid}")
 
     return "OK"
   end
@@ -746,7 +744,7 @@ class Djinn
     if my_node.is_shadow? and stop_deployment
       Djinn.log_info("Stopping all other nodes.")
       # Let's stop all other nodes.
-      threads << Thread.new {
+      Thread.new {
         @nodes.each { |node|
           if node.private_ip != my_node.private_ip
             acc = AppControllerClient.new(ip, @@secret)
@@ -1875,26 +1873,30 @@ class Djinn
   def notify_restart_app_to_nodes(apps_to_restart)
     return if apps_to_restart.empty?
 
-    Djinn.log_info("Remove old AppServers for #{apps_to_restart}.")
-    APPS_LOCK.synchronize {
-      apps_to_restart.each{ |app|
-        @app_info_map[app]['appengine'].clear
-      }
-    }
-
     Djinn.log_info("Notify nodes to restart #{apps_to_restart}.")
+    threads = []
     @nodes.each_index { |index|
       result = ""
       ip = @nodes[index].private_ip
       next if my_node.private_ip == ip
 
-      acc = AppControllerClient.new(ip, @@secret)
-      begin
-        result = acc.set_apps_to_restart(apps_to_restart)
-      rescue FailedNodeException
-        Djinn.log_warn("Couldn't tell #{ip} to restart #{apps_to_restart}.")
-      end
-      Djinn.log_debug("Set apps to restart at #{ip} returned #{result}.")
+      threads << Thread.new {
+        acc = AppControllerClient.new(ip, @@secret)
+        begin
+          result = acc.set_apps_to_restart(apps_to_restart)
+        rescue FailedNodeException
+          Djinn.log_warn("Couldn't tell #{ip} to restart #{apps_to_restart}.")
+        end
+        Djinn.log_debug("Set apps to restart at #{ip} returned #{result}.")
+      }
+    }
+    threads.each { |t| t.join }
+
+    Djinn.log_info("Remove old AppServers for #{apps_to_restart}.")
+    APPS_LOCK.synchronize {
+      apps_to_restart.each{ |app|
+        @app_info_map[app]['appengine'].clear
+      }
     }
   end
 


### PR DESCRIPTION
This PR fixes a race condition where AppServers could have been
restarted before the new code was deployed on each App Engine node.