### PR TITLE
Only check disk usage for mountpoints in whitelist

### DIFF
--- a/InfrastructureManager/system_manager.py
+++ b/InfrastructureManager/system_manager.py
@@ -84,9 +84,10 @@ class SystemManager():
 
     inner_disk_stats_dict = []
     for partition in psutil.disk_partitions(all=True):
-      disk_stats = psutil.disk_usage(partition.mountpoint)
       if partition.mountpoint not in MOUNTPOINT_WHITELIST:
         continue
+
+      disk_stats = psutil.disk_usage(partition.mountpoint)
       inner_disk_stats_dict.append({ partition.mountpoint : {
         JSONTags.TOTAL : disk_stats.total,
         JSONTags.FREE : disk_stats.free,

--- a/InfrastructureManager/system_manager.py
+++ b/InfrastructureManager/system_manager.py
@@ -83,7 +83,7 @@ class SystemManager():
         InfrastructureManager.REASON_BAD_SECRET)
 
     inner_disk_stats_dict = []
-    for partition in psutil.disk_partitions(all=True):
+    for partition in psutil.disk_partitions():
       if partition.mountpoint not in MOUNTPOINT_WHITELIST:
         continue
 


### PR DESCRIPTION
psutil is not able to get disk usage information on some devices. For example, /var/lib/ureadahead/debugfs is problematic.