### PR TITLE
Continue build when repo update is not required

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -43,8 +43,6 @@ if [ "$HOME" != "/root" ]; then
 fi
 echo "Success"
 
-set -e
-
 # Let's get the  command line arguments.
 while [ $# -gt 0 ]; do
         if [ "${1}" = "--repo" ]; then 
@@ -257,9 +255,7 @@ if [ -d /etc/appscale/certs ]; then
         if [ "${UPDATE_REPO}" = "Y" ]; then
                 # Upgrade the repository. If GIT_TAG is empty, we are on HEAD.
                 if [ -n "${GIT_TAG}" ]; then
-                        set +e
-                        (cd appscale; git checkout "$GIT_TAG")
-                        if [ $? -gt 0 ]; then
+                        if ! (cd appscale; git checkout "$GIT_TAG"); then
                                 echo "Please stash your local unsaved changes"\
                                      "and checkout the version of AppScale"\
                                      "you are currently using to fix this "\
@@ -267,8 +263,8 @@ if [ -d /etc/appscale/certs ]; then
                                 echo "e.g.: git stash; git checkout <AppScale-version>"
                                 exit 1
                         fi
-                        (cd appscale-tools; git checkout "$GIT_TAG")
-                        if [ $? -gt 0 ]; then
+
+                        if ! (cd appscale-tools; git checkout "$GIT_TAG"); then
                                 echo "Please stash your local unsaved changes"\
                                      "and checkout the version of "\
                                      "appscale-tools you are currently using"\
@@ -279,7 +275,6 @@ if [ -d /etc/appscale/certs ]; then
                 else
                         (cd appscale; git pull)
                         (cd appscale-tools; git pull)
-                        set -e
                 fi
         fi
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -210,11 +210,6 @@ if [ -d /etc/appscale/certs ]; then
                 exit 1
         fi
 
-        echo
-        echo "Found AppScale version $APPSCALE_MAJOR.$APPSCALE_MINOR. An upgrade"
-        echo "to the latest version available will be attempted in 5 seconds."
-        sleep 5
-
         # Make sure AppScale is not running.
         MONIT=$(which monit)
         if $MONIT summary | grep controller > /dev/null ; then
@@ -253,6 +248,11 @@ if [ -d /etc/appscale/certs ]; then
 
 
         if [ "${UPDATE_REPO}" = "Y" ]; then
+                echo "Found AppScale version $APPSCALE_MAJOR.$APPSCALE_MINOR."\
+                     "An upgrade to the latest version available will be"\
+                     "attempted in 5 seconds."
+                sleep 5
+
                 # Upgrade the repository. If GIT_TAG is empty, we are on HEAD.
                 if [ -n "${GIT_TAG}" ]; then
                         if ! (cd appscale; git checkout "$GIT_TAG"); then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -156,6 +156,8 @@ fi
 # Since the last step in appscale_build.sh is to create the certs directory,
 # its existence indicates that appscale has already been installed.
 if [ -d /etc/appscale/certs ]; then
+        UPDATE_REPO="Y"
+
         # For upgrade, we don't switch across branches.
         if [ "${APPSCALE_BRANCH}" != "master" ]; then
                 echo "Cannot use --branch when upgrading"
@@ -197,8 +199,9 @@ if [ -d /etc/appscale/certs ]; then
            (cd appscale; git tag -l | grep $(git describe)) ; then
                 CURRENT_BRANCH="$(cd appscale; git tag -l | grep $(git describe))"
                 if [ "${CURRENT_BRANCH}" = "${GIT_TAG}" ]; then
-                        echo "AppScale is already at the specified release."
-                        exit 0
+                        echo "AppScale repository is already at the"\
+                             "specified release. Building with current code."
+                        UPDATE_REPO="N"
                 fi
         fi
 
@@ -252,7 +255,7 @@ if [ -d /etc/appscale/certs ]; then
 
 
         # Let's upgrade the repository: if GIT_TAG is empty we are on HEAD.
-        if [ -n "${GIT_TAG}" ]; then
+        if [ -n "${GIT_TAG}" ] && [ "${UPDATE_REPO}" = "Y" ]; then
                 set +e
                 (cd appscale; git checkout "$GIT_TAG")
                 if [ $? -gt 0 ]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -254,25 +254,33 @@ if [ -d /etc/appscale/certs ]; then
         fi
 
 
-        # Let's upgrade the repository: if GIT_TAG is empty we are on HEAD.
-        if [ -n "${GIT_TAG}" ] && [ "${UPDATE_REPO}" = "Y" ]; then
-                set +e
-                (cd appscale; git checkout "$GIT_TAG")
-                if [ $? -gt 0 ]; then
-                    echo "Please stash your local unsaved changes and checkout the version of AppScale you are currently using to fix this error."
-                    echo "e.g.: git stash; git checkout <AppScale-version>"
-                    exit 1
+        if [ "${UPDATE_REPO}" = "Y" ]; then
+                # Upgrade the repository. If GIT_TAG is empty, we are on HEAD.
+                if [ -n "${GIT_TAG}" ]; then
+                        set +e
+                        (cd appscale; git checkout "$GIT_TAG")
+                        if [ $? -gt 0 ]; then
+                                echo "Please stash your local unsaved changes"\
+                                     "and checkout the version of AppScale"\
+                                     "you are currently using to fix this "\
+                                     "error."
+                                echo "e.g.: git stash; git checkout <AppScale-version>"
+                                exit 1
+                        fi
+                        (cd appscale-tools; git checkout "$GIT_TAG")
+                        if [ $? -gt 0 ]; then
+                                echo "Please stash your local unsaved changes"\
+                                     "and checkout the version of "\
+                                     "appscale-tools you are currently using"\
+                                     "to fix this error."
+                                echo "e.g.: git stash; git checkout <appscale-tools-version>"
+                                exit 1
+                        fi
+                else
+                        (cd appscale; git pull)
+                        (cd appscale-tools; git pull)
+                        set -e
                 fi
-                (cd appscale-tools; git checkout "$GIT_TAG")
-                if [ $? -gt 0 ]; then
-                    echo "Please stash your local unsaved changes and checkout the version of AppScale you are currently using to fix this error."
-                    echo "e.g.: git stash; git checkout <AppScale-version>"
-                    exit 1
-                fi
-        else
-                (cd appscale; git pull)
-                (cd appscale-tools; git pull)
-                set -e
         fi
 fi
 


### PR DESCRIPTION
This allows users to re-run "upgrade" if the first time fails.