### PR TITLE
Use Kazoo's native reconnect policy

### DIFF
--- a/AppDB/appscale/datastore/zkappscale/zktransaction.py
+++ b/AppDB/appscale/datastore/zkappscale/zktransaction.py
@@ -141,17 +141,9 @@ class ZKTransaction:
   (e.g., releasing locks, keeping track of transaction metadata).
   """
 
-  # The number of times we should retry ZooKeeper operations, by default.
-  DEFAULT_NUM_RETRIES = 0
-
   # How long to wait before retrying an operation.
   ZK_RETRY_TIME = .5
 
-  # The number of seconds to wait before we consider a zk call a failure.
-  DEFAULT_ZK_TIMEOUT = 3
-
-  # When we have this many failures trying to connect to ZK, abort execution.
-  MAX_CONNECTION_FAILURES = 10 
   # The maximum number of seconds to wait before retrying to connect.
   MAX_RECONNECT_DELAY = 30
 
@@ -176,18 +168,11 @@ class ZKTransaction:
     self.logger.info('Starting {}'.format(class_name))
 
     # Connection instance variables.
-    self.needs_connection = True
-    self.failure_count = 0
     self.host = host
     self.handle = kazoo.client.KazooClient(hosts=host,
                                            connection_retry=reconnect_policy)
     self.run_with_retry = self.handle.retry
-    try:
-      self.handle.start()
-      self.needs_connection = False
-    except kazoo.exceptions.KazooException as kazoo_exception:
-      self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
+    self.handle.start()
 
     self.__counter_cache = {}
 
@@ -246,9 +231,6 @@ class ZKTransaction:
     Raises:
       ZKTransactionException: If it could not increment the counter.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     if path not in self.__counter_cache:
       self.__counter_cache[path] = InspectableCounter(self.handle, path)
 
@@ -278,9 +260,6 @@ class ZKTransaction:
     Raises:
       ZKInternalException: If there was an error trying to fetch the node.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     try:
       return self.run_with_retry(self.handle.get, path)
     except kazoo.exceptions.NoNodeError:
@@ -312,25 +291,13 @@ class ZKTransaction:
       value: A str representing the value that should be associated with the
         updated node.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     self.logger.debug(
       'Updating node at {}, with new value {}'.format(path, value))
     try:
       self.run_with_retry(self.handle.set, path, str(value))
     except kazoo.exceptions.NoNodeError:
-      try:
-        self.run_with_retry(self.handle.create, path, str(value), ZOO_ACL_OPEN,
-          makepath=True)
-      except kazoo.exceptions.KazooException as kazoo_exception:
-        self.logger.exception(kazoo_exception)
-        self.reestablish_connection()
-    except kazoo.exceptions.ZookeeperError as zoo_exception:
-      self.logger.exception(zoo_exception)
-    except kazoo.exceptions.KazooException as kazoo_exception:
-      self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
+      self.run_with_retry(self.handle.create, path, str(value), ZOO_ACL_OPEN,
+                          makepath=True)
 
   def delete_recursive(self, path):
     """ Deletes the ZooKeeper node at path, and any child nodes it may have.
@@ -338,9 +305,6 @@ class ZKTransaction:
     Args:
       path: A PATH_SEPARATOR-separated str that represents the node to delete.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     try:
       children = self.run_with_retry(self.handle.get_children, path)
       for child in children:
@@ -348,9 +312,6 @@ class ZKTransaction:
       self.run_with_retry(self.handle.delete, path)
     except kazoo.exceptions.NoNodeError:
       pass
-    except kazoo.exceptions.KazooException as kazoo_exception:
-      self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
 
   def dump_tree(self, path):
     """ Prints information about the given ZooKeeper node and its children.
@@ -367,9 +328,6 @@ class ZKTransaction:
         self.dump_tree(PATH_SEPARATOR.join([path, child]))
     except kazoo.exceptions.NoNodeError:
       self.logger.info("{0} does not exist.".format(path))
-    except kazoo.exceptions.KazooException as kazoo_exception:
-      self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
 
   def get_app_root_path(self, app_id):
     """ Returns the ZooKeeper path that holds all information for the given
