### PR TITLE
Don't scale versions that haven't been loaded

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5238,6 +5238,8 @@ HOSTS
   def scale_appservers
     needed_appservers = 0
     ZKInterface.get_app_names.each { |app_name|
+      next unless @apps_loaded.include?(app_name)
+
       initialize_scaling_info_for_app(app_name)
 
       # Get the desired changes in the number of AppServers.


### PR DESCRIPTION
If a version node was added after `setup_appengine_application` and before `check_running_appservers`, the controller would crash.