### PR TITLE
Stop the TaskQueue server gracefully

### DIFF
--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -175,7 +175,8 @@ CONFIG
                   '--pidfile', pidfile,
                   '--startas', "#{bash} -- -c '#{bash_exec}'"]
 
-    stop_cmd = "#{start_stop_daemon} --stop --pidfile #{pidfile} && " +
+    stop_cmd = "#{start_stop_daemon} --stop --pidfile #{pidfile} " +
+               "--retry=TERM/20/KILL/5 && " +
                "#{rm} #{pidfile}"
 
     contents = <<BOO

--- a/AppTaskQueue/appscale/taskqueue/appscale_taskqueue.py
+++ b/AppTaskQueue/appscale/taskqueue/appscale_taskqueue.py
@@ -28,6 +28,9 @@ from google.appengine.api.taskqueue import taskqueue_service_pb
 from google.appengine.ext.remote_api import remote_api_pb
 
 
+# The TaskQueue server's Tornado HTTPServer.
+server = None
+
 # Global for Distributed TaskQueue.
 task_queue = None
 
@@ -202,7 +205,6 @@ def graceful_shutdown(*_):
   of requests as soon as the server has asynchronous handlers.
   """
   logger.info('Stopping server')
-  global server
   server.stop()
   io_loop = IOLoop.instance()
   io_loop.add_callback_from_signal(io_loop.stop)

--- a/common/appscale/common/monit_app_configuration.py
+++ b/common/appscale/common/monit_app_configuration.py
@@ -50,7 +50,8 @@ def create_config_file(watch, start_cmd, pidfile, port=None, env_vars=None,
     '/', 'var', 'log', 'appscale', '{}.log'.format(process_name))
 
   if syslog_server is None:
-    stop = 'start-stop-daemon --stop --pidfile {0} && rm {0}'.format(pidfile)
+    stop = ('start-stop-daemon --stop --pidfile {0} --retry=TERM/20/KILL/5 && '
+            'rm {0}'.format(pidfile))
     bash_exec = 'exec env {vars} {start_cmd} >> {log} 2>&1'.format(
       vars=env_vars_str, start_cmd=start_cmd, log=logfile)
   else:


### PR DESCRIPTION
This allows Monit to restart the server when it uses too much memory without interrupting requests in progress.