### PR TITLE
Don't allow DS clients to keep connections alive

### DIFF
--- a/AppDB/appscale/datastore/scripts/datastore.py
+++ b/AppDB/appscale/datastore/scripts/datastore.py
@@ -49,6 +49,9 @@ STATS = {}
 
 class ClearHandler(tornado.web.RequestHandler):
   """ Defines what to do when the webserver receives a /clear HTTP request. """
+  def set_default_headers(self):
+    """ Instructs clients to close the connection after each response. """
+    self.set_header('Connection', 'close')
 
   @tornado.web.asynchronous
   def post(self):
@@ -61,6 +64,10 @@ class ClearHandler(tornado.web.RequestHandler):
 
 class ReadOnlyHandler(tornado.web.RequestHandler):
   """ Handles requests to check or set read-only mode. """
+  def set_default_headers(self):
+    """ Instructs clients to close the connection after each response. """
+    self.set_header('Connection', 'close')
+
   @tornado.web.asynchronous
   def post(self):
     """ Handle requests to turn read-only mode on or off. """
@@ -88,6 +95,9 @@ class MainHandler(tornado.web.RequestHandler):
   Defines what to do when the webserver receives different types of 
   HTTP requests.
   """
+  def set_default_headers(self):
+    """ Instructs clients to close the connection after each response. """
+    self.set_header('Connection', 'close')
 
   def unknown_request(self, app_id, http_request_data, pb_type):
     """ Function which handles unknown protocol buffers.


### PR DESCRIPTION
The Java AppServer was keeping datastore connections alive. HAProxy treated these as requests in progress, which severely limited datastore capacity until the 50s client timeout passed.