### PR TITLE
Relocate versions without restarting AppServers

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -778,10 +778,6 @@ class Djinn
     # Notify nodes, and remove any running AppServer of the application.
     notify_restart_app_to_nodes([appid])
 
-    # Once we've relocated the app, we need to tell the XMPPReceiver about the
-    # app's new location.
-    MonitInterface.restart("xmpp-#{appid}")
-
     return "OK"
   end
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -775,9 +775,6 @@ class Djinn
       return
     end
 
-    # Notify nodes, and remove any running AppServer of the application.
-    notify_restart_app_to_nodes([appid])
-
     return "OK"
   end
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -775,6 +775,10 @@ class Djinn
       return
     end
 
+    CronHelper.update_cron(
+      get_load_balancer.public_ip, http_port, @app_info_map[appid]['language'],
+      appid)
+
     return "OK"
   end
 

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -3143,9 +3143,9 @@ class DatastoreDistributed():
       task_ops: A list of tasks.
     """
     if app not in self.taskqueue_stubs:
-      # The host and port are used only for generating URLs, which have already
-      # been generated for the tasks.
-      self.taskqueue_stubs[app] = TaskQueueServiceStub(app, '', '')
+      # The host is used only for generating URLs, which have already been
+      # generated for the tasks.
+      self.taskqueue_stubs[app] = TaskQueueServiceStub(app, '')
 
     bulk_request = taskqueue_service_pb.TaskQueueBulkAddRequest()
     bulk_response = taskqueue_service_pb.TaskQueueBulkAddResponse()

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -728,7 +728,6 @@ def create_java_start_cmd(app_name, port, load_balancer_host, max_heap,
     "--appscale_version=1",
     "--APP_NAME=" + app_name,
     "--NGINX_ADDRESS=" + load_balancer_host,
-    "--NGINX_PORT=anything",
     "--TQ_PROXY=" + tq_proxy,
     "--pidfile={}".format(pidfile),
     os.path.dirname(locate_dir("/var/apps/" + app_name + "/app/", "WEB-INF"))

--- a/AppServer/google/appengine/api/images/images_blob_stub.py
+++ b/AppServer/google/appengine/api/images/images_blob_stub.py
@@ -45,7 +45,7 @@ class ImagesBlobStub(object):
     """Stub implementation of blob-related parts of the images API.
 
     Args:
