### PR TITLE
Remove port suffix from LogService logfile

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3902,7 +3902,7 @@ class Djinn
   # Starts the Log Server service on this machine
   def start_log_server
     log_server_pid = "/var/run/appscale-logserver.pid"
-    log_server_file = "/var/log/appscale/log_service-7422.log"
+    log_server_file = "/var/log/appscale/log_service.log"
     start_cmd = "twistd --pidfile=#{log_server_pid}  --logfile " +
                 "#{log_server_file} appscale-logserver"
     stop_cmd = "/bin/bash -c 'kill $(cat #{log_server_pid})'"


### PR DESCRIPTION
This matches the format of the other service logfiles.