### PR TITLE
Use eventlet pool for Celery workers

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/push_worker.py
+++ b/AppTaskQueue/appscale/taskqueue/push_worker.py
@@ -1,6 +1,5 @@
 """ A Celery worker script that executes push tasks with HTTP requests. """
 import datetime
-import httplib
 import json
 import logging
 import os
@@ -10,6 +9,7 @@ from appscale.common import appscale_info
 from appscale.common import constants
 from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
 from celery.utils.log import get_task_logger
+from eventlet.green import httplib
 from httplib import BadStatusLine
 from socket import error as SocketError
 from urlparse import urlparse

--- a/AppTaskQueue/appscale/taskqueue/tq_config.py
+++ b/AppTaskQueue/appscale/taskqueue/tq_config.py
@@ -30,11 +30,8 @@ from google.appengine.runtime import apiproxy_errors
 class TaskQueueConfig():
   """ Contains configuration of the TaskQueue system. """
 
-  # Min concurrency per worker.
-  MIN_CELERY_CONCURRENCY = 2
-
-  # Max concurrency per worker.
-  MAX_CELERY_CONCURRENCY = 20
+  # The number of tasks the Celery worker can handle at a time.
+  CELERY_CONCURRENCY = 1000
 
   # The default YAML used if a queue.yaml or queue.xml is not supplied.
   DEFAULT_QUEUE_YAML = """

--- a/AppTaskQueue/setup.py
+++ b/AppTaskQueue/setup.py
@@ -14,6 +14,7 @@ setup(
     'appscale-common',
     'cassandra-driver',
     'celery>=3.1,<4.0.0',
+    'eventlet',
     'PyYaml',
     'tornado==4.2.0'
   ],


### PR DESCRIPTION
This makes the celery worker more efficient in memory usage, and it allows a higher concurrency (20 -> 1000).

This is a continuation from https://github.com/AppScale/appscale/pull/2387.