@@ -514,15 +472,11 @@ class ZKTransaction:
     Raises:
       ZKTransactionException: If the sequence node couldn't be created.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     try:
       self.run_with_retry(self.handle.create, path, value=str(value), 
         acl=ZOO_ACL_OPEN, ephemeral=False, sequence=False, makepath=True)
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       raise ZKTransactionException("Couldn't create path {0} with value {1} " \
         .format(path, value))
 
@@ -542,9 +496,6 @@ class ZKTransaction:
     Raises:
       ZKTransactionException: If the sequence node couldn't be created.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     try:
       txn_id_path = self.run_with_retry(self.handle.create, path, 
         value=str(value), acl=ZOO_ACL_OPEN, ephemeral=False, sequence=True,
@@ -564,11 +515,9 @@ class ZKTransaction:
           return txn_id
     except kazoo.exceptions.ZookeeperError as zoo_exception:
       self.logger.exception(zoo_exception)
-      self.reestablish_connection()
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
-      
+
     raise ZKTransactionException("Unable to create sequence node with path" \
       " {0}, value {1}".format(path, value))
 
@@ -586,9 +535,6 @@ class ZKTransaction:
     Returns:
       A long that represents the new transaction ID.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     timestamp = str(time.time())
 
     # First, make the ZK node for the actual transaction id.
@@ -614,16 +560,12 @@ class ZKTransaction:
       ZKTransactionException: If the transaction is not in progress, or it
         has timed out.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     txpath = self.get_transaction_path(app_id, txid)
     try:
       if self.is_blacklisted(app_id, txid):
         raise ZKTransactionException("Transaction {0} timed out.".format(txid))
     except ZKInternalException as zk_exception:
       self.logger.exception(zk_exception)
-      self.reestablish_connection()
       raise ZKTransactionException("Couldn't see if transaction {0} is valid" \
         .format(txid))
 
@@ -635,7 +577,6 @@ class ZKTransaction:
       return True
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       raise ZKTransactionException(
         'Unable to determine status of transaction {}'.format(txid))
 
@@ -653,9 +594,6 @@ class ZKTransaction:
       ZKInternalException: If there was an error seeing if the transaction was
         blacklisted.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     tx_lock_path = self.get_transaction_lock_list_path(app_id, txid)
     if self.is_blacklisted(app_id, txid):
       raise ZKTransactionException(
@@ -673,7 +611,6 @@ class ZKTransaction:
         time.sleep(self.ZK_RETRY_TIME)
         return self.is_in_transaction(app_id=app_id, txid=txid,
           retries=retries - 1)
-      self.reestablish_connection()
       raise ZKInternalException("Couldn't see if we are in transaction {0}" \
         .format(txid))
 
@@ -710,9 +647,6 @@ class ZKTransaction:
       ZKTransactionException: If we can't acquire the lock for the given
         entity group, because a different transaction already has it.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     txpath = self.get_transaction_path(app_id, txid)
     lockrootpath = self.get_lock_root_path(app_id, entity_key)
     lockpath = None
@@ -743,7 +677,6 @@ class ZKTransaction:
         "already another transaction using {0} lock".format(lockrootpath))
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       raise ZKTransactionException("Couldn't get a lock at path {0}" \
         .format(lockrootpath))
 
@@ -773,7 +706,6 @@ class ZKTransaction:
 
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       raise ZKTransactionException("Couldn't create or set a lock at path {0}" \
         .format(transaction_lock_path))
 
@@ -793,9 +725,6 @@ class ZKTransaction:
       ZKInternalException: If we can't tell if the transaction is a XG
         transaction or not.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     try:
       return self.run_with_retry(self.handle.exists, self.get_xg_path(app_id,
         tx_id))
@@ -804,7 +733,6 @@ class ZKTransaction:
         .format(zk_exception)) 
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       raise ZKInternalException("Couldn't see if transaction {0} was XG " \
         "for app {1}".format(tx_id, app_id))
 
