### PR TITLE
Define max_memory for the deployment

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1422,6 +1422,7 @@ class Djinn
         Djinn.log_warn("Changing keyname can break your deployment!")
       elsif key == "max_memory"
         Djinn.log_warn("max_memory will be enforced on new AppServers only.")
+        ZKInterface.set_max_memory(Integer(val))
       elsif key == "min_images"
         unless is_cloud?
           Djinn.log_warn("min_images is not used in non-cloud infrastructures.")
@@ -3164,6 +3165,10 @@ class Djinn
     ZKInterface.set('/appscale/config/cassandra', JSON.dump(cassandra_config),
                     false)
     Djinn.log_info('Set custom cassandra configuration.')
+
+    if @options.key?('max_memory')
+      ZKInterface.set_max_memory(Integer(@options['max_memory']))
+    end
   end
 
   # Updates the file that says where all the ZooKeeper nodes are

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1422,7 +1422,7 @@ class Djinn
         Djinn.log_warn("Changing keyname can break your deployment!")
       elsif key == "max_memory"
         Djinn.log_warn("max_memory will be enforced on new AppServers only.")
-        ZKInterface.set_max_memory(Integer(val))
+        ZKInterface.set_runtime_params({:max_memory => Integer(val)})
       elsif key == "min_images"
         unless is_cloud?
           Djinn.log_warn("min_images is not used in non-cloud infrastructures.")
@@ -3167,7 +3167,8 @@ class Djinn
     Djinn.log_info('Set custom cassandra configuration.')
 
     if @options.key?('max_memory')
-      ZKInterface.set_max_memory(Integer(@options['max_memory']))
+      ZKInterface.set_runtime_params(
+        {:max_memory => Integer(@options['max_memory'])})
     end
   end
 

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -501,12 +501,11 @@ class ZKInterface
   end
 
 
-  # Defines a deployment-wide default for maximum instance memory.
-  def self.set_max_memory(max_memory)
-    max_memory_node = '/appscale/config/max_memory'
-    data = {'max_memory' => max_memory}
+  # Defines deployment-wide defaults for runtime parameters.
+  def self.set_runtime_params(parameters)
+    runtime_params_node = '/appscale/config/runtime_parameters'
     self.ensure_path('/appscale/config')
-    self.set(max_memory_node, JSON.dump(data), false)
+    self.set(runtime_params_node, JSON.dump(parameters), false)
   end
 
 

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -501,6 +501,15 @@ class ZKInterface
   end
 
 
+  # Defines a deployment-wide default for maximum instance memory.
+  def self.set_max_memory(max_memory)
+    max_memory_node = '/appscale/config/max_memory'
+    data = {'max_memory' => max_memory}
+    self.ensure_path('/appscale/config')
+    self.set(max_memory_node, JSON.dump(data), false)
+  end
+
+
   def self.run_zookeeper_operation(&block)
     begin
       yield


### PR DESCRIPTION
This is needed by the AppManager in order to start instances without direct input from the AppController.