-      host_prefix: the URL prefix (protocol://host) to preprend to image urls
+      host_prefix: the URL prefix (protocol://host) to prepend to image urls
         on a call to GetUrlBase.
     """
     self._host_prefix = host_prefix

--- a/AppServer/google/appengine/api/images/images_stub.py
+++ b/AppServer/google/appengine/api/images/images_stub.py
@@ -145,8 +145,8 @@ class ImagesServiceStub(apiproxy_stub.APIProxyStub):
 
     Args:
       service_name: Service name expected for all calls.
-      host_prefix: the URL prefix (protocol://host:port) to preprend to
-        image urls on a call to GetUrlBase.
+      host_prefix: the URL prefix (protocol://host) to preprend to image urls
+        on a call to GetUrlBase.
     """
     super(ImagesServiceStub, self).__init__(service_name,
                                             max_request_size=MAX_REQUEST_SIZE)

--- a/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
+++ b/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
@@ -220,8 +220,7 @@ class TaskQueueServiceStub(apiproxy_stub.APIProxyStub):
       return response
 
     port_file_location = os.path.join(
-      '/', 'etc', 'appscale',
-      'port-{}.txt'.format(os.environ['APPLICATION_ID']))
+      '/', 'etc', 'appscale', 'port-{}.txt'.format(self.__app_id))
     with open(port_file_location) as port_file:
       port = port_file.read().strip()
 

--- a/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
+++ b/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
@@ -86,20 +86,18 @@ class TaskQueueServiceStub(apiproxy_stub.APIProxyStub):
   """
   _ACCEPTS_REQUEST_ID = True
 
-  def __init__(self, app_id, host, port, service_name='taskqueue'):
+  def __init__(self, app_id, host, service_name='taskqueue'):
     """Constructor.
 
     Args:
       app_id: The application ID.
       host: The nginx host.
-      port: The nginx port.
       service_name: Service name expected for all calls.
     """
     super(TaskQueueServiceStub, self).__init__(
         service_name, max_request_size=MAX_REQUEST_SIZE)
     self.__app_id = app_id
     self.__nginx_host = host
-    self.__nginx_port = port
 
   def _GetTQLocations(self):
     """ Gets a list of TaskQueue proxies. """
@@ -221,10 +219,16 @@ class TaskQueueServiceStub(apiproxy_stub.APIProxyStub):
       self._AddTransactionalBulkTask(request, response)
       return response
 
+    port_file_location = os.path.join(
+      '/', 'etc', 'appscale',
+      'port-{}.txt'.format(os.environ['APPLICATION_ID']))
+    with open(port_file_location) as port_file:
+      port = port_file.read().strip()
+
     for add_request in request.add_request_list():
       add_request.set_app_id(self.__app_id)
       url = add_request.url()
-      url = "http://" + self.__nginx_host + ":" + str(self.__nginx_port) + url
+      url = "http://" + self.__nginx_host + ":" + port + url
       add_request.set_url(url)
 
     self._RemoteSend(request, response, "BulkAdd", request_id)

--- a/AppServer/google/appengine/api/taskqueue/test/test_taskqueue_distributed.py
+++ b/AppServer/google/appengine/api/taskqueue/test/test_taskqueue_distributed.py
@@ -114,6 +114,8 @@ class TestTaskqueueDistributed(unittest.TestCase):
     self.assertEquals(None, tqd._Dynamic_Add(FakeAddRequest(), FakeAddResponse()))
 
   def test_dynamic_bulkadd(self):
+    app_id = 'app_id'
+
     tqd = flexmock(taskqueue_distributed.TaskQueueServiceStub)
     flexmock(taskqueue_service_pb) 
     taskqueue_service_pb.should_receive("TaskQueueBulkAddRequest").\
@@ -122,8 +124,13 @@ class TestTaskqueueDistributed(unittest.TestCase):
       and_return(FakeBulkAddResponse())
     tqd.should_receive("_GetTQLocations").and_return(["some_location"])
     tqd.should_receive("_RemoteSend").and_return()
-    tqd = taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname")
-     
+    tqd = taskqueue_distributed.TaskQueueServiceStub(app_id, "hostname")
+
+    port_file = os.path.join(
+      '/', 'etc', 'appscale', 'port-{}.txt'.format(app_id))
+    flexmock(sys.modules['__builtin__']).should_receive('open').\
+      with_args(port_file).and_return(flexmock(read=lambda: '80'))
+
     self.assertEquals(None, tqd._Dynamic_BulkAdd(FakeBulkAddRequest(), None))
 
   def test_add_transactional_bulk_task(self):

--- a/AppServer/google/appengine/api/taskqueue/test/test_taskqueue_distributed.py
+++ b/AppServer/google/appengine/api/taskqueue/test/test_taskqueue_distributed.py
@@ -97,7 +97,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
     """ Test the constructor. """
     tqd = flexmock(taskqueue_distributed.TaskQueueServiceStub)
     tqd.should_receive("_GetTQLocations").and_return(["some_location"])
-    taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname", 12345)
+    taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname")
 
   def test_dynamic_add(self):
     flexmock(taskqueue_service_pb)
@@ -110,7 +110,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
     tqd.should_receive("_RemoteSend").and_return()
     tqd.should_receive("_Dynamic_BulkAdd").and_return()
 
-    tqd = taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname", 12345)
+    tqd = taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname")
     self.assertEquals(None, tqd._Dynamic_Add(FakeAddRequest(), FakeAddResponse()))
 
   def test_dynamic_bulkadd(self):
@@ -122,7 +122,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
       and_return(FakeBulkAddResponse())
     tqd.should_receive("_GetTQLocations").and_return(["some_location"])
     tqd.should_receive("_RemoteSend").and_return()
-    tqd = taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname", 12345)
+    tqd = taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname")
      
     self.assertEquals(None, tqd._Dynamic_BulkAdd(FakeBulkAddRequest(), None))
 
@@ -132,7 +132,7 @@ class TestTaskqueueDistributed(unittest.TestCase):
     tqd.should_receive("_RemoteSend").and_return()
     flexmock(apiproxy_stub_map)
     apiproxy_stub_map.should_receive("MakeSyncCall")
-    tqd = taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname", 12345)
+    tqd = taskqueue_distributed.TaskQueueServiceStub("app_id", "hostname")
     response = FakeBulkAddResponse() 
     self.assertEquals(response, tqd._AddTransactionalBulkTask(FakeBulkAddRequest(),
       response))

--- a/AppServer/google/appengine/tools/dev_appserver.py
+++ b/AppServer/google/appengine/tools/dev_appserver.py
@@ -3514,7 +3514,6 @@ def SetupStubs(app_id, **config):
 
   # AppScale 
   # Set the port and server to the Nginx proxy.
-  serve_port = int(config.get('NGINX_PORT', 8080))
   serve_address = config.get('NGINX_HOST', 'localhost')
   xmpp_path = config['xmpp_path']
   uaserver_path = config['uaserver_path']
@@ -3577,7 +3576,7 @@ def SetupStubs(app_id, **config):
   hash_secret = hashlib.sha1(app_id + '/'+ cookie_secret).hexdigest()
   apiproxy_stub_map.apiproxy.RegisterStub(
       'taskqueue',
-      taskqueue_distributed.TaskQueueServiceStub(app_id, serve_address, serve_port))
+      taskqueue_distributed.TaskQueueServiceStub(app_id, serve_address))
 
   apiproxy_stub_map.apiproxy.RegisterStub(
       'urlfetch',

--- a/AppServer/google/appengine/tools/dev_appserver.py
+++ b/AppServer/google/appengine/tools/dev_appserver.py
@@ -3636,7 +3636,7 @@ def SetupStubs(app_id, **config):
 
   try:
     from google.appengine.api.images import images_stub
-    host_prefix = 'http://%s:%d' % (serve_address, serve_port)
+    host_prefix = 'http://{}'.format(serve_address)
     apiproxy_stub_map.apiproxy.RegisterStub(
         'images',
         images_stub.ImagesServiceStub(host_prefix=host_prefix))

--- a/AppServer/google/appengine/tools/dev_appserver.py
+++ b/AppServer/google/appengine/tools/dev_appserver.py
@@ -182,7 +182,6 @@ DEFAULT_ENV = {
     'COOKIE_SECRET': 'secret',
     'LOGIN_SERVER': '0.0.0.0',
     'NGINX_HOST': '0.0.0.0',
-    'NGINX_PORT': '0',
 }
 
 

--- a/AppServer/google/appengine/tools/dev_appserver_login.py
+++ b/AppServer/google/appengine/tools/dev_appserver_login.py
@@ -153,7 +153,12 @@ def LoginRedirect(login_url,
     outfile: File-like object to which the response should be written.
   """
   hostname = os.environ['NGINX_HOST']
-  port = os.environ['NGINX_PORT']
+
+  port_file_location = os.path.join(
+    '/', 'etc', 'appscale', 'port-{}.txt'.format(os.environ['APPLICATION_ID']))
+  with open(port_file_location) as port_file:
+    port = port_file.read().strip()
+
   dest_url = "http://%s:%s%s" % (hostname, port, relative_url)
   redirect_url = 'http://%s:%s%s?%s=%s' % (hostname,
                                            port,
@@ -197,12 +202,13 @@ def main():
   LOGIN_SERVER = os.environ['LOGIN_SERVER']
 
   nginx_url = os.environ['NGINX_HOST']
-  nginx_port = os.environ['NGINX_PORT']
-  ah_login_url = 'http://' + nginx_url + ":" + nginx_port + ah_path
 
-  host = 'https://'+os.environ['SERVER_NAME']
-  if os.environ['SERVER_PORT'] != '80':
-    host = host + ":" + os.environ['SERVER_PORT']
+  port_file_location = os.path.join(
+    '/', 'etc', 'appscale', 'port-{}.txt'.format(os.environ['APPLICATION_ID']))
+  with open(port_file_location) as port_file:
+    nginx_port = port_file.read().strip()
+
+  ah_login_url = 'http://' + nginx_url + ":" + nginx_port + ah_path
 
   action = form.getfirst(ACTION_PARAM)
 

--- a/AppServer/google/appengine/tools/dev_appserver_main.py
+++ b/AppServer/google/appengine/tools/dev_appserver_main.py
@@ -569,21 +569,6 @@ def ParseArguments(argv):
                          option_dict[ARG_ADDRESS] == DEFAULT_ARGS[ARG_ADDRESS])
   return args, option_dict
 
-def get_nginx_port(appid):
-  """ An AppScale-specific method that callers can use to find out what port
-  Task Queue API calls should be routed through.
-
-  Args:
-    appid: A str that names this application.
-  Returns:
-    A str that names the port that is used by nginx as a reverse proxy to this
-    app.
-  """
-  filename = "/etc/appscale/port-" + appid + ".txt"
-  file_handle = open(filename)
-  port = file_handle.read()
-  file_handle.close()
-  return port
 
 def _ParsePort(port, description):
   """Parses a port number from a string.
@@ -718,12 +703,6 @@ def main(argv):
   static_caching = option_dict[ARG_STATIC_CACHING]
   skip_sdk_update_check = option_dict[ARG_SKIP_SDK_UPDATE_CHECK]
   interactive_console = option_dict[ARG_CONSOLE]
-
-  nginx_port = get_nginx_port(appinfo.application)
-  os.environ['NGINX_PORT'] = nginx_port
-  option_dict['NGINX_PORT'] = nginx_port
-  dev_appserver.DEFAULT_ENV["NGINX_PORT"] = nginx_port
-  logging.info("Setting nginx port to " + str(nginx_port))
 
   if (option_dict[ARG_ADMIN_CONSOLE_SERVER] != '' and
       not dev_process.IsSubprocess()):

--- a/AppServer/google/appengine/tools/devappserver2/api_server.py
+++ b/AppServer/google/appengine/tools/devappserver2/api_server.py
@@ -328,7 +328,6 @@ def setup_stubs(
       file_service_stub.FileServiceStub(blob_storage))
 
   serve_address = os.environ['NGINX_HOST']
-  serve_port = int(os.environ['NGINX_PORT'])
   try:
     from google.appengine.api.images import images_stub
   except ImportError:
@@ -382,8 +381,7 @@ def setup_stubs(
 
   apiproxy_stub_map.apiproxy.RegisterStub(
       'taskqueue',
-      taskqueue_distributed.TaskQueueServiceStub(app_id, serve_address,
-      serve_port))
+      taskqueue_distributed.TaskQueueServiceStub(app_id, serve_address))
 
   urlmatchers_to_fetch_functions = []
   urlmatchers_to_fetch_functions.extend(

--- a/AppServer/google/appengine/tools/devappserver2/api_server.py
+++ b/AppServer/google/appengine/tools/devappserver2/api_server.py
@@ -342,7 +342,7 @@ def setup_stubs(
         images_not_implemented_stub.ImagesNotImplementedServiceStub(
             host_prefix=images_host_prefix))
   else:
-    host_prefix = 'http://{0}:{1}'.format(serve_address, serve_port)
+    host_prefix = 'http://{}'.format(serve_address)
     apiproxy_stub_map.apiproxy.RegisterStub(
         'images',
         images_stub.ImagesServiceStub(host_prefix=host_prefix))

--- a/AppServer/google/appengine/tools/devappserver2/devappserver2.py
+++ b/AppServer/google/appengine/tools/devappserver2/devappserver2.py
@@ -510,14 +510,6 @@ def _setup_environ(app_id):
   """
   os.environ['APPLICATION_ID'] = app_id
 
-  # In AppScale, we need to know what port nginx binds to when sending traffic
-  # to this app. Since we need to know the appid to know what port we're on,
-  # this is a good place to set that value.
-  filename = "/etc/appscale/port-{0}.txt".format(app_id)
-  with open(filename) as file_handle:
-    port = file_handle.read()
-    os.environ['NGINX_PORT'] = port
-
 
 class DevelopmentServer(object):
   """Encapsulates the logic for the development server.

--- a/AppServer/google/appengine/tools/devappserver2/server.py
+++ b/AppServer/google/appengine/tools/devappserver2/server.py
@@ -521,11 +521,19 @@ class Server(object):
     Returns:
       An iterable over strings containing the body of the HTTP response.
     """
-    environ['SERVER_PORT'] = os.environ['NGINX_PORT']
+    try:
+      environ['SERVER_PORT'] = environ['HTTP_HOST'].split(':')[1]
+    except IndexError:
+      scheme = environ['HTTP_X_FORWARDED_PROTO']
+      if scheme == 'http':
+        environ['SERVER_PORT'] = 80
+      else:
+        environ['SERVER_PORT'] = 443
+
     if 'HTTP_HOST' in environ:
       environ['SERVER_NAME'] = environ['HTTP_HOST'].split(':', 1)[0]
     environ['DEFAULT_VERSION_HOSTNAME'] = '%s:%s' % (
-        environ['SERVER_NAME'], os.environ['NGINX_PORT'])
+        environ['SERVER_NAME'], environ['SERVER_PORT'])
     with self._request_data.request(
         environ,
         self._server_configuration) as request_id:

