### PR TITLE
Fix scaling down of instances

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5482,7 +5482,7 @@ HOSTS
       @apps_loaded.each { |app_name|
         @app_info_map[app_name]['appengine'].each { |location|
           host, port = location.split(":")
-          if host == node_ip
+          if host == node.private_ip
             hosted_apps << "#{app_name}:#{port}"
           end
         }

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5519,7 +5519,7 @@ HOSTS
     remove_node_from_local_and_zookeeper(node_to_remove.private_ip)
 
     to_remove = {}
-    @app_info_map.each { |app_id, info|
+    @app_info_map.each { |_, info|
       next if info['appengine'].nil?
 
       info['appengine'].each { |location|

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5369,11 +5369,21 @@ HOSTS
   # on the statistics of the application and the loads of the various
   # services.
   def scale_deployment
+    # Here, we calculate how many more AppServers we need and try to start them.
+    # If we do not have enough capacity to start all of them, we return the number
+    # of more AppServers needed and spawn new machines to accommodate them.
     needed_appservers = scale_appservers
     if needed_appservers > 0
       Djinn.log_debug("Need to start VMs for #{needed_appservers} more AppServers.")
+      scale_up_instances(needed_appservers)
+      return
     end
+  end
 
+  # Adds additional nodes to the deployment, depending on the
+  # statistics of the application and the loads of the various
+  # services.
+  def scale_up_instances(needed_appservers)
     # Here we count the number of machines we need to spawn, and the roles
     # we need.
     vms_to_spawn = 0

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5448,7 +5448,7 @@ HOSTS
     # If we are already at the minimum number of machines that the user specified,
     # then we do not have the capacity to scale down. 
     max_scale_down_capacity = @nodes.length - Integer(@options['min_images'])
-    if max_scale_down_capacity == 0
+    if max_scale_down_capacity <= 0
       Djinn.log_warn("We are already at the minimum number of user specified machines," +
         "so will not be scaling down")
       return
@@ -5465,9 +5465,7 @@ HOSTS
     get_all_appengine_nodes.reverse_each { |node_ip|
       # If we have already scaled down to our maximum capacity
       # then return.
-      if num_scaled_down == max_scale_down_capacity
-        return
-      end 
+      break if num_scaled_down == max_scale_down_capacity
       
       hosted_apps = []
       @apps_loaded.each { |app_name|

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5381,9 +5381,11 @@ HOSTS
     scale_down_instances
   end
 
-  # Adds additional nodes to the deployment, depending on the
-  # statistics of the application and the loads of the various
-  # services.
+  # Adds additional nodes to the deployment, depending on the load of the 
+  # application and the additional AppServers we need to accomodate.
+  #
+  # Args:
+  #   needed_appservers: The number of additional AppServers needed.
   def scale_up_instances(needed_appservers)
     # Here we count the number of machines we need to spawn, and the roles
     # we need.
@@ -5441,10 +5443,6 @@ HOSTS
   # Removes autoscaled nodes from the deployment as long as they are not running
   # any AppServers and the minimum number of user specified machines are still
   # running in the deployment.
-  #
-  # Args:
-  #   max_scale_down_capacity: A Integer containing the maximum number of
-  #     instances we can scale down for this deployment.
   def scale_down_instances
 
     Djinn.log_warn("APPS LOADED #{@apps_loaded}")

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5489,7 +5489,7 @@ HOSTS
       }
       
       unless hosted_apps.empty?
-        Djinn.log_debug("The node #{node_ip} has these AppServers " +
+        Djinn.log_debug("The node #{node.private_ip} has these AppServers " +
         "running: #{hosted_apps}")
         next
       end

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5487,6 +5487,9 @@ HOSTS
         next
       end
 
+      # Right now, only the autoscaled machines are started with just the 
+      # appengine role, so we check specifically for that during downscaling
+      # to make sure we only downscale the new machines added.
       node_to_remove = nil
       @nodes.each{ |node|
         if node.private_ip == node_ip && node.jobs == ['appengine']

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5504,7 +5504,7 @@ HOSTS
 
     if total_req_in_queue.zero?
       if Time.now.to_i - @last_decision[app_name] < SCALEDOWN_THRESHOLD * DUTY_CYCLE
-        Djinn.log_debug("Not enough time as passed to scale down app #{app_name}")
+        Djinn.log_debug("Not enough time has passed to scale down app #{app_name}")
         return 0
       end
       Djinn.log_debug("No requests are enqueued for app #{app_name} - " +
@@ -5514,7 +5514,7 @@ HOSTS
 
     if total_req_in_queue > SCALEUP_QUEUE_SIZE_THRESHOLD
       if Time.now.to_i - @last_decision[app_name] < SCALEUP_THRESHOLD * DUTY_CYCLE
-        Djinn.log_debug("Not enough time as passed to scale up app #{app_name}")
+        Djinn.log_debug("Not enough time has passed to scale up app #{app_name}")
         return 0
       end
       Djinn.log_debug("#{total_req_in_queue} requests are enqueued for app " +

--- a/AppController/lib/infrastructure_manager_client.rb
+++ b/AppController/lib/infrastructure_manager_client.rb
@@ -167,6 +167,7 @@ class InfrastructureManagerClient
     end
     parameters['instance_ids'] = instance_ids
     parameters['region'] = options['region']
+    parameters['IS_VERBOSE'] = options['verbose']
 
     terminate_result = make_call(NO_TIMEOUT, RETRY_ON_FAIL,
       "terminate_instances") {


### PR DESCRIPTION
This PR allows downscaling of instances to be evaluated every duty cycle, where we go through a list of added appengine nodes (in reverse), and terminate only autoscaled appengine nodes which are not currently running any AppServers.