### PR TITLE
Watch for deployment configuration section updates

### DIFF
--- a/AdminServer/appscale/admin/push_worker_manager.py
+++ b/AdminServer/appscale/admin/push_worker_manager.py
@@ -5,6 +5,7 @@ import json
 import os
 from datetime import timedelta
 
+from kazoo.exceptions import ZookeeperError
 from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.options import options
@@ -57,11 +58,13 @@ class ProjectPushWorkerManager(object):
       monit_operator: A MonitOperator.
       project_id: A string specifying a project ID.
     """
+    self.zk_client = zk_client
     self.project_id = project_id
     self.monit_operator = monit_operator
-    queues_node = '/appscale/projects/{}/queues'.format(project_id)
-    self.watch = zk_client.DataWatch(queues_node, self._update_worker)
+    self.queues_node = '/appscale/projects/{}/queues'.format(project_id)
+    self.watch = zk_client.DataWatch(self.queues_node, self._update_worker)
     self.monit_watch = 'celery-{}'.format(project_id)
+    self._stopped = False
 
   @gen.coroutine
   def update_worker(self, queue_config):
@@ -118,6 +121,13 @@ class ProjectPushWorkerManager(object):
       '-Ofair'
     ])
 
+  def ensure_watch(self):
+    """ Restart the watch if it has been cancelled. """
+    if self._stopped:
+      self._stopped = False
+      self.watch = self.zk_client.DataWatch(self.queues_node,
+                                            self._update_worker)
+
   @gen.coroutine
   def _wait_for_stable_state(self):
     """ Waits until the worker's state is not pending. """
@@ -158,11 +168,21 @@ class ProjectPushWorkerManager(object):
       queue_config: A JSON string specifying queue configuration.
     """
     main_io_loop = IOLoop.instance()
-    main_io_loop.add_callback(self.update_worker, queue_config)
 
-  def stop(self):
-    """ Cancels the ZooKeeper watch for the project's queue configuration. """
-    self.watch._stopped = True
+    # Prevent further watches if they are no longer needed.
+    if queue_config is None:
+      try:
+        project_exists = self.zk_client.exists(
+          '/appscale/projects/{}'.format(self.project_id)) is not None
+      except ZookeeperError:
+        # If the project has been deleted, an extra "exists" watch will remain.
+        project_exists = True
+
+      if not project_exists:
+        self._stopped = True
+        return False
+
+    main_io_loop.add_callback(self.update_worker, queue_config)
 
 
 class GlobalPushWorkerManager(object):
@@ -189,13 +209,15 @@ class GlobalPushWorkerManager(object):
     to_stop = [project for project in self.projects
                if project not in new_project_list]
     for project_id in to_stop:
-      self.projects[project_id].stop()
       del self.projects[project_id]
 
     for new_project_id in new_project_list:
       if new_project_id not in self.projects:
         self.projects[new_project_id] = ProjectPushWorkerManager(
           self.zk_client, self.monit_operator, new_project_id)
+
+      # Handle changes that happen between watches.
+      self.projects[new_project_id].ensure_watch()
 
   def _update_projects(self, new_projects):
     """ Handles creation and deletion of projects.

--- a/AppDB/appscale/datastore/scripts/blobstore.py
+++ b/AppDB/appscale/datastore/scripts/blobstore.py
@@ -31,6 +31,7 @@ from appscale.common.constants import LOG_FORMAT
 from appscale.common.deployment_config import DeploymentConfig
 from appscale.common.deployment_config import ConfigInaccessible
 from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+from kazoo.client import KazooClient
 from StringIO import StringIO
 
 sys.path.append(APPSCALE_PYTHON_APPSERVER)
@@ -423,7 +424,10 @@ def main():
   args = parser.parse_args()
 
   datastore_path = args.datastore_path
-  deployment_config = DeploymentConfig(appscale_info.get_zk_locations_string())
+  zk_ips = appscale_info.get_zk_node_ips()
+  zk_client = KazooClient(hosts=','.join(zk_ips))
+  zk_client.start()
+  deployment_config = DeploymentConfig(zk_client)
   setup_env()
 
   http_server = tornado.httpserver.HTTPServer(

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -17,6 +17,7 @@ import urllib
 import urllib2
 from xml.etree import ElementTree
 
+from kazoo.client import KazooClient
 from M2Crypto import SSL
 from tornado.httpclient import HTTPClient
 from tornado.httpclient import HTTPError
@@ -847,7 +848,11 @@ def is_config_valid(config):
 ################################
 if __name__ == "__main__":
   file_io.set_logging_format()
-  deployment_config = DeploymentConfig(appscale_info.get_zk_locations_string())
+
+  zk_ips = appscale_info.get_zk_node_ips()
+  zk_client = KazooClient(hosts=','.join(zk_ips))
+  zk_client.start()
+  deployment_config = DeploymentConfig(zk_client)
 
   INTERNAL_IP = appscale_info.get_private_ip()
   SERVER = SOAPpy.SOAPServer((INTERNAL_IP, constants.APP_MANAGER_PORT))

--- a/AppTaskQueue/appscale/taskqueue/queue_manager.py
+++ b/AppTaskQueue/appscale/taskqueue/queue_manager.py
@@ -2,6 +2,7 @@
 
 import json
 
+from kazoo.exceptions import ZookeeperError
 from tornado.ioloop import IOLoop
 
 from appscale.taskqueue.utils import create_celery_for_app
@@ -21,12 +22,15 @@ class ProjectQueueManager(dict):
       project_id: A string specifying a project ID.
     """
     super(ProjectQueueManager, self).__init__()
