### PR TITLE
Always round up when scaling

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5531,7 +5531,7 @@ HOSTS
                                   allow_concurrency)
     max_conn = allow_concurrency ? HAProxy::MAX_APPSERVER_CONN : 1
     desired_appservers = curr_sessions.to_f / (DESIRED_LOAD * max_conn)
-    appservers_to_scale = desired_appservers.round - num_appengines
+    appservers_to_scale = desired_appservers.ceil - num_appengines
     return appservers_to_scale
   end
 


### PR DESCRIPTION
Previously, it was difficult to scale up when there was only one AppServer. This is because the desired appservers rounds down even for a full load (1.25 for 7 current sessions).

This change can result in scaling down 0 AppServers when below the minimum threshold (2 AppServers with 7 current sessions, for example).