### PR TITLE
Start AppScale services in background

### DIFF
--- a/AppController/lib/backup_restore_service.rb
+++ b/AppController/lib/backup_restore_service.rb
@@ -14,10 +14,7 @@ module BackupRecoveryService
   def self.start()
     bk_service = self.scriptname()
     start_cmd = "#{bk_service}"
-    stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
-          "#{bk_service} /usr/bin/python"
-    MonitInterface.start(:backup_recovery_service, start_cmd, stop_cmd,
-                         nil, {}, start_cmd, nil, nil, nil)
+    MonitInterface.start(:backup_recovery_service, start_cmd)
   end
 
   # Stops the backup/recovery service running on this machine. Since it's

--- a/AppController/lib/blobstore.rb
+++ b/AppController/lib/blobstore.rb
@@ -27,11 +27,8 @@ module BlobServer
       "-d #{db_local_ip}:#{db_local_port}",
       "-p #{self::SERVER_PORT}"
     ].join(' ')
-    stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
-      "#{self.scriptname} /usr/bin/python"
 
-    MonitInterface.start(:blobstore, start_cmd, stop_cmd, nil,
-                         nil, start_cmd, nil, nil, nil)
+    MonitInterface.start(:blobstore, start_cmd)
   end
 
   def self.stop()

--- a/AppController/lib/cassandra_helper.rb
+++ b/AppController/lib/cassandra_helper.rb
@@ -138,10 +138,10 @@ def start_cassandra(clear_datastore, needed, desired)
   Djinn.log_run("mkdir -p #{CASSANDRA_DATA_DIR}")
   Djinn.log_run("chown -R cassandra #{CASSANDRA_DATA_DIR}")
 
-  start_cmd = %Q[su -c "#{CASSANDRA_EXECUTABLE} -p #{PID_FILE}" cassandra]
+  su = `which su`.chomp
+  start_cmd = "#{su} -c '#{CASSANDRA_EXECUTABLE} -p #{PID_FILE}' cassandra"
   stop_cmd = "/bin/bash -c 'kill $(cat #{PID_FILE})'"
-  MonitInterface.start(:cassandra, start_cmd, stop_cmd, nil, nil, nil, nil,
-                       PID_FILE, START_TIMEOUT)
+  MonitInterface.start_daemon(:cassandra, start_cmd, stop_cmd, PID_FILE)
 
   # Ensure enough Cassandra nodes are available.
   Djinn.log_info('Waiting for Cassandra to start')

--- a/AppController/lib/datastore_server.rb
+++ b/AppController/lib/datastore_server.rb
@@ -46,12 +46,9 @@ module DatastoreServer
       "LOCAL_DB_IP" => db_local_ip 
     }
   
-    start_cmd = "/usr/bin/python2 #{datastore_server} --type #{table}"
+    start_cmd = "#{datastore_server} --type #{table}"
     start_cmd << ' --verbose' if verbose
-    stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
-          "#{datastore_server}"
-    MonitInterface.start(:datastore_server, start_cmd, stop_cmd, ports,
-                         env_vars, start_cmd, nil, nil, nil)
+    MonitInterface.start(:datastore_server, start_cmd, ports, env_vars)
   end
 
 

--- a/AppController/lib/ejabberd.rb
+++ b/AppController/lib/ejabberd.rb
@@ -25,17 +25,12 @@ module Ejabberd
   ONLINE_USERS_FILE = "/etc/appscale/online_xmpp_users"
 
 
-  # We need some additional logic for the start command hence using 
-  # a script.
-  START_EJABBERD_SCRIPT = File.dirname(__FILE__) + "/../" + \
-                          "scripts/start_ejabberd.sh"
-
   def self.start
-    start_cmd = "bash #{START_EJABBERD_SCRIPT}"
-    stop_cmd = "/etc/init.d/ejabberd stop"
-    match_cmd = "sname ejabberd"
-    MonitInterface.start(:ejabberd, start_cmd, stop_cmd, nil, nil,
-                         match_cmd, nil, nil, nil)
+    service = `which service`.chomp
+    start_cmd = "#{service} ejabberd start"
+    stop_cmd = "#{service} ejabberd stop"
+    pidfile = '/var/run/ejabberd/ejabberd.pid'
+    MonitInterface.start_daemon(:ejabberd, start_cmd, stop_cmd, pidfile)
   end
 
   def self.stop

--- a/AppController/lib/groomer_service.rb
+++ b/AppController/lib/groomer_service.rb
@@ -15,12 +15,8 @@ module GroomerService
   # Starts the Groomer Service on this machine. We don't want to monitor
   # it ourselves, so just tell monit to start it and watch it.
   def self.start()
