### PR TITLE
Fix logic to allow adding instances on a cluster

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2593,7 +2593,7 @@ class Djinn
 
     # If we have an already running node with the same IP, we change its
     # roles list.
-    new_nodes_info << node_roles unless node_roles.empty?
+    new_nodes_info += node_roles unless node_roles.empty?
     @state_change_lock.synchronize {
       @nodes.each { |node|
         delete_index = nil

--- a/AppController/lib/djinn_job_data.rb
+++ b/AppController/lib/djinn_job_data.rb
@@ -40,7 +40,8 @@ class DjinnJobData
     end
 
     @cloud = "cloud1"
-    @instance_id = json_data['instance_id']
+    @instance_id = 'i-APPSCALE'
+    @instance_id = json_data['instance_id'] if json_data['instance_id']
     @disk = json_data['disk']
     @ssh_key = File.expand_path("/etc/appscale/keys/#{@cloud}/#{keyname}.key")
   end


### PR DESCRIPTION
This PR fixes a couple of bugs, which did not allow manually instances to be added in a cluster. In cluster mode, the tools provides a default dummy instance id while starting a new deployment which the manual add instance logic does not go through.