### PR TITLE
Start AppServers and Celery workers in background

### DIFF
--- a/AppManager/test/unit/test_app_manager_server.py
+++ b/AppManager/test/unit/test_app_manager_server.py
@@ -244,8 +244,9 @@ class TestAppManager(unittest.TestCase):
       and_return('/path/to/dir/')
     app_id = 'testapp'
     max_heap = 260
+    pidfile = 'testpid'
     cmd = app_manager_server.create_java_start_cmd(
-      app_id, '20000', '127.0.0.2', max_heap)
+      app_id, '20000', '127.0.0.2', max_heap, pidfile)
     assert app_id in cmd
 
   def test_create_java_stop_cmd(self): 

--- a/AppServer/google/appengine/tools/devappserver2/devappserver2.py
+++ b/AppServer/google/appengine/tools/devappserver2/devappserver2.py
@@ -457,6 +457,7 @@ def create_command_line_parser():
     const=True,
     default=False,
     help='if this application can read data stored by other applications.')
+  appscale_group.add_argument('--pidfile', help='create pidfile at location')
 
   return parser
 
@@ -716,6 +717,11 @@ def main():
   os.environ['MY_PORT'] = str(options.port)
   os.environ['COOKIE_SECRET'] = appscale_info.get_secret()
   os.environ['NGINX_HOST'] = options.nginx_host
+
+  if options.pidfile:
+    with open(options.pidfile, 'w') as pidfile:
+      pidfile.write(str(os.getpid()))
+
   dev_server = DevelopmentServer()
   try:
     dev_server.start(options)

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
@@ -209,36 +209,36 @@ public class DevAppServerMain
         	}
         }, new DevAppServerOption(main, null, "admin_console_version", false)
         { // changed from admin_console_server
-                    public void apply()
-                    {
-                        this.main.admin_console_version = getValue();
-                        System.setProperty("ADMIN_CONSOLE_VERSION", this.main.admin_console_version);
-                    }
-                }, new DevAppServerOption(main, null, "APP_NAME", false)
-                {
-                    public void apply()
-                    {
-                        System.setProperty("APP_NAME", getValue());
-                    }
-                }, new DevAppServerOption(main, null, "NGINX_ADDRESS", false)
-                {
-                    public void apply()
-                    {
-                        System.setProperty("NGINX_ADDR", getValue());
-                    }
-                }, new DevAppServerOption(main, null, "NGINX_PORT", false)
-                {
-                    public void apply()
-                    {
-                        System.setProperty("NGINX_PORT", getNginxPort());
-                    }
-                }, new DevAppServerOption(main, null, "TQ_PROXY", false)
-                {
-                    public void apply()
-                    {
-                        System.setProperty("TQ_PROXY", getValue());
-                    }
-                } });
+            public void apply()
+            {
+                this.main.admin_console_version = getValue();
+                System.setProperty("ADMIN_CONSOLE_VERSION", this.main.admin_console_version);
+            }
+        }, new DevAppServerOption(main, null, "APP_NAME", false)
+        {
+            public void apply()
+            {
+                System.setProperty("APP_NAME", getValue());
+            }
+        }, new DevAppServerOption(main, null, "NGINX_ADDRESS", false)
+        {
+            public void apply()
+            {
+                System.setProperty("NGINX_ADDR", getValue());
+            }
+        }, new DevAppServerOption(main, null, "NGINX_PORT", false)
+        {
+            public void apply()
+            {
+                System.setProperty("NGINX_PORT", getNginxPort());
+            }
+        }, new DevAppServerOption(main, null, "TQ_PROXY", false)
+        {
+            public void apply()
+            {
+                System.setProperty("TQ_PROXY", getValue());
+            }
+        }});
     }
 
     private static void processInstancePorts(List<String> optionValues) {

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
@@ -16,6 +16,10 @@ import com.google.appengine.tools.util.Parser.ParseResult;
 import java.awt.Toolkit;
 import java.io.File;
 import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -238,6 +242,12 @@ public class DevAppServerMain
             {
                 System.setProperty("TQ_PROXY", getValue());
             }
+        }, new DevAppServerOption(main, null, "pidfile", false)
+        {
+            public void apply()
+            {
+                System.setProperty("PIDFILE", getValue());
+            }
         }});
     }
 