--- a/AppServer/run_tests.py
+++ b/AppServer/run_tests.py
@@ -51,7 +51,6 @@ def main():
   os.environ['COOKIE_SECRET'] = 'secret'
   os.environ['MY_PORT'] = '8080'
   os.environ['NGINX_HOST'] = 'localhost'
-  os.environ['NGINX_PORT'] = '8080'
 
   sys.path.extend(TEST_LIBRARY_PATHS)
 

--- a/AppServer_Java/src/com/google/appengine/api/blobstore/dev/BlobUploadSessionStorage.java
+++ b/AppServer_Java/src/com/google/appengine/api/blobstore/dev/BlobUploadSessionStorage.java
@@ -12,6 +12,7 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.users.User;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.tools.resources.ResourceLoader;
 
 
 public final class BlobUploadSessionStorage
@@ -51,7 +52,8 @@ public final class BlobUploadSessionStorage
          * AppScale - added NGINX success path to entity
          */
 
-        String path = "http://" + System.getProperty("NGINX_ADDR") + ":" + System.getProperty("NGINX_PORT") + session.getSuccessPath();
+        String nginxPort = ResourceLoader.getNginxPort();
+        String path = "http://" + System.getProperty("NGINX_ADDR") + ":" + nginxPort + session.getSuccessPath();
         logger.fine("success path has been set as [" + path + "]");
         entity.setProperty(SUCCESS_PATH, path);
         entity.setProperty("creation", time);

