### PR TITLE
Store version details in ZooKeeper

### DIFF
--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -351,7 +351,8 @@ class VersionsHandler(BaseHandler):
 
     Args:
       project_id: A string specifying a project ID.
-      source_path: A string specifying the location of the version's source.
+      source_location: A string specifying the location of the version's
+        source archive.
     """
     private_ip = appscale_info.get_private_ip()
     hoster_node = '/apps/{}/{}'.format(project_id, private_ip)

--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -342,6 +342,10 @@ class VersionsHandler(BaseHandler):
     Raises:
       CustomHTTPError if the user is not the owner.
     """
+    # Immutable projects do not have owners.
+    if project_id in constants.IMMUTABLE_PROJECTS:
+      return
+
     try:
       project_metadata = self.ua_client.get_app_data(project_id)
     except UAException:
@@ -601,6 +605,10 @@ class VersionHandler(BaseHandler):
       version_id: A string specifying a version ID.
     """
     self.authenticate()
+
+    if project_id in constants.IMMUTABLE_PROJECTS:
+      raise CustomHTTPError(HTTPCodes.BAD_REQUEST,
+                            message='{} cannot be deleted'.format(project_id))
 
     if service_id != constants.DEFAULT_SERVICE:
       raise CustomHTTPError(HTTPCodes.BAD_REQUEST, message='Invalid service')

--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -392,8 +392,7 @@ class VersionsHandler(BaseHandler):
 
     self.ensure_user_is_owner(project_id, user)
 
-    source_path = utils.resolve_source_path(
-      version['deployment']['zip']['sourceUrl'])
+    source_path = version['deployment']['zip']['sourceUrl']
 
     try:
       utils.extract_source(version, project_id)

--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -503,7 +503,7 @@ class VersionHandler(BaseHandler):
       A dictionary containing version details.
     """
     update_mask = self.get_argument('updateMask', None)
-    if update_mask is None:
+    if not update_mask:
       message = 'At least one field must be specified for this operation.'
       raise CustomHTTPError(HTTPCodes.BAD_REQUEST, message=message)
 

--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -333,8 +333,9 @@ class VersionsHandler(BaseHandler):
     Returns:
       A dictionary containing updated version details.
     """
-    version_node = '/appscale/projects/{}/services/{}/versions/{}'.format(
-      project_id, service_id, new_version['id'])
+    version_node = constants.VERSION_NODE_TEMPLATE.format(
+      project_id=project_id, service_id=service_id,
+      version_id=new_version['id'])
 
     try:
       old_version_json, _ = self.zk_client.get(version_node)
@@ -485,8 +486,8 @@ class VersionHandler(BaseHandler):
     Returns:
       A dictionary containing version details.
     """
-    version_node = '/appscale/projects/{}/services/{}/versions/{}'.format(
-      project_id, service_id, version_id)
+    version_node = constants.VERSION_NODE_TEMPLATE.format(
+      project_id=project_id, service_id=service_id, version_id=version_id)
 
     try:
       version_json, _ = self.zk_client.get(version_node)