@@ -434,6 +444,13 @@ public class DevAppServerMain
                     updateCheck.maybePrintNagScreen(System.err);
                 }
                 updateCheck.checkJavaVersion(System.err);
+
+                String pidfile = System.getProperty("PIDFILE");
+                if (pidfile != null) {
+                    String pidString = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
+                    Path file = Paths.get(pidfile);
+                    Files.write(file, pidString.getBytes());
+                }
 
                 DevAppServer server = new DevAppServerFactory().createDevAppServer(appDir, externalResourceDir, DevAppServerMain.this.address, DevAppServerMain.this.port, noJavaAgent);
 

--- a/common/appscale/common/monit_app_configuration.py
+++ b/common/appscale/common/monit_app_configuration.py
@@ -24,6 +24,7 @@ def create_config_file(watch, start_cmd, pidfile, port=None, env_vars=None,
     watch: A string which identifies this process with monit.
     start_cmd: The start command to start the process.
     pidfile: The location of the pidfile that the process creates.
+    port: An integer specifying the port for the process.
     env_vars: A dictionary specifying environment variables.
     max_memory: An integer that specifies the maximum amount of memory in
       megabytes that the process should use.

--- a/common/appscale/common/monit_app_configuration.py
+++ b/common/appscale/common/monit_app_configuration.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from appscale.common import appscale_info
+from distutils.spawn import find_executable
 from . import file_io
 
 # Directory with the task templates.
@@ -8,83 +10,127 @@ TEMPLATE_DIR = os.path.join(
   os.path.dirname(sys.modules['appscale.common'].__file__), 'templates')
 
 # Template used for monit configuration files.
-TEMPLATE_LOCATION_SYSLOG = os.path.join(TEMPLATE_DIR,
-                                        'monit_template_syslog.conf')
 TEMPLATE_LOCATION = os.path.join(TEMPLATE_DIR, 'monit_template.conf')
 
-TEMPLATE_LOCATION_FOR_UPGRADE = os.path.join(TEMPLATE_DIR,
-                                             'monit_template_for_upgrade.conf')
 # The directory used when storing a service's config file.
 MONIT_CONFIG_DIR = '/etc/monit/conf.d'
 
-def create_config_file(watch, start_cmd, stop_cmd, ports, env_vars={},
-  max_memory=500, syslog_server="", host=None, upgrade_flag=False, match_cmd=""):
-  """ Reads in a template file for monit and fills it with the 
-      correct configuration. The caller is responsible for deleting 
-      the created file.
-  
+
+def create_config_file(watch, start_cmd, pidfile, port=None, env_vars=None,
+                       max_memory=None, syslog_server=None, check_port=False):
+  """ Writes a monit configuration file for a service.
+
   Args:
-    watch: A string which identifies this process with monit
-    start_cmd: The start command to start the process
-    stop_cmd: The stop command to kill the process
-    ports: A list of ports that are being watched
-    env_vars: The environment variables used when starting the process
-    max_memory: An int that names the maximum amount of memory that this process
-      is allowed to use (in megabytes) before monit should restart it.
-    syslog_server: The IP of the remote syslog server to use.
-    host: The private IP of a server that runs the appengine role; used for 
-      reliably detecting a running app server process.
-  Returns:
-    The name of the created configuration file. 
-  Raises: 
-    TypeError with bad argument types
+    watch: A string which identifies this process with monit.
+    start_cmd: The start command to start the process.
+    pidfile: The location of the pidfile that the process creates.
+    env_vars: A dictionary specifying environment variables.
+    max_memory: An integer that specifies the maximum amount of memory in
+      megabytes that the process should use.
+    syslog_server: The IP address of the remote syslog server to use.
+    check_port: A boolean specifying that monit should check host and port.
   """
-  if not isinstance(watch, str): raise TypeError("Expected str")
-  if not isinstance(start_cmd, str): raise TypeError("Expected str")
-  if not isinstance(stop_cmd, str): raise TypeError("Expected str")
-  if not isinstance(ports, list): raise TypeError("Expected list")
-  if not isinstance(env_vars, dict): raise TypeError("Expected dict")
+  if check_port:
+    assert port is not None, 'When using check_port, port must be defined'
 
-  env = ""
-  for ii in env_vars:
-    env += "export " + str(ii) + "=\"" + str(env_vars[ii]) + "\" && "
+  process_name = watch
+  if port is not None:
+    process_name += '-{}'.format(port)
 
-  # Convert ints to strings for template formatting
-  for index, ii in enumerate(ports): ports[index] = str(ii) 
+  env_vars_str = ''
+  if env_vars is not None:
+    for key in env_vars:
+      env_vars_str += '{}={} '.format(key, env_vars[key])
 
-  # 'WATCH' and 'port' are substituted here as the last two arguments 
-  # because the template script itself uses {}. If we do not sub for them 
-  # a key error is raised by template.format().
-  template = ""
+  bash = find_executable('bash')
+  start_stop_daemon = find_executable('start-stop-daemon')
 
-  # If the match is not specified, we will match the starting commands.
-  if not match_cmd:
-    match_cmd = start_cmd
+  logfile = os.path.join(
+    '/', 'var', 'log', 'appscale', '{}.log'.format(process_name))
 
-  # During upgrade we need to disable the memory usage rule.
-  if upgrade_flag:
-    max_memory = 0
+  if syslog_server is None:
+    stop = 'start-stop-daemon --stop --pidfile {0} && rm {0}'.format(pidfile)
+    bash_exec = 'exec env {vars} {start_cmd} >> {log} 2>&1'.format(
+      vars=env_vars_str, start_cmd=start_cmd, log=logfile)
+  else:
+    # Kill entire process group.
+    get_pgid = 'ps -o pgid= $(cat {}) | grep -o "[0-9]*"'.format(pidfile)
+    stop = 'kill -- -$({}) && rm {}'.format(get_pgid, pidfile)
+    bash_exec = 'exec env {vars} {start_cmd} 2>&1 | tee -a {log} | '\
+                'logger -t {watch} -u /tmp/ignored -n {syslog_server} -P 514'.\
+      format(vars=env_vars_str, start_cmd=start_cmd, log=logfile, watch=watch,
+             syslog_server=syslog_server)
 
-  for port in ports:
-    if syslog_server:
-      template = file_io.read(TEMPLATE_LOCATION_SYSLOG)
-      template = template.format(watch=watch, start=start_cmd, stop=stop_cmd,
-        port=port, env=env, syslog_server=syslog_server, match=match_cmd)
-    else:
-        template = file_io.read(TEMPLATE_LOCATION)
-        template = template.format(watch=watch, start=start_cmd, stop=stop_cmd,
-          port=port, match=match_cmd, env=env)
+  start_line = ' '.join([
+    start_stop_daemon,
+    '--start',
+    '--background',
+    '--pidfile', pidfile,
+    '--startas', "{} -- -c '{}'".format(bash, bash_exec)
+  ])
+  stop_line = "{} -c '{}'".format(bash, stop)
 
-    if max_memory > 0:
-      template += "  if totalmem > {} MB for 10 cycles then restart\n".\
-        format(max_memory)
+  with open(TEMPLATE_LOCATION) as template:
+    output = template.read()
+    output = output.format(
+      process_name=process_name, match_clause='PIDFILE {}'.format(pidfile),
+      group=watch, start_line=start_line, stop_line=stop_line)
 
-    if host:
-      template += "  if failed host {} port {} then restart\n".\
-        format(host, port)
+  if max_memory is not None:
+    output += '  if totalmem > {} MB for 10 cycles then restart\n'.format(
+      max_memory)
 
-    config_file = '{}/appscale-{}-{}.cfg'.\
-      format(MONIT_CONFIG_DIR, watch, port)
-    file_io.write(config_file, template)
+  if check_port:
+    private_ip = appscale_info.get_private_ip()
+    output += '  if failed host {} port {} then restart\n'.format(
+      private_ip, port)
+
+  config_file = os.path.join(MONIT_CONFIG_DIR,
+                             'appscale-{}.cfg'.format(process_name))
+  file_io.write(config_file, output)
 
   return
+
+
+def create_daemon_config(watch, start_cmd, stop_cmd, pidfile, max_memory=None):
+  """ Writes a monit configuration file for a daemonized service.
+
+  Args:
+    watch: A string which identifies this process with monit.
+    start_cmd: A string specifying the command to start the service.
+    stop_cmd: A string specifying the command to stop the service.
+    pidfile: A string specifying the location of the service's pidfile.
+    max_memory: An integer that specifies the maximum amount of memory in
+      megabytes that the process should use.
+  """
+  with open(TEMPLATE_LOCATION) as template:
+    output = template.read()
+    output = output.format(
+      process_name=watch, match_clause='PIDFILE {}'.format(pidfile),
+      group=watch, start_line=start_cmd, stop_line=stop_cmd)
+
+  if max_memory is not None:
+    output += '  if totalmem > {} MB for 10 cycles then restart\n'.format(
+      max_memory)
+
+  config_file = os.path.join(MONIT_CONFIG_DIR, 'appscale-{}.cfg'.format(watch))
+  file_io.write(config_file, output)
+
+
+def create_custom_config(watch, start_cmd, stop_cmd, match_cmd):
+  """ Writes a monit configuration for a service without a pidfile.
+
+  Args:
+    watch: A string which identifies this process with monit.
+    start_cmd: A string specifying the command to start the service.
+    stop_cmd: A string specifying the command to stop the service.
+    match_cmd: The string monit should use to check if the process is running.
+  """
+  with open(TEMPLATE_LOCATION) as template:
+    output = template.read()
+    output = output.format(
+      process_name=watch, match_clause='MATCHING {}'.format(match_cmd),
+      group=watch, start_line=start_cmd, stop_line=stop_cmd)
+
+  config_file = os.path.join(MONIT_CONFIG_DIR, 'appscale-{}.cfg'.format(watch))
+  file_io.write(config_file, output)

--- a/common/appscale/common/templates/monit_template.conf
+++ b/common/appscale/common/templates/monit_template.conf
@@ -1,4 +1,4 @@
-check process {watch}-{port} matching "(^/usr/bin/python |^/usr/bin/python2 )?{match}"
-  group {watch}
-  start program = "/bin/bash -c '{env} {start} >>/var/log/appscale/{watch}-{port}.log 2>&1'"
-  stop program = "{stop}"
+CHECK PROCESS {process_name} {match_clause}
+  group {group}
+  start program = "{start_line}"
+  stop program = "{stop_line}"

--- a/common/appscale/common/templates/monit_template_syslog.conf
+++ b/common/appscale/common/templates/monit_template_syslog.conf
@@ -1,4 +1,0 @@
-check process {watch}-{port} matching "^(/usr/bin/python |/usr/bin/python2)?{match}"
-  group {watch}
-  start program = "/bin/bash -c '{env} {start} 2>&1 | tee -a /var/log/appscale/{watch}-{port}.log | logger -t {watch} -u /tmp/ignored -n {syslog_server} -P 514'"
-  stop program = "{stop}"

--- a/common/test/unit/test_monit_app_configuration.py
+++ b/common/test/unit/test_monit_app_configuration.py
@@ -9,16 +9,10 @@ from appscale.common import monit_app_configuration
 
 class TestGodAppInterface(unittest.TestCase):
   def test_create_config_file(self):
-    flexmock(file_io)\
-      .should_receive('write')\
-      .and_return()
-    temp_file = monit_app_configuration.create_config_file("mywatch",
-                                                     "start_cmd",
-                                                     "stop_cmd",
-                                                     [1,2,3],
-                                                     {'ENV1':"VALUE1",
-                                                      'ENV2':"VALUE2"})
-    self.assertIsNone(temp_file)
-    
+    flexmock(file_io).should_receive('write')
+    monit_app_configuration.create_config_file(
+      'mywatch', 'start_cmd', 'pidfile', 4000,
+      {'ENV1': 'VALUE1', 'ENV2': 'VALUE2'})
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
This matches the changes made to the controller's monit interface, with the exception that the services create their own pidfile.