-    groomer = self.scriptname
-    start_cmd = "/usr/bin/python2 #{groomer}"
-    stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
-      "#{groomer} /usr/bin/python"
-    MonitInterface.start(:groomer_service, start_cmd, stop_cmd, nil, {},
-                         start_cmd, MAX_MEM, nil, nil)
+    start_cmd = self.scriptname
+    MonitInterface.start(:groomer_service, start_cmd, nil, nil, MAX_MEM)
   end
 
   # Stops the groomer service running on this machine. Since it's

--- a/AppController/lib/haproxy.rb
+++ b/AppController/lib/haproxy.rb
@@ -94,11 +94,11 @@ module HAProxy
 
 
   def self.start()
-    start_cmd = "/usr/sbin/service haproxy start"
-    stop_cmd = "/usr/sbin/service haproxy stop"
-    match_cmd = "/usr/sbin/haproxy"
-    MonitInterface.start(:haproxy, start_cmd, stop_cmd, nil, nil, match_cmd,
-                         nil, nil, nil)
+    service = `which service`.chomp
+    start_cmd = "#{service} haproxy start"
+    stop_cmd = "#{service} haproxy stop"
+    pidfile = '/var/run/haproxy.pid'
+    MonitInterface.start_daemon(:haproxy, start_cmd, stop_cmd, pidfile)
   end
 
   def self.stop()

--- a/AppController/lib/hermes_service.rb
+++ b/AppController/lib/hermes_service.rb
@@ -12,10 +12,7 @@ module HermesService
   def self.start()
     hermes = self.scriptname()
     start_cmd = "/usr/bin/python2 #{hermes}"
-    stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
-          "#{hermes} /usr/bin/python2"
-    MonitInterface.start(:hermes, start_cmd, stop_cmd, nil, {},
-                         start_cmd, nil, nil, nil)
+    MonitInterface.start(:hermes, start_cmd)
   end
 
   # Stops the Hermes service running on this machine. Since it's

--- a/AppController/lib/nginx.rb
+++ b/AppController/lib/nginx.rb
@@ -53,12 +53,11 @@ module Nginx
     # Nginx runs both a 'master process' and one or more 'worker process'es, so
     # when we have monit watch it, as long as one of those is running, nginx is
     # still running and shouldn't be restarted.
-    service_bin = `which service`.chomp()
+    service_bin = `which service`.chomp
     start_cmd = "#{service_bin} nginx start"
     stop_cmd = "#{service_bin} nginx stop"
-    match_cmd = "nginx: (.*) process"
-    MonitInterface.start(:nginx, start_cmd, stop_cmd, nil, nil, match_cmd,
-                         nil, nil, nil)
+    pidfile = '/var/run/nginx.pid'
+    MonitInterface.start_daemon(:nginx, start_cmd, stop_cmd, pidfile)
   end
 
   def self.stop()

--- a/AppController/lib/search.rb
+++ b/AppController/lib/search.rb
@@ -18,7 +18,7 @@ require 'monit_interface'
 module Search
 
   # AppScale install directory.
-  APPSCALE_HOME = ENV["APPSCALE_HOME"]
+  APPSCALE_HOME = ENV["APPSCALE_HOME"] || File.join('/', 'root', 'appscale')
 
   # The port that SOLR server runs on, by default.
   SOLR_SERVER_PORT = 8983

--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -89,8 +89,7 @@ module TaskQueue
     start_cmd = "/usr/sbin/rabbitmq-server -detached -setcookie #{HelperFunctions.get_taskqueue_secret()}"
     stop_cmd = "/usr/sbin/rabbitmqctl stop"
     match_cmd = "sname rabbit"
-    MonitInterface.start(:rabbitmq, start_cmd, stop_cmd, nil, nil,
-                         match_cmd, nil, nil, nil)
+    MonitInterface.start_custom(:rabbitmq, start_cmd, stop_cmd, match_cmd)
 
     # Next, start up the TaskQueue Server.
     start_taskqueue_server(verbose)