@@ -547,8 +548,8 @@ class VersionHandler(BaseHandler):
     Returns:
       A dictionary containing completed version details.
     """
-    version_node = '/appscale/projects/{}/services/{}/versions/{}'.format(
-      project_id, service_id, version_id)
+    version_node = constants.VERSION_NODE_TEMPLATE.format(
+      project_id=project_id, service_id=service_id, version_id=version_id)
 
     try:
       version_json, _ = self.zk_client.get(version_node)
@@ -623,8 +624,8 @@ class VersionHandler(BaseHandler):
       raise CustomHTTPError(HTTPCodes.NOT_FOUND,
                             message='Version serving port not found')
 
-    version_node = '/appscale/projects/{}/services/{}/versions/{}'.format(
-      project_id, service_id, version_id)
+    version_node = constants.VERSION_NODE_TEMPLATE.format(
+      project_id=project_id, service_id=service_id, version_id=version_id)
 
     yield self.thread_pool.submit(self.version_update_lock.acquire)
     try:

--- a/AdminServer/appscale/admin/constants.py
+++ b/AdminServer/appscale/admin/constants.py
@@ -27,6 +27,7 @@ class Methods(object):
   """ The methods handled by the Admin API. """
   CREATE_VERSION = 'google.appengine.v1.Versions.CreateVersion'
   DELETE_VERSION = 'google.appengine.v1.Versions.DeleteVersion'
+  UPDATE_VERSION = 'google.appengine.v1.Versions.UpdateVersion'
 
 
 class OperationTimeout(Exception):

--- a/AdminServer/appscale/admin/constants.py
+++ b/AdminServer/appscale/admin/constants.py
@@ -69,5 +69,19 @@ VALID_RUNTIMES = {PYTHON27, JAVA, GO, PHP}
 # The seconds to wait for redeploys.
 REDEPLOY_WAIT = 20
 
-# A list of projects that cannot be used or modified by users.
-RESERVED_PROJECTS = [DASHBOARD_APP_ID]
+# A list of projects that cannot be modified by users.
+IMMUTABLE_PROJECTS = [DASHBOARD_APP_ID]
+
+# The ZooKeeper node that prevents concurrent location assignments.
+VERSION_UPDATE_LOCK_NODE = '/appscale/version_update_lock'
+
+# The ranges to use for automatically assigned ports.
+AUTO_HTTP_PORTS = range(8080, 8100)
+AUTO_HTTPS_PORTS = range(4380, 4400)
+
+# The ports that can be assigned to versions.
+ALLOWED_HTTP_PORTS = [80, 1080] + list(AUTO_HTTP_PORTS)
+ALLOWED_HTTPS_PORTS = [443, 1443] + list(AUTO_HTTPS_PORTS)
+
+# The range of HAProxy ports to assign to versions.
+HAPROXY_PORTS = range(10000, 10020)

--- a/AdminServer/appscale/admin/constants.py
+++ b/AdminServer/appscale/admin/constants.py
@@ -73,6 +73,10 @@ REDEPLOY_WAIT = 20
 # A list of projects that cannot be modified by users.
 IMMUTABLE_PROJECTS = [DASHBOARD_APP_ID]
 
+# The ZooKeeper location for storing version details.
+VERSION_NODE_TEMPLATE = ('/appscale/projects/{project_id}'
+                         '/services/{service_id}/versions/{version_id}')
+
 # The ZooKeeper node that prevents concurrent location assignments.
 VERSION_UPDATE_LOCK_NODE = '/appscale/version_update_lock'
 

--- a/AdminServer/appscale/admin/operation.py
+++ b/AdminServer/appscale/admin/operation.py
@@ -129,7 +129,7 @@ class UpdateVersionOperation(Operation):
   """ A container that keeps track of UpdateVersion operations. """
 
   def __init__(self, project_id, service_id, version):
-    """ Creates a new CreateVersionOperation.
+    """ Creates a new UpdateVersionOperation.
 
     Args:
       project_id: A string specifying a project ID.

--- a/AdminServer/appscale/admin/operation.py
+++ b/AdminServer/appscale/admin/operation.py
@@ -123,3 +123,19 @@ class DeleteVersionOperation(Operation):
     """ Marks the operation as completed. """
     self.response = {'@type': Types.EMPTY}
     self.done = True
+
+
+class UpdateVersionOperation(Operation):
+  """ A container that keeps track of UpdateVersion operations. """
+
+  def __init__(self, project_id, service_id, version):
+    """ Creates a new CreateVersionOperation.
+
+    Args:
+      project_id: A string specifying a project ID.
+      service_id: A string specifying a service ID.
+      version: A dictionary containing verision details.
+    """
+    super(UpdateVersionOperation, self).__init__(
+      project_id, service_id, version)
+    self.method = Methods.UPDATE_VERSION

--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -104,22 +104,6 @@ def ensure_path(path):
       raise
 
 
-def resolve_source_path(source_url):
-  """ Extracts file system path from source URL.
-
-  Args:
-    source_url: A string containing the version's source URL.
-  Returns:
-    A string specifying a file system path.
-  """
-  proto_prefix = 'file://'
-  source_path = source_url
-  # Strip protocol prefix.
-  if source_path.startswith(proto_prefix):
-    source_path = source_path[len(proto_prefix):]
-  return source_path
-
-
 def extract_source(version, project_id):
   """ Unpacks an archive to a given location.
 