--- a/AppServer_Java/src/com/google/appengine/api/blobstore/dev/LocalBlobstoreService.java
+++ b/AppServer_Java/src/com/google/appengine/api/blobstore/dev/LocalBlobstoreService.java
@@ -25,6 +25,7 @@ import com.google.appengine.tools.development.AbstractLocalRpcService;
 import com.google.appengine.tools.development.LocalRpcService;
 import com.google.appengine.tools.development.LocalServiceContext;
 import com.google.appengine.tools.development.ServiceProvider;
+import com.google.appengine.tools.resources.ResourceLoader;
 import com.google.apphosting.api.ApiBasePb;
 import com.google.apphosting.api.ApiProxy;
 import com.google.appengine.repackaged.com.google.common.io.BaseEncoding;
@@ -103,7 +104,8 @@ public final class LocalBlobstoreService extends AbstractLocalRpcService
          * AppScale - changed upload URL to NGINX address and port
          */
         BlobstoreServicePb.CreateUploadURLResponse response = new BlobstoreServicePb.CreateUploadURLResponse();
-        String url = "http://" + System.getProperty("NGINX_ADDR") + ":" + System.getProperty("NGINX_PORT") + "/" + "_ah/upload/" + System.getProperty("APPLICATION_ID") + "/" + sessionId;
+        String nginxPort = ResourceLoader.getNginxPort();
+        String url = "http://" + System.getProperty("NGINX_ADDR") + ":" + nginxPort + "/" + "_ah/upload/" + System.getProperty("APPLICATION_ID") + "/" + sessionId;
         logger.fine("UploadURL set to [" + url + "]");
         response.setUrl(url);
 