@@ -155,8 +154,7 @@ module TaskQueue
 
     tries_left = RABBIT_START_RETRY
     loop {
-      MonitInterface.start(:rabbitmq, full_cmd, stop_cmd, nil, nil,
-                           match_cmd, nil, nil, nil)
+      MonitInterface.start_custom(:rabbitmq, full_cmd, stop_cmd, match_cmd)
       Djinn.log_debug("Waiting for RabbitMQ on local node to come up")
       begin
         Timeout::timeout(MAX_WAIT_FOR_RABBITMQ) do
@@ -192,13 +190,10 @@ module TaskQueue
     Djinn.log_debug("Starting taskqueue servers on this node")
     ports = self.get_server_ports()
 
-    start_cmd = "/usr/bin/python2 #{TASKQUEUE_SERVER_SCRIPT}"
+    start_cmd = TASKQUEUE_SERVER_SCRIPT
     start_cmd << ' --verbose' if verbose
-    stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
-               "#{TASKQUEUE_SERVER_SCRIPT}"
     env_vars = {:PATH => '$PATH:/usr/local/bin'}
-    MonitInterface.start(:taskqueue, start_cmd, stop_cmd, ports, env_vars,
-                         start_cmd, nil, nil, nil)
+    MonitInterface.start(:taskqueue, start_cmd, ports, env_vars)
     Djinn.log_debug("Done starting taskqueue servers on this node")
   end
 
@@ -253,10 +248,7 @@ module TaskQueue
 
     flower_cmd = `which flower`.chomp
     start_cmd = "#{flower_cmd} --basic_auth=appscale:#{flower_password}"
-    stop_cmd = "/usr/bin/python2 #{APPSCALE_HOME}/scripts/stop_service.py " +
-          "flower #{flower_password}"
-    MonitInterface.start(:flower, start_cmd, stop_cmd, nil,
-                         nil, start_cmd, nil, nil, nil)
+    MonitInterface.start(:flower, start_cmd)
   end
 
 

--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -140,17 +140,20 @@ module TaskQueue
       end
     end
 
-    start_cmds = [
+    bash = `which bash`.chomp
+    rabbitmqctl = `which rabbitmqctl`.chomp
+    start_cmd = [
       # Restarting the RabbitMQ server ensures that we read the correct cookie.
-      "service rabbitmq-server restart",
-      "/usr/sbin/rabbitmqctl stop_app",
+      'service rabbitmq-server restart',
+      'rabbitmqctl stop_app',
       # Read master hostname given the master IP.
-      "/usr/sbin/rabbitmqctl join_cluster rabbit@#{master_tq_host}",
-      "/usr/sbin/rabbitmqctl start_app"
-    ]
-    full_cmd = "#{start_cmds.join('; ')}"
-    stop_cmd = "/usr/sbin/rabbitmqctl stop"
-    match_cmd = "sname rabbit"
+      "rabbitmqctl join_cluster rabbit@#{master_tq_host}",
+      'rabbitmqctl start_app'
+    ].join(' && ')
+    log_file = '/var/log/appscale/rabbitmq.log'
+    full_cmd = "#{bash} -c '#{start_cmd} >> #{log_file} 2>&1'"
+    stop_cmd = "#{rabbitmqctl} stop"
+    match_cmd = 'sname rabbit'
 
     tries_left = RABBIT_START_RETRY
     loop {

--- a/AppController/lib/zookeeper_helper.rb
+++ b/AppController/lib/zookeeper_helper.rb
@@ -91,11 +91,11 @@ def start_zookeeper(clear_datastore)
   # myid is needed for multi node configuration.
   Djinn.log_run("ln -sfv /etc/zookeeper/conf/myid #{DATA_LOCATION}/myid")
 
-  start_cmd = "/usr/sbin/service #{zk_server} start"
-  stop_cmd = "/usr/sbin/service #{zk_server} stop"
+  service = `which service`.chomp
+  start_cmd = "#{service} #{zk_server} start"
+  stop_cmd = "#{service} #{zk_server} stop"
   match_cmd = "org.apache.zookeeper.server.quorum.QuorumPeerMain"
-  MonitInterface.start(:zookeeper, start_cmd, stop_cmd, nil, nil,
-                       match_cmd, nil, nil, nil)
+  MonitInterface.start_custom(:zookeeper, start_cmd, stop_cmd, match_cmd)
 end
 
 def is_zookeeper_running?

--- a/AppController/scripts/start_ejabberd.sh
+++ b/AppController/scripts/start_ejabberd.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Only start ejabberd if it is not already running.
-# We do this because God cannot handle this logic directly.
-ISEJABBERDRUNNING=`ps aux | grep ejabberd | grep mnesia | grep -v grep | wc | awk {'print $1'}`
-[[ $ISEJABBERDRUNNING -eq "0" ]] && /etc/init.d/ejabberd start

--- a/AppController/scripts/start_rabbitmq.sh
+++ b/AppController/scripts/start_rabbitmq.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# First argument is the secret.
-# Because God cannot do conditional login in the start command, 
-# we have it call this script instead.
-ISRABBITRUNNING=`ps aux | grep rabbitmq | grep erlang | grep -v grep | wc | awk {'print $1'}`
-[[ $ISRABBITRUNNING -eq "0" ]] && rabbitmq-server -detached -setcookie $1

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -294,6 +294,7 @@ class TestDjinn < Test::Unit::TestCase
     # mock out and commands
     flexmock(Djinn).should_receive(:log_run).and_return()
     flexmock(HAProxy).should_receive(:create_tq_server_config).and_return()
+    flexmock(MonitInterface).should_receive(:start_custom).and_return()
     flexmock(MonitInterface).should_receive(:start).and_return()
     flexmock(Resolv).should_receive("getname").with("private_ip1").and_return("")
 


### PR DESCRIPTION
Newer versions of Monit wait for the start_cmd to exit before checking if the process is running. This PR ensures that all of the services that the AppController starts get started in the background.