@@ -138,7 +122,7 @@ def extract_source(version, project_id):
   # The working directory must be the target in order to validate paths.
   os.chdir(app_path)
 
-  source_path = resolve_source_path(version['deployment']['zip']['sourceUrl'])
+  source_path = version['deployment']['zip']['sourceUrl']
   with tarfile.open(source_path, 'r:gz') as archive:
     # Check if the archive is valid before extracting it.
     has_config = False

--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -272,8 +272,8 @@ def assigned_locations(zk_client):
     except NoNodeError:
       continue
     version_nodes.extend([
-      '/appscale/projects/{}/services/{}/versions/{}'.format(
-        project_id, service_id, version_id)
+      constants.VERSION_NODE_TEMPLATE.format(
+        project_id=project_id, service_id=service_id, version_id=version_id)
       for version_id in new_version_ids])
 
   locations = set()

--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -88,6 +88,12 @@ def version_contains_field(version, field):
 def apply_mask_to_version(given_version, desired_fields):
   """ Reduces a version to the desired fields.
 
+  Example:
+    given_version: {'runtime': 'python27',
+                    'appscaleExtensions': {'httpPort': 80}}
+    desired_fields: ['appscaleExtensions.httpPort']
+    output: {'appscaleExtensions': {'httpPort': 80}}
+
   Args:
     given_version: A dictionary containing version details.
     desired_fields: A list of strings representing key paths.

--- a/AdminServer/setup.py
+++ b/AdminServer/setup.py
@@ -1,4 +1,16 @@
+import sys
+
 from setuptools import setup
+
+install_requires = [
+  'appscale-common',
+  'kazoo',
+  'PyYaml',
+  'SOAPpy',
+  'tornado'
+]
+if sys.version_info < (3,):
+  install_requires.append('futures')
 
 setup(
   name='appscale-admin',
@@ -9,12 +21,7 @@ setup(
   license='Apache License 2.0',
   keywords='appscale google-app-engine python',
   platforms='Posix',
-  install_requires=[
-    'appscale-common',
-    'kazoo',
-    'SOAPpy',
-    'tornado'
-  ],
+  install_requires=install_requires,
   classifiers=[
     'Development Status :: 3 - Alpha',
     'Intended Audience :: Developers',

--- a/AdminServer/tests/test_utils.py
+++ b/AdminServer/tests/test_utils.py
@@ -1,0 +1,33 @@
+import unittest
+
+from appscale.admin import utils
+
+
+class TestUtils(unittest.TestCase):
+  def test_apply_mask_to_version(self):
+    given_version = {'runtime': 'python27',
+                     'appscaleExtensions': {'httpPort': 80}}
+    desired_fields = ['appscaleExtensions.httpPort']
+    self.assertDictEqual(
+      utils.apply_mask_to_version(given_version, desired_fields),
+      {'appscaleExtensions': {'httpPort': 80}})
+
+    given_version = {'appscaleExtensions': {'httpPort': 80, 'httpsPort': 443}}
+    desired_fields = ['appscaleExtensions.httpPort',
+                      'appscaleExtensions.httpsPort']
+    self.assertDictEqual(
+      utils.apply_mask_to_version(given_version, desired_fields),
+      {'appscaleExtensions': {'httpPort': 80, 'httpsPort': 443}})
+
+    given_version = {'runtime': 'python27'}
+    desired_fields = ['appscaleExtensions.httpPort',
+                      'appscaleExtensions.httpsPort']
+    self.assertDictEqual(
+      utils.apply_mask_to_version(given_version, desired_fields), {})
+
+    given_version = {'runtime': 'python27',
+                     'appscaleExtensions': {'httpPort': 80, 'httpsPort': 443}}
+    desired_fields = ['appscaleExtensions']
+    self.assertDictEqual(
+      utils.apply_mask_to_version(given_version, desired_fields),
+      {'appscaleExtensions': {'httpPort': 80, 'httpsPort': 443}})

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -94,10 +94,6 @@ NOT_READY = "false: not ready yet"
 INVALID_REQUEST = 'false: invalid request'
 
 
-# Regular expression to determine if a file is a .tar.gz file.
-TAR_GZ_REGEX = /\.tar\.gz$/
-
-
 # The maximum number of seconds that we should wait when deploying Google App
 # Engine applications via the AppController.
 APP_UPLOAD_TIMEOUT = 180

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -743,8 +743,8 @@ class Djinn
     end
 
     # Forward relocate as a patch request to the AdminServer.
-    version = {:appscaleExtensions => {:httpPort => http_port,
-                                       :httpsPort => https_port}}
+    version = {:appscaleExtensions => {:httpPort => http_port.to_i,
+                                       :httpsPort => https_port.to_i}}
     endpoint = ['v1', 'apps', appid, 'services', DEFAULT_SERVICE,
                 'versions', DEFAULT_VERSION].join('/')
     fields_updated = %w(appscaleExtensions.httpPort
@@ -5478,8 +5478,8 @@ HOSTS
       num_appengines = @app_info_map[app_name]['appengine'].length
     end
 
-    scaling_params = version_details.fetch(:automaticScaling, {})
-    min = scaling_params.fetch(:minTotalInstances,
+    scaling_params = version_details.fetch('automaticScaling', {})
+    min = scaling_params.fetch('minTotalInstances',
                                Integer(@options['appengine']))
     if num_appengines < min
       Djinn.log_info("#{app_name} needs #{min - num_appengines} more AppServers.")
@@ -5762,8 +5762,8 @@ HOSTS
     # if we already are at the requested minimum.
     version_details = ZKInterface.get_version_details(
       app_name, DEFAULT_SERVICE, DEFAULT_VERSION)
-    scaling_params = version_details.fetch(:automaticScaling, {})
-    min = scaling_params.fetch(:minTotalInstances,
+    scaling_params = version_details.fetch('automaticScaling', {})
+    min = scaling_params.fetch('minTotalInstances',
                                Integer(@options['appengine']))
     if @app_info_map[app_name]['appengine'].length <= min
       Djinn.log_debug("We are already at the minimum number of AppServers for #{app_name}.")

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4776,7 +4776,7 @@ HOSTS
                'AppScale-User' => APPSCALE_USER}
     request = Net::HTTP::Post.new(uri.path, headers)
     request.body = JSON.dump(version)
-    while true
+    loop do
       begin
         response = Net::HTTP.start(uri.hostname, uri.port) do |http|
           http.request(request)

--- a/AppController/lib/app_dashboard.rb
+++ b/AppController/lib/app_dashboard.rb
@@ -38,7 +38,7 @@ module AppDashboard
   #   secret: A String that is used to authenticate this application with
   #     other AppScale services.
   # Returns:
-  #   true if the AppDashboard was started successfully, and false otherwise.
+  #   A string specifying the location of the prepared archive.
   def self.prep(public_ip, private_ip, persistent_storage, secret)
 
     # Pass the secret key and our public IP address (needed to connect to the

--- a/AppController/lib/app_dashboard.rb
+++ b/AppController/lib/app_dashboard.rb
@@ -29,9 +29,7 @@ module AppDashboard
   APP_LANGUAGE = "python27"
 
 
-  # Starts the AppDashboard on this machine. Does not configure or start nginx
-  # or haproxy, which are needed to load balance traffic to the AppDashboard
-  # instances we start here.
+  # Prepares the dashboard's source archive.
   #
   # Args:
   #   public_ip: This machine's public IP address or FQDN.
@@ -41,7 +39,7 @@ module AppDashboard
   #     other AppScale services.
   # Returns:
   #   true if the AppDashboard was started successfully, and false otherwise.
-  def self.start(public_ip, private_ip, persistent_storage, secret)
+  def self.prep(public_ip, private_ip, persistent_storage, secret)
 
     # Pass the secret key and our public IP address (needed to connect to the
     # AppController) to the app.
@@ -65,7 +63,7 @@ module AppDashboard
 
     Djinn.log_debug("Done setting dashboard.")
 
-    return true
+    return app_location
   end
 
 

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -20,6 +20,11 @@ class FailedZooKeeperOperationException < StandardError
 end
 
 
+# Indicates that the requested version node was not found.
+class VersionNotFound < StandardError
+end
+
+
 # The AppController employs the open source software ZooKeeper as a highly
 # available naming service, to store and retrieve information about the status
 # of applications hosted within AppScale. This class provides methods to
@@ -466,6 +471,19 @@ class ZKInterface
   def self.set_job_data_for_ip(ip, job_data)
     return self.set("#{APPCONTROLLER_NODE_PATH}/#{ip}/job_data", 
       JSON.dump(job_data), NOT_EPHEMERAL)
+  end
+
+
+  def self.get_version_details(project_id, service_id, version_id)
+    version_node = "/appscale/projects/#{project_id}/services/#{service_id}" +
+      "/versions/#{version_id}"
+    begin
+      version_details_json = self.get(version_node)
+    rescue FailedZooKeeperOperationException
+      raise VersionNotFound,
+            "#{project_id}/#{service_id}/#{version_id} does not exist"
+    end
+    return JSON.load(version_details_json)
   end
 
 

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -474,6 +474,20 @@ class ZKInterface
   end
 
 
+  def self.get_app_names()
+    projects = self.get_children('/appscale/projects')
+    active_projects = []
+    service_id = Djinn::DEFAULT_SERVICE
+    version_id = Djinn::DEFAULT_VERSION
+    projects.each { |project_id|
+      version_node = "/appscale/projects/#{project_id}" +
+        "/services/#{service_id}/versions/#{version_id}"
+      active_projects << project_id if self.exists?(version_node)
+    }
+    return active_projects
+  end
+
+
   def self.get_version_details(project_id, service_id, version_id)
     version_node = "/appscale/projects/#{project_id}/services/#{service_id}" +
       "/versions/#{version_id}"

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -519,8 +519,8 @@ class TestDjinn < Test::Unit::TestCase
       instance.should_receive(:valid_secret?).and_return(true)
     }
     role = {
-      "public_ip" => "public_ip",
-      "private_ip" => "private_ip",
+      "public_ip" => "1.2.3.4",
+      "private_ip" => "1.2.3.4",
       "jobs" => ["login","shadow"],
       "instance_id" => "instance_id"
     }
@@ -532,24 +532,21 @@ class TestDjinn < Test::Unit::TestCase
     djinn.nodes = [my_node]
     djinn.app_info_map = {
       'myapp' => {
-        'nginx' => 8081,
-        'nginx_https' => 4381,
-        'haproxy' => 10001,
         'appengine' => ["1.2.3.4:20001"]
       },
       'another-app' => {
-        'nginx' => 80,
-        'nginx_https' => 443,
-        'haproxy' => 10000,
         'appengine' => ["1.2.3.4:20000"]
       }
     }
 
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:80 -sTCP:LISTEN").and_return("")
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:4380 -sTCP:LISTEN").and_return("")
+    admin_server_error = 'httpPort not available'
+    flexmock(ZKInterface).should_receive(:get_version_details).
+      and_return(djinn.app_info_map['myapp'])
+    flexmock(Net::HTTP).should_receive(:start).and_return(
+      flexmock(:request => nil, :code => 400, :body => admin_server_error))
 
-    expected = "Error: requested http port is already in use."
-    assert_equal(expected, djinn.relocate_app('myapp', 80, 4380, @secret))
+    assert_equal("false: #{admin_server_error}",
+                 djinn.relocate_app('myapp', 80, 4380, @secret))
   end
 
 
@@ -558,8 +555,8 @@ class TestDjinn < Test::Unit::TestCase
       instance.should_receive(:valid_secret?).and_return(true)
     }
     role = {
-      "public_ip" => "public_ip",
-      "private_ip" => "private_ip",
+      "public_ip" => "1.2.3.4",
+      "private_ip" => "1.2.3.4",
       "jobs" => ["login","shadow"],
       "instance_id" => "instance_id"
     }
@@ -571,24 +568,21 @@ class TestDjinn < Test::Unit::TestCase
     djinn.nodes = [my_node]
     djinn.app_info_map = {
       'myapp' => {
-        'nginx' => 8081,
-        'nginx_https' => 4381,
-        'haproxy' => 10001,
         'appengine' => ["1.2.3.4:20001"]
       },
       'another-app' => {
-        'nginx' => 80,
-        'nginx_https' => 443,
-        'haproxy' => 10000,
         'appengine' => ["1.2.3.4:20000"]
       }
     }
 
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:8080 -sTCP:LISTEN").and_return("")
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:443 -sTCP:LISTEN").and_return("")
+    admin_server_error = 'httpPort not available'
+    flexmock(ZKInterface).should_receive(:get_version_details).
+      and_return(djinn.app_info_map['myapp'])
+    flexmock(Net::HTTP).should_receive(:start).and_return(
+      flexmock(:request => nil, :code => 400, :body => admin_server_error))
 
-    expected = "Error: requested https port is already in use."
-    assert_equal(expected, djinn.relocate_app('myapp', 8080, 443, @secret))
+    assert_equal("false: #{admin_server_error}",
+                 djinn.relocate_app('myapp', 8080, 443, @secret))
   end
 
 
@@ -597,8 +591,8 @@ class TestDjinn < Test::Unit::TestCase
       instance.should_receive(:valid_secret?).and_return(true)
     }
     role = {
-      "public_ip" => "public_ip",
-      "private_ip" => "private_ip",
+      "public_ip" => "1.2.3.4",
+      "private_ip" => "1.2.3.4",
       "jobs" => ["login","shadow"],
       "instance_id" => "instance_id"
     }
@@ -610,24 +604,21 @@ class TestDjinn < Test::Unit::TestCase
     djinn.nodes = [my_node]
     djinn.app_info_map = {
       'myapp' => {
-        'nginx' => 8081,
-        'nginx_https' => 4381,
-        'haproxy' => 10001,
         'appengine' => ["1.2.3.4:20001"]
       },
       'another-app' => {
-        'nginx' => 80,
-        'nginx_https' => 443,
-        'haproxy' => 4380,
         'appengine' => ["1.2.3.4:20000"]
       }
     }
 
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:8080 -sTCP:LISTEN").and_return("")
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:4380 -sTCP:LISTEN").and_return("")
+    admin_server_error = 'httpPort not available'
+    flexmock(ZKInterface).should_receive(:get_version_details).
+      and_return(djinn.app_info_map['myapp'])
+    flexmock(Net::HTTP).should_receive(:start).and_return(
+      flexmock(:request => nil, :code => 400, :body => admin_server_error))
 
-    expected = "Error: requested https port is already in use."
-    assert_equal(expected, djinn.relocate_app('myapp', 8080, 4380, @secret))
+    assert_equal("false: #{admin_server_error}",
+                 djinn.relocate_app('myapp', 8080, 4380, @secret))
   end
 
 
@@ -636,8 +627,8 @@ class TestDjinn < Test::Unit::TestCase
       instance.should_receive(:valid_secret?).and_return(true)
     }
     role = {
-      "public_ip" => "public_ip",
-      "private_ip" => "private_ip",
+      "public_ip" => "1.2.3.4",
+      "private_ip" => "1.2.3.4",
       "jobs" => ["login","shadow"],
       "instance_id" => "instance_id"
     }
@@ -649,24 +640,21 @@ class TestDjinn < Test::Unit::TestCase
     djinn.nodes = [my_node]
     djinn.app_info_map = {
       'myapp' => {
-        'nginx' => 8081,
-        'nginx_https' => 4381,
-        'haproxy' => 10001,
         'appengine' => ["1.2.3.4:20000"]
       },
       'another-app' => {
-        'nginx' => 80,
-        'nginx_https' => 443,
-        'haproxy' => 10000,
         'appengine' => ["1.2.3.4:8080"]
       }
     }
 
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:8080 -sTCP:LISTEN").and_return("")
-    flexmock(Djinn).should_receive(:log_run).with("lsof -i:4380 -sTCP:LISTEN").and_return("")
+    admin_server_error = 'httpPort not available'
+    flexmock(ZKInterface).should_receive(:get_version_details).
+      and_return(djinn.app_info_map['myapp'])
+    flexmock(Net::HTTP).should_receive(:start).and_return(
+      flexmock(:request => nil, :code => 400, :body => admin_server_error))
 
-    expected = "Error: requested http port is already in use."
-    assert_equal(expected, djinn.relocate_app('myapp', 8080, 4380, @secret))
+    assert_equal("false: #{admin_server_error}",
+                 djinn.relocate_app('myapp', 8080, 4380, @secret))
   end
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -138,6 +138,14 @@ namespace :xmppreceiver do
 
 end
 
+namespace :adminserver do
+
+  task :test do
+    sh 'python -m unittest discover -b -v -s AdminServer/tests'
+  end
+
+end
+
 python_tests = [
   'appdashboard:test',
   'appdb:test',
@@ -149,7 +157,8 @@ python_tests = [
   'infrastructuremanager:test',
   'searchservice:test',
   'xmppreceiver:test',
-  'apps:test'
+  'apps:test',
+  'adminserver:test'
 ]
 ruby_tests = ['appcontroller:test']
 

--- a/common/appscale/common/constants.py
+++ b/common/appscale/common/constants.py
@@ -16,8 +16,8 @@ class HTTPCodes(object):
 # AppScale home directory.
 APPSCALE_HOME = os.environ.get("APPSCALE_HOME", "/root/appscale")
 
-# Location of PID files for processes and applications.
-APP_PID_DIR = '/etc/appscale/'
+# Directory where configuration files are stored.
+CONFIG_DIR = os.path.join('/', 'etc', 'appscale')
 
 # Location of where data is persisted on disk.
 APPSCALE_DATA_DIR = '/opt/appscale'

--- a/common/appscale/common/ua_client.py
+++ b/common/appscale/common/ua_client.py
@@ -45,6 +45,20 @@ class UAClient(object):
     if response.lower() != 'true':
       raise UAException(response)
 
+  def add_instance(self, app_id, host, port, https_port):
+    """ Associates an application with a hostname and ports.
+
+    Args:
+      app_id: A string specifying an application ID.
+      host: A string specifying a hostname.
+      port: An integer specifying a port.
+      https_port: An integer specifying a port.
+    """
+    response = self.server.add_instance(app_id, host, port, https_port,
+                                        self.secret)
+    if response.lower() != 'true':
+      raise UAException(response)
+
   def commit_new_app(self, app_id, email, language):
     """ Creates new project.
 


### PR DESCRIPTION
The new nodes, located at /appscale/`project_id`/services/`service_id`/versions/`version-id`, replace `@app_names` and part of `@app_info_map`.

In doing so, this also introduces the patch method for the version handler and the instanceClass key for version details.