### PR TITLE
Fix images stub to work with newer pillow

### DIFF
--- a/AppServer/google/appengine/api/images/images_stub.py
+++ b/AppServer/google/appengine/api/images/images_stub.py
@@ -586,7 +586,7 @@ class ImagesServiceStub(apiproxy_stub.APIProxyStub):
 
 
     degrees = 360 - degrees
-    return image.rotate(degrees)
+    return image.rotate(degrees, expand=True)
 
   def _Crop(self, image, transform):
     """Use PIL to crop the given image with the given transform.


### PR DESCRIPTION
In newer versions of pillow, rotating by 90 degrees does not change the dimensions of the image. However, the dimensions do change in App Engine.