+    self.zk_client = zk_client
     self.project_id = project_id
     self.db_access = db_access
-    queues_node = '/appscale/projects/{}/queues'.format(project_id)
-    self.watch = zk_client.DataWatch(queues_node, self._update_queues_watch)
+    self.queues_node = '/appscale/projects/{}/queues'.format(project_id)
+    self.watch = zk_client.DataWatch(self.queues_node,
+                                     self._update_queues_watch)
     self.celery = None
     self.rates = None
+    self._stopped = False
 
   def update_queues(self, queue_config):
     """ Caches new configuration details and cleans up old state.
@@ -73,9 +77,15 @@ class ProjectQueueManager(dict):
     for queue in push_queues:
       queue.celery = self.celery
 
+  def ensure_watch(self):
+    """ Restart the watch if it has been cancelled. """
+    if self._stopped:
+      self._stopped = False
+      self.watch = self.zk_client.DataWatch(self.queues_node,
+                                            self._update_queues_watch)
+
   def stop(self):
-    """ Removes all cached queue configuration and closes connection. """
-    self.watch._stopped = True
+    """ Close the Celery connections if they still exist. """
     if self.celery is not None:
       self.celery.close()
 
@@ -89,6 +99,20 @@ class ProjectQueueManager(dict):
       queue_config: A JSON string specifying queue configuration.
     """
     main_io_loop = IOLoop.instance()
+
+    # Prevent further watches if they are no longer needed.
+    if queue_config is None:
+      try:
+        project_exists = self.zk_client.exists(
+          '/appscale/projects/{}'.format(self.project_id)) is not None
+      except ZookeeperError:
+        # If the project has been deleted, an extra "exists" watch will remain.
+        project_exists = True
+
+      if not project_exists:
+        self._stopped = True
+        return False
+
     main_io_loop.add_callback(self.update_queues, queue_config)
 
 
@@ -123,6 +147,9 @@ class GlobalQueueManager(dict):
       if project_id not in self:
         self[project_id] = ProjectQueueManager(self.zk_client, self.db_access,
                                                project_id)
+
+      # Handle changes that happen between watches.
+      self[project_id].ensure_watch()
 
   def _update_projects_watch(self, new_projects):
     """ Handles creation and deletion of projects.

--- a/common/appscale/common/deployment_config.py
+++ b/common/appscale/common/deployment_config.py
@@ -2,7 +2,6 @@ import json
 import logging
 import time
 
-from kazoo.client import KazooClient
 from kazoo.client import KazooException
 from kazoo.client import KazooState
 from kazoo.client import NoNodeError
@@ -34,19 +33,18 @@ class DeploymentConfig(object):
   # The ZooKeeper node where configuration is stored.
   CONFIG_ROOT = '/appscale/config'
 
-  def __init__(self, hosts):
+  def __init__(self, zk_client):
     """ Creates new DeploymentConfig object.
 
     Args:
-      hosts: A list of ZooKeeper hosts.
+      zk_client: A KazooClient.
     """
     self.logger = logging.getLogger(self.__class__.__name__)
     self.update_lock = Lock()
     self.state = ConfigStates.LOADING
     self.config = {}
-    self.conn = KazooClient(hosts=hosts, read_only=True)
+    self.conn = zk_client
     self.conn.add_listener(self._conn_listener)
-    self.conn.start()
     self.conn.ensure_path(self.CONFIG_ROOT)
     self.conn.ChildrenWatch(self.CONFIG_ROOT, func=self._update_config)
 

--- a/scripts/setup_cassandra_config_files.py
+++ b/scripts/setup_cassandra_config_files.py
@@ -7,6 +7,8 @@ import os
 import pkgutil
 import sys
 
+from kazoo.client import KazooClient
+
 from appscale.common import appscale_info
 from appscale.common.deployment_config import DeploymentConfig
 from appscale.common.deployment_config import InvalidConfig
@@ -28,7 +30,9 @@ if __name__ == "__main__":
   args = parser.parse_args()
   zk_locations = args.zk_locations if args.zk_locations else \
     appscale_info.get_zk_locations_string()
-  deployment_config = DeploymentConfig(zk_locations)
+  zk_client = KazooClient(hosts=zk_locations)
+  zk_client.start()
+  deployment_config = DeploymentConfig(zk_client)
   cassandra_config = deployment_config.get_config('cassandra')
   if 'num_tokens' not in cassandra_config:
     raise InvalidConfig('num_tokens not specified in deployment config.')


### PR DESCRIPTION
Previously, updates to a node within /appscale/config would go unnoticed.

This change is needed for modules in order to make it easier to use a KazooClient with the AppManager. It's also in preparation for storing the max_memory parameter in a way that the AppManager can retrieve it.