### PR TITLE
Exit controller service with error when not configured

### DIFF
--- a/AppController/scripts/appcontroller
+++ b/AppController/scripts/appcontroller
@@ -25,7 +25,7 @@ do_start()
 {
    if [ ! -e $SECRET_FILE ]; then
      log_begin_msg "AppScale not configured: not starting."
-     exit 0
+     exit 1
    fi
 
    # If we start from boot, we need to clear the monit state. The


### PR DESCRIPTION
Otherwise, the init system will not know that the start failed.