### PR TITLE
Remove groomer log file check

### DIFF
--- a/AppController/lib/groomer_service.rb
+++ b/AppController/lib/groomer_service.rb
@@ -15,21 +15,18 @@ module GroomerService
   # Starts the Groomer Service on this machine. We don't want to monitor
   # it ourselves, so just tell monit to start it and watch it.
   def self.start()
-    groomer = self.scriptname()
+    groomer = self.scriptname
     start_cmd = "/usr/bin/python2 #{groomer}"
     stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
       "#{groomer} /usr/bin/python"
     MonitInterface.start(:groomer_service, start_cmd, stop_cmd, nil, {},
                          start_cmd, MAX_MEM, nil, nil)
-    MonitInterface.start_file(:groomer_file_check,
-      "/var/log/appscale/groomer_service.log", stop_cmd, "12")
   end
 
   # Stops the groomer service running on this machine. Since it's
   # managed by monit, just tell monit to shut it down.
   def self.stop()
     MonitInterface.stop(:groomer_service)
-    MonitInterface.stop(:groomer_file_check)
   end
 
   def self.scriptname()
@@ -37,4 +34,3 @@ module GroomerService
   end
 
 end
-

--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -56,22 +56,6 @@ module MonitInterface
     self.run_cmd("#{MONIT} start -g #{watch}")
   end
 
-  def self.start_file(watch, path, action, hours=12)
-    contents = <<BOO
-check file #{watch} path "#{path}" every 2 cycles
-  group #{watch}
-  if timestamp > 12 hours then exec "#{action}"
-BOO
-    monit_file = "#{MONIT_CONFIG}/appscale-#{watch}.cfg"
-    HelperFunctions.write_file(monit_file, contents)
-    self.run_cmd('service monit reload', true)
-
-    Djinn.log_info("Watching file #{path} for #{watch}" +
-      " with exec action [#{action}]")
-
-    self.run_cmd('#{MONIT} start -g #{watch}')
-  end
-
   def self.restart(watch)
     self.run_cmd("#{MONIT} restart -g #{watch}")
   end


### PR DESCRIPTION
This was originally added as a fallback for when the groomer froze, but that issue is fixed now that the groomer does not run the ZooKeeper GC thread.