### PR TITLE
Only start one process per BRServer

### DIFF
--- a/AppDB/appscale/datastore/scripts/br_server.py
+++ b/AppDB/appscale/datastore/scripts/br_server.py
@@ -60,5 +60,5 @@ def main():
   # Start Tornado.
   http_server = tornado.httpserver.HTTPServer(get_application())
   http_server.bind(DEFAULT_PORT)
-  http_server.start(0)
+  http_server.start()
   tornado.ioloop.IOLoop.instance().start()


### PR DESCRIPTION
Otherwise, tornado will start one process per core, making it more difficult to monitor with a pidfile.