@@ -826,9 +754,6 @@ class ZKTransaction:
     Raises:
       ZKTransactionException: If it could not get the lock.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     lockrootpath = self.get_lock_root_path(app_id, entity_key)
 
     try:
@@ -849,13 +774,11 @@ class ZKTransaction:
               "different root entity in non-cross-group transaction.")
     except ZKInternalException as zk_exception:
       self.logger.exception(zk_exception)
-      self.reestablish_connection()
       raise ZKTransactionException("An internal exception prevented us from " \
         "getting the lock for app id {0}, txid {1}, entity key {2}" \
         .format(app_id, txid, entity_key))
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       raise ZKTransactionException("Couldn't get lock for app id {0}, txid " \
         "{1}, entity key {2}".format(app_id, txid, entity_key))
 
@@ -891,7 +814,6 @@ class ZKTransaction:
         "is not valid.".format(txid))
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       raise ZKTransactionException("Couldn't get updated key list for appid " \
         "{0}, txid {1}".format(app_id, txid))
 
@@ -927,9 +849,6 @@ class ZKTransaction:
       ZKTransactionException: If any locks acquired during this transaction
         could not be released.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     self.check_transaction(app_id, txid)
     txpath = self.get_transaction_path(app_id, txid)
      
@@ -951,13 +870,11 @@ class ZKTransaction:
           return True
       except ZKInternalException as zk_exception:
         self.logger.exception(zk_exception)
-        self.reestablish_connection()
         raise ZKTransactionException("Internal exception prevented us from " \
           "releasing lock {0} for app id {1}".format(transaction_lock_path,
           app_id))
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       raise ZKTransactionException("Couldn't release lock {0} for appid {1}" \
         .format(transaction_lock_path, app_id))
 
@@ -978,13 +895,11 @@ class ZKTransaction:
       # Although there was a failure doing the async deletes, since we've
       # already released the locks above, we can safely return True here.
       self.logger.exception(zk_exception)
-      self.reestablish_connection()
       return True
     except kazoo.exceptions.KazooException as kazoo_exception:
       # Although there was a failure doing the async deletes, since we've
       # already released the locks above, we can safely return True here.
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       return True
 
     return True
