### PR TITLE
Determine pidfile location from RabbitMQ version

### DIFF
--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -70,7 +70,7 @@ module MonitInterface
   # background process, and it should create its own pidfile.
   def self.start_daemon(watch, start_cmd, stop_cmd, pidfile)
     config = <<CONFIG
-CHECK PROCESS #{watch} PIDFILE #{pidfile}
+CHECK PROCESS #{watch} PIDFILE "#{pidfile}"
   group #{watch}
   start program = "#{start_cmd}"
   stop program = "#{stop_cmd}"
@@ -179,7 +179,7 @@ CONFIG
                "#{rm} #{pidfile}"
 
     contents = <<BOO
-CHECK PROCESS #{process_name} PIDFILE #{pidfile}
+CHECK PROCESS #{process_name} PIDFILE "#{pidfile}"
   group #{group}
   start program = "#{start_stop_daemon} #{start_args.join(' ')}"
   stop program = "#{bash} -c '#{stop_cmd}'"

--- a/common/appscale/common/monit_app_configuration.py
+++ b/common/appscale/common/monit_app_configuration.py
@@ -74,7 +74,7 @@ def create_config_file(watch, start_cmd, pidfile, port=None, env_vars=None,
   with open(TEMPLATE_LOCATION) as template:
     output = template.read()
     output = output.format(
-      process_name=process_name, match_clause='PIDFILE {}'.format(pidfile),
+      process_name=process_name, match_clause='PIDFILE "{}"'.format(pidfile),
       group=watch, start_line=start_line, stop_line=stop_line)
 
   if max_memory is not None:
@@ -107,7 +107,7 @@ def create_daemon_config(watch, start_cmd, stop_cmd, pidfile, max_memory=None):
   with open(TEMPLATE_LOCATION) as template:
     output = template.read()
     output = output.format(
-      process_name=watch, match_clause='PIDFILE {}'.format(pidfile),
+      process_name=watch, match_clause='PIDFILE "{}"'.format(pidfile),
       group=watch, start_line=start_cmd, stop_line=stop_cmd)
 
   if max_memory is not None:


### PR DESCRIPTION
Xenial's RabbitMQ uses a different pidfile location.