### PR TITLE
Use database locations from arguments

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
+++ b/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
@@ -285,7 +285,7 @@ class DatastoreProxy(AppDBInterface):
   """ 
     Cassandra implementation of the AppDBInterface
   """
-  def __init__(self, log_level=logging.INFO):
+  def __init__(self, log_level=logging.INFO, hosts=None):
     """
     Constructor.
     """
@@ -294,7 +294,10 @@ class DatastoreProxy(AppDBInterface):
     self.logger.setLevel(log_level)
     self.logger.info('Starting {}'.format(class_name))
 
-    self.hosts = appscale_info.get_db_ips()
+    if hosts is not None:
+      self.hosts = hosts
+    else:
+      self.hosts = appscale_info.get_db_ips()
 
     remaining_retries = INITIAL_CONNECT_RETRIES
     while True:

--- a/scripts/datastore_upgrade.py
+++ b/scripts/datastore_upgrade.py
@@ -151,16 +151,6 @@ def start_zookeeper(zk_ips, keyname):
   logging.info("Successfully started ZooKeeper.")
 
 
-def get_datastore():
-  """ Returns a reference to the batch datastore interface. Validates where
-  the <database>_interface.py is and adds that path to the system path.
-  """
-  db_info = appscale_info.get_db_info()
-  db_type = db_info[':table']
-  datastore_batch = appscale_datastore_batch.DatastoreFactory.getDatastore(db_type)
-  return datastore_batch
-
-
 def get_zookeeper(zk_location_ips):
   """ Returns a handler for making ZooKeeper operations.
   Args:
@@ -357,17 +347,18 @@ def stop_zookeeper(zk_ips, keyname):
       logging.error('Unable to stop ZooKeeper on {}'.format(ip))
 
 
-def wait_for_quorum(keyname, db_nodes, replication):
+def wait_for_quorum(keyname, db_master, db_nodes, replication):
   """ Waits until enough Cassandra nodes are up for a quorum.
 
   Args:
     keyname: A string containing the deployment's keyname.
+    db_master: A string containing the IP address of the primary DB machine.
     db_nodes: An integer specifying the total number of DB nodes.
     replication: An integer specifying the keyspace replication factor.
   """
   command = cassandra_interface.NODE_TOOL + " " + 'status'
   key_file = '{}/{}.key'.format(utils.KEY_DIRECTORY, keyname)
-  ssh_cmd = ['ssh', '-i', key_file, appscale_info.get_db_master_ip(), command]
+  ssh_cmd = ['ssh', '-i', key_file, db_master, command]
 
   # Determine the number of nodes needed for a quorum.
   if db_nodes < 1 or replication < 1:

--- a/scripts/upgrade.py
+++ b/scripts/upgrade.py
@@ -18,6 +18,7 @@ from appscale.datastore.dbconstants import AppScaleDBError
 
 from appscale.common.constants import LOG_FORMAT
 from appscale.common.constants import ZK_CASSANDRA_CONFIG
+from appscale.datastore.cassandra_env.cassandra_interface import DatastoreProxy
 
 sys.path.append\
   (os.path.join(os.path.dirname(__file__), '../InfrastructureManager'))
@@ -67,8 +68,8 @@ if __name__ == "__main__":
                   makepath=True)
     start_cassandra(args.database, args.db_master, args.keyname, args.zookeeper)
     datastore_upgrade.wait_for_quorum(
-      args.keyname, len(args.database), args.replication)
-    db_access = datastore_upgrade.get_datastore()
+      args.keyname, args.db_master, len(args.database), args.replication)
+    db_access = DatastoreProxy(hosts=args.database)
 
     # Exit early if a data layout upgrade is not needed.
     if db_access.valid_data_version():

--- a/scripts/upgrade.py
+++ b/scripts/upgrade.py
@@ -85,6 +85,7 @@ if __name__ == "__main__":
                           total_entities)
     status = {'status': 'complete', 'message': 'Data layout upgrade complete'}
   except Exception as error:
+    logging.exception('Failed to upgrade AppScale')
     status = {'status': 'error', 'message': error.message}
     sys.exit()
   finally:


### PR DESCRIPTION
Since 3.2.1, `appscale down` removes the location files.