--- a/AppServer_Java/src/com/google/appengine/api/datastore/dev/LocalDatastoreService.java
+++ b/AppServer_Java/src/com/google/appengine/api/datastore/dev/LocalDatastoreService.java
@@ -726,6 +726,8 @@ public final class LocalDatastoreService extends AbstractLocalRpcService
             return;
         }
 
+        String nginxPort = ResourceLoader.getNginxPort();
+
         String app = request.addRequests().get(0).getTransaction().getApp();
         TaskQueuePb.TaskQueueBulkAddRequest bulkAddRequest = request.clone();
         TaskQueuePb.TaskQueueBulkAddResponse bulkAddResponse = new TaskQueuePb.TaskQueueBulkAddResponse();
@@ -734,7 +736,6 @@ public final class LocalDatastoreService extends AbstractLocalRpcService
         for (TaskQueuePb.TaskQueueAddRequest addRequest : bulkAddRequest.addRequests())
         {
             String nginxHost = System.getProperty("NGINX_ADDR");
-            String nginxPort = System.getProperty("NGINX_PORT");
             String fullTaskPath = "http://" + nginxHost + ":" + nginxPort + addRequest.getUrl();
             addRequest.setUrl(fullTaskPath);
             addRequest.setAppId(app);

--- a/AppServer_Java/src/com/google/appengine/api/taskqueue/dev/AppScaleTaskQueueClient.java
+++ b/AppServer_Java/src/com/google/appengine/api/taskqueue/dev/AppScaleTaskQueueClient.java
@@ -10,6 +10,7 @@ import java.io.FileReader;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
+import com.google.appengine.tools.resources.ResourceLoader;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -61,9 +62,11 @@ public class AppScaleTaskQueueClient {
     }
 
     public TaskQueuePb.TaskQueueAddResponse add(TaskQueuePb.TaskQueueAddRequest addRequest) {
+        String nginxPort = ResourceLoader.getNginxPort();
+
         addRequest.setAppId(getAppId());
         String taskPath = addRequest.getUrl();
-        String appScaleTaskPath = "http://" + getNginxHost() + ":" + getNginxPort() + taskPath;
+        String appScaleTaskPath = "http://" + getNginxHost() + ":" + nginxPort + taskPath;
         addRequest.setUrl(appScaleTaskPath);
         Request request = new Request();
         request.setMethod("Add");
@@ -185,11 +188,6 @@ public class AppScaleTaskQueueClient {
     private String getNginxHost() {
         String nginxHost = System.getProperty("NGINX_ADDR");
         return nginxHost;
-    }
-
-    private String getNginxPort() {
-        String nginxPort = System.getProperty("NGINX_PORT");
-        return nginxPort;
     }
 
     private String getAppId() {

--- a/AppServer_Java/src/com/google/appengine/api/users/dev/LocalLoginServlet.java
+++ b/AppServer_Java/src/com/google/appengine/api/users/dev/LocalLoginServlet.java
@@ -17,7 +17,6 @@ public final class LocalLoginServlet extends HttpServlet
     private static final String LOGIN_SERVER        = System.getProperty("LOGIN_SERVER");
     private static final String CONTINUE_PARAM      = "continue";
     private static final String NGINX_ADDR_PROPERTY = "NGINX_ADDR";
-    private static final String NGINX_PORT_PROPERTY = "NGINX_PORT";
     private static final String PATH_INFO_PROPERTY  = "PATH_INFO";
     private final String DASHBOARD_HTTPS_PORT = "1443";
 

--- a/AppServer_Java/src/com/google/appengine/api/users/dev/LocalUserService.java
+++ b/AppServer_Java/src/com/google/appengine/api/users/dev/LocalUserService.java
@@ -9,6 +9,7 @@ import com.google.appengine.tools.development.AbstractLocalRpcService;
 import com.google.appengine.tools.development.LocalRpcService;
 import com.google.appengine.tools.development.LocalServiceContext;
 import com.google.appengine.tools.development.ServiceProvider;
+import com.google.appengine.tools.resources.ResourceLoader;
 import com.google.apphosting.api.UserServicePb;
 
 
@@ -33,7 +34,6 @@ public final class LocalUserService extends AbstractLocalRpcService
     private String oauthAuthDomain = "gmail.com";
     private boolean oauthIsAdmin = false;
     private final String NGINX_ADDR = "NGINX_ADDR";
-    private final String NGINX_PORT = "NGINX_PORT";
     private final String DASHBOARD_HTTPS_PORT = "1443";
 
     public UserServicePb.CreateLoginURLResponse createLoginURL( LocalRpcService.Status status, UserServicePb.CreateLoginURLRequest request )
@@ -42,7 +42,8 @@ public final class LocalUserService extends AbstractLocalRpcService
         String destinationUrl = request.getDestinationUrl();
         if(destinationUrl != null && destinationUrl.startsWith("/"))
         {
-            destinationUrl = "http://" + System.getProperty(NGINX_ADDR) + ":" + System.getProperty(NGINX_PORT) + destinationUrl;
+            String nginxPort = ResourceLoader.getNginxPort();
+            destinationUrl = "http://" + System.getProperty(NGINX_ADDR) + ":" + nginxPort + destinationUrl;
         }
          
         response.setLoginUrl(LOGIN_URL + "?continue=" + encode(destinationUrl));
@@ -52,7 +53,8 @@ public final class LocalUserService extends AbstractLocalRpcService
     public UserServicePb.CreateLogoutURLResponse createLogoutURL( LocalRpcService.Status status, UserServicePb.CreateLogoutURLRequest request )
     {
         UserServicePb.CreateLogoutURLResponse response = new UserServicePb.CreateLogoutURLResponse();
-        String redirect_url = "https://" + LOGIN_SERVER + ":" + DASHBOARD_HTTPS_PORT + "/logout?continue=http://" + LOGIN_SERVER + ":" + getAppPort();
+        String nginxPort = ResourceLoader.getNginxPort();
+        String redirect_url = "https://" + LOGIN_SERVER + ":" + DASHBOARD_HTTPS_PORT + "/logout?continue=http://" + LOGIN_SERVER + ":" + nginxPort;
         response.setLogoutUrl(redirect_url);
 
         return response;
@@ -120,10 +122,5 @@ public final class LocalUserService extends AbstractLocalRpcService
         {
             throw new RuntimeException("Could not find UTF-8 encoding", ex);
         }
-    }
-
-    private String getAppPort()
-    {
-        return System.getProperty(NGINX_PORT);
     }
 }

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
@@ -230,12 +230,6 @@ public class DevAppServerMain
             {
                 System.setProperty("NGINX_ADDR", getValue());
             }
-        }, new DevAppServerOption(main, null, "NGINX_PORT", false)
-        {
-            public void apply()
-            {
-                System.setProperty("NGINX_PORT", getNginxPort());
-            }
         }, new DevAppServerOption(main, null, "TQ_PROXY", false)
         {
             public void apply()
@@ -272,35 +266,6 @@ public class DevAppServerMain
 
     private static void reportBadInstancePortValue(String optionValue) {
         throw new IllegalArgumentException("Invalid instance_port value " + optionValue);
-    }
-
-    private static String getNginxPort()
-    {
-        String appName = System.getProperty("APP_NAME");
-        String portString = null;
-        BufferedReader bufferReader = null;
-        try
-        {
-            bufferReader = new BufferedReader(new FileReader(PORT_FILE_PREFIX + appName + ".txt"));
-            portString = bufferReader.readLine();
-        }
-        catch(IOException e)
-        {
-            System.out.println("IOException getting port from " + PORT_FILE_PREFIX + appName + ".txt");
-            e.printStackTrace(); 
-        }        
-        finally
-        {
-            try
-            {
-                if (bufferReader != null) bufferReader.close();
-            } 
-            catch (IOException ex)
-            {
-                ex.printStackTrace();
-            }
-        }
-        return portString; 
     }
 
     private static List<Option> buildOptions( DevAppServerMain main )

--- a/AppServer_Java/src/com/google/appengine/tools/resources/ResourceLoader.java
+++ b/AppServer_Java/src/com/google/appengine/tools/resources/ResourceLoader.java
@@ -1,6 +1,11 @@
 package com.google.appengine.tools.resources;
 
 
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+
 public class ResourceLoader
 {
 
@@ -58,5 +63,28 @@ public class ResourceLoader
     public String getMrTmpLocation()
     {
         return TMP_LOCATION;
+    }
+
+    public static String getNginxPort()
+    {
+        String portFileLocation = "/etc/appscale/port-" + System.getProperty("APP_NAME") + ".txt";
+        BufferedReader br;
+        try {
+            br = new BufferedReader(new FileReader(portFileLocation));
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(portFileLocation + " does not exist");
+        }
+
+        try {
+            return br.readLine();
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading from " + portFileLocation);
+        } finally {
+            try {
+                br.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/XMPPReceiver/xmpp_receiver.py
+++ b/XMPPReceiver/xmpp_receiver.py
@@ -11,6 +11,7 @@
 # General-purpose Python libraries
 import httplib
 import logging
+import os
 import select
 import sys
 import urllib
@@ -60,9 +61,6 @@ class XMPPReceiver():
     self.login_ip = login_ip
     self.app_password = app_password
 
-    with open("/etc/appscale/port-{0}.txt".format(self.appid)) as file_handle:
-      self.app_port = int(file_handle.read().strip())
-
     self.my_jid = self.appid + "@" + self.login_ip
     log_file = "/var/log/appscale/xmppreceiver-{0}.log".format(self.my_jid)
     sys.stderr = open(log_file, 'a')
@@ -91,10 +89,15 @@ class XMPPReceiver():
     params['body'] = event.getBody()
     encoded_params = urllib.urlencode(params)
 
+    port_file_location = os.path.join(
+      '/', 'etc', 'appscale', 'port-{}.txt'.format(self.appid))
+    with open(port_file_location) as port_file:
+      app_port = int(port_file.read().strip())
+
     try:
       logging.debug("Attempting to open connection to {0}:{1}".format(
-        self.login_ip, self.app_port))
-      connection = httplib.HTTPConnection(self.login_ip, self.app_port)
+        self.login_ip, app_port))
+      connection = httplib.HTTPConnection(self.login_ip, app_port)
       connection.request('POST', '/_ah/xmpp/message/chat/', encoded_params,
         self.HEADERS)
       response = connection.getresponse()


### PR DESCRIPTION
This allows relocates to complete without downtime. It also simplifies the administrative work required for a relocate.