@@ -1002,9 +917,6 @@ class ZKTransaction:
       ZKInternalException: If we couldn't determine if the transaction was
         blacklisted or not.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     try:
       blacklist_root = self.get_blacklist_root_path(app_id)
       blacklist_txn = PATH_SEPARATOR.join([blacklist_root, 
@@ -1019,7 +931,6 @@ class ZKTransaction:
         time.sleep(self.ZK_RETRY_TIME)
         return self.is_blacklisted(app_id=app_id, txid=txid,
                                    retries=retries - 1)
-      self.reestablish_connection()
       raise ZKInternalException("Couldn't see if appid {0}'s transaction, " \
         "{1}, is blacklisted.".format(app_id, txid))
 
@@ -1037,9 +948,6 @@ class ZKTransaction:
     Raises:
       ZKInternalException: If we couldn't get a valid transaction ID.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     # If this is an ongoing transaction give the previous value.
     try:
       if self.is_in_transaction(app_id, target_txid):
@@ -1058,7 +966,6 @@ class ZKTransaction:
         return long(0)
       except kazoo.exceptions.KazooException as kazoo_exception:
         self.logger.exception(kazoo_exception)
-        self.reestablish_connection()
         raise ZKInternalException("Couldn't get valid transaction id for " \
           "app {0}, target txid {1}, entity key {2}".format(app_id, target_txid,
           entity_key))
@@ -1082,9 +989,6 @@ class ZKTransaction:
       ZKTransactionException: If the transaction is not valid.
       ZKInternalException: If we were unable to register the key.
     """
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     vtxpath = self.get_valid_transaction_path(app_id, entity_key)
 
     try:
@@ -1106,7 +1010,6 @@ class ZKTransaction:
             current_txid))
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       raise ZKInternalException("Couldn't register updated key for app " \
         "{0}, current txid {1}, target txid {2}, entity_key {3}".format(app_id,
         current_txid, target_txid, entity_key))
@@ -1131,9 +1034,6 @@ class ZKTransaction:
     lockpath = None
     lock_list = []
 
-    if self.needs_connection or not self.handle.connected:
-      self.reestablish_connection()
-
     txpath = self.get_transaction_path(app_id, txid)
     try:
       lockpath = self.run_with_retry(self.handle.get,
@@ -1148,7 +1048,6 @@ class ZKTransaction:
       return False
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       return False
 
     try:
@@ -1213,75 +1112,9 @@ class ZKTransaction:
       return False
     except kazoo.exceptions.KazooException as kazoo_exception:
       self.logger.exception(kazoo_exception)
-      self.reestablish_connection()
       return False
       
     return True
-
-  def reestablish_connection(self):
-    """ Checks the connection and resets it as needed. """
-    self.logger.warning('Re-establishing ZooKeeper connection.')
-    try:
-      self.handle.restart()
-      self.needs_connection = False
-      self.failure_count = 0
-      self.logger.info('Restarted ZK connection successfully.')
-      return
-    except kazoo.exceptions.ZookeeperError:
-      self.logger.exception(
-        'Unable to restart ZK connection. Creating a new one.')
-    except kazoo.exceptions.KazooException:
-      self.logger.exception(
-        'Unable to restart ZK connection. Creating a new one.')
-    except Exception:
-      self.logger.exception(
-        'Unable to restart ZK connection. Creating a new one.')
-
-    try:
-      self.handle.stop()
-    except kazoo.exceptions.ZookeeperError:
-      self.logger.exception('Issue stopping ZK connection.')
-    except kazoo.exceptions.KazooException:
-      self.logger.exception('Issue stopping ZK connection.')
-    except Exception:
-      self.logger.exception('Issue stopping ZK connection.')
-
-    try:
-      self.handle.close()
-    except kazoo.exceptions.ZookeeperError:
-      self.logger.exception('Issue closing ZK connection.')
-    except kazoo.exceptions.KazooException:
-      self.logger.exception('Issue closing ZK connection.')
-    except Exception:
-      self.logger.exception('Issue closing ZK connection.')
-
-    self.logger.warning('Creating a new connection to ZK')
-    reconnect_error = False
-
-    self.handle = kazoo.client.KazooClient(hosts=self.host,
-      max_retries=self.DEFAULT_NUM_RETRIES, timeout=self.DEFAULT_ZK_TIMEOUT)
-
-    try:
-      self.handle.start()
-    except kazoo.exceptions.KazooException as kazoo_exception:
-      reconnect_error = True
-      self.logger.exception(kazoo_exception)
-    except Exception as exception:
-      reconnect_error = True
-      self.logger.exception(exception)
-
-    if reconnect_error:
-      self.logger.error('Error re-establishing ZooKeeper connection!')
-      self.needs_connection = True
-      self.failure_count += 1
-    else:
-      self.logger.info('Successfully created a new connection')
-      self.needs_connection = False
-      self.failure_count = 0
-
-    if self.failure_count > self.MAX_CONNECTION_FAILURES:
-      self.logger.critical('Too many connection errors to ZooKeeper. Aborting')
-      sys.exit(1)
 
   def gc_runner(self):
     """ Transaction ID garbage collection (GC) runner.
@@ -1308,10 +1141,8 @@ class ZKTransaction:
         self.logger.exception('GC timeout when fetching {}'.format(APPS_PATH))
       except (ZookeeperError, KazooException):
         self.logger.exception('Error when trying garbage collection')
-        self.reestablish_connection()
       except Exception:
         self.logger.exception('Unknown exception')
-        self.reestablish_connection()
 
       with self.gc_cv:
         self.gc_cv.wait(GC_INTERVAL)
@@ -1336,11 +1167,9 @@ class ZKTransaction:
       last_time = 0
     except (ZookeeperError, KazooException):
       self.logger.exception('Error when fetching {}'.format(gc_time_path))
-      self.reestablish_connection()
       return False
     except Exception:
       self.logger.exception('Unknown exception')
-      self.reestablish_connection()
       return False
  
     # If the last time plus our GC interval is less than the current time,
@@ -1366,11 +1195,9 @@ class ZKTransaction:
         pass
       except (ZookeeperError, KazooException):
         self.logger.exception('Error while executing garbage collection')
-        self.reestablish_connection()
         return False
       except Exception:
         self.logger.exception('Unknown exception')
-        self.reestablish_connection()
         return False
  
       return True
@@ -1396,11 +1223,9 @@ class ZKTransaction:
     except (kazoo.exceptions.SystemZookeeperError, ZookeeperError,
             KazooException, SystemError):
       self.logger.exception('Unable to create {}'.format(path))
-      self.reestablish_connection()
       return False
     except Exception:
       self.logger.exception('Unknown exception')
-      self.reestablish_connection()
       return False
       
     return True
@@ -1422,11 +1247,9 @@ class ZKTransaction:
     except (kazoo.exceptions.SystemZookeeperError, KazooException,
             SystemError):
       self.logger.exception('Unable to delete lock: {0}'.format(path))
-      self.reestablish_connection()
       return False
     except Exception:
       self.logger.exception('Unknown exception')
-      self.reestablish_connection()
       return False
     return True
 
@@ -1516,11 +1339,9 @@ class ZKTransaction:
       return
     except (ZookeeperError, KazooException):
       self.logger.exception('Unable to get children of {}'.format(txrootpath))
-      self.reestablish_connection()
       return
     except Exception:
       self.logger.exception('Unknown exception')
-      self.reestablish_connection()
       return
     # Verify the time stamp of each transaction.
     for txid in txlist:
@@ -1550,12 +1371,10 @@ class ZKTransaction:
       except (ZookeeperError, KazooException):
         self.logger.exception(
           'Error while running GC for {}:{}'.format(app_id, txid))
-        self.reestablish_connection()
         return
       except Exception:
         self.logger.exception('Unknown exception')
-        self.reestablish_connection()
-        return 
+        return
     self.logger.debug('Lock GC took {} seconds.'.format(time.time() - start))
 
   def get_current_transactions(self, project):

--- a/AppDB/appscale/datastore/zkappscale/zktransaction.py
+++ b/AppDB/appscale/datastore/zkappscale/zktransaction.py
@@ -161,6 +161,7 @@ class ZKTransaction:
     """
     reconnect_policy = KazooRetry(max_tries=-1,
                                   max_delay=self.MAX_RECONNECT_DELAY)
+    retry_policy = KazooRetry(max_tries=5)
 
     class_name = self.__class__.__name__
     self.logger = logging.getLogger(class_name)
@@ -169,8 +170,9 @@ class ZKTransaction:
 
     # Connection instance variables.
     self.host = host
-    self.handle = kazoo.client.KazooClient(hosts=host,
-                                           connection_retry=reconnect_policy)
+    self.handle = kazoo.client.KazooClient(
+      hosts=host, connection_retry=reconnect_policy,
+      command_retry=retry_policy)
     self.run_with_retry = self.handle.retry
     self.handle.start()
 


### PR DESCRIPTION
Recreating the KazooClient object during manual reconnect was causing problems for other functions using the old (closed) object. It was possible for a request to hang indefinitely.