### PR TITLE
Don't require an email address when deploying apps

### DIFF
--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -269,51 +269,22 @@ class VersionsHandler(BaseHandler):
       logging.exception(message)
       raise CustomHTTPError(HTTPCodes.INTERNAL_ERROR, message=message)
 
-  def create_project(self, project_id, user, runtime):
+  def create_project(self, project_id, runtime):
     """ Creates a new project.
     
     Args:
       project_id: A string specifying a project ID.
-      user: A string specifying a user's email address.
       runtime: A string specifying the project's runtime.
     Raises:
       CustomHTTPError if unable to create new project.
     """
     logging.info('Creating project: {}'.format(project_id))
     try:
-      self.ua_client.commit_new_app(project_id, user, runtime)
+      self.ua_client.commit_new_app(project_id, runtime)
     except UAException:
       message = 'Unable to ensure project exists: {}'.format(project_id)
       logging.exception(message)
       raise CustomHTTPError(HTTPCodes.INTERNAL_ERROR, message=message)
-
-  def ensure_user_is_owner(self, project_id, user):
-    """ Ensures a user is the owner of a project.
-    
-    Args:
-      project_id: A string specifying a project ID.
-      user: A string specifying a user's email address.
-    Raises:
-      CustomHTTPError if the user is not the owner.
-    """
-    # Immutable projects do not have owners.
-    if project_id in constants.IMMUTABLE_PROJECTS:
-      return
-
-    try:
-      project_metadata = self.ua_client.get_app_data(project_id)
-    except UAException:
-      message = 'Unable to retrieve project metadata'
-      logging.exception(message)
-      raise CustomHTTPError(HTTPCodes.INTERNAL_ERROR, message=message)
-
-    if 'owner' not in project_metadata:
-      raise CustomHTTPError(HTTPCodes.INTERNAL_ERROR,
-                            message='Project owner not defined')
-
-    if project_metadata['owner'] != user:
-      message = 'User is not project owner: {}'.format(user)
-      raise CustomHTTPError(HTTPCodes.FORBIDDEN, message=message)
 
   def put_version(self, project_id, service_id, new_version):
     """ Create or update version node.
@@ -414,17 +385,14 @@ class VersionsHandler(BaseHandler):
       service_id: A string specifying a service ID.
     """
     self.authenticate()
-    user = self.get_current_user()
     version = self.version_from_payload()
 
     project_exists = self.project_exists(project_id)
     if not project_exists:
-      self.create_project(project_id, user, version['runtime'])
+      self.create_project(project_id, version['runtime'])
 
     if service_id != constants.DEFAULT_SERVICE:
       raise CustomHTTPError(HTTPCodes.BAD_REQUEST, message='Invalid service')
-
-    self.ensure_user_is_owner(project_id, user)
 
     try:
       utils.extract_source(version, project_id)

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1129,13 +1129,12 @@ class Djinn
   #   archived_file: A String, with the path to the compressed file containing
   #     the app.
   #   file_suffix: A String indicating what suffix the file should have.
-  #   email: A String with the email address of the user that will own this app.
   #   secret: A String with the shared key for authentication.
   # Returns:
   #   A JSON-dumped Hash with fields indicating if the upload process began
   #   successfully, and a reservation ID that can be used with
   #   get_app_upload_status to see if the app has successfully uploaded or not.
-  def upload_app(archived_file, file_suffix, email, secret)
+  def upload_app(archived_file, file_suffix, secret)
     return BAD_SECRET_MSG unless valid_secret?(secret)
 
     unless my_node.is_shadow?
@@ -1145,7 +1144,7 @@ class Djinn
         remote_file = [archived_file, file_suffix].join('.')
         HelperFunctions.scp_file(archived_file, remote_file,
                                  get_shadow.private_ip, get_shadow.ssh_key)
-        return acc.upload_app(remote_file, file_suffix, email)
+        return acc.upload_app(remote_file, file_suffix)
       rescue FailedNodeException
         Djinn.log_warn("Failed to forward upload_app call to shadow (#{get_shadow}).")
         return NOT_READY
@@ -1157,7 +1156,7 @@ class Djinn
 
     Djinn.log_debug(
       "Received a request to upload app at #{archived_file}, with suffix " +
-      "#{file_suffix}, with admin user #{email}.")
+      "#{file_suffix}")
 
     Thread.new {
       # If the dashboard is on the same node as the shadow, the archive needs
@@ -1172,7 +1171,7 @@ class Djinn
       Djinn.log_debug("Uploading file at location #{archived_file}")
       keyname = @options['keyname']
       command = "#{UPLOAD_APP_SCRIPT} --file '#{archived_file}' " +
-        "--email #{email} --keyname #{keyname} 2>&1"
+        "--keyname #{keyname} 2>&1"
       output = Djinn.log_run(command)
       if output.include?("Your app can be reached at the following URL")
         result = "true"

--- a/AppController/djinnServer.rb
+++ b/AppController/djinnServer.rb
@@ -68,8 +68,7 @@ class DjinnServer < SOAP::RPC::HTTPServer
     add_method(@djinn, "set_parameters", "layout", "options", "secret")
     add_method(@djinn, "get_cluster_stats_json", "secret")
     add_method(@djinn, "get_application_cron_info", "app_name", "secret")
-    add_method(@djinn, "upload_app", "archived_file", "file_suffix", "email",
-      "secret")
+    add_method(@djinn, "upload_app", "archived_file", "file_suffix", "secret")
     add_method(@djinn, "get_app_upload_status", "reservation_id", "secret")
     add_method(@djinn, "get_database_information", "secret")
     add_method(@djinn, "get_instance_info", "app_id", "secret")

--- a/AppController/lib/app_controller_client.rb
+++ b/AppController/lib/app_controller_client.rb
@@ -69,7 +69,7 @@ class AppControllerClient
     @conn.options["protocol.http.ssl_config.verify_mode"] = nil
     @conn.add_method("set_parameters", "layout", "options", "secret")
     @conn.add_method("set_apps_to_restart", "apps_to_restart", "secret")
-    @conn.add_method("upload_app", "archived_file", "file_suffix", "email", "secret")
+    @conn.add_method("upload_app", "archived_file", "file_suffix", "secret")
     @conn.add_method("update", "app_names", "secret")
     @conn.add_method("stop_app", "app_name", "secret")    
     @conn.add_method("get_all_public_ips", "secret")
@@ -151,9 +151,9 @@ class AppControllerClient
     end
   end
 
-  def upload_app(archived_file, file_suffix, email)
+  def upload_app(archived_file, file_suffix)
     make_call(30, RETRY_ON_FAIL, "upload_app") {
-      @conn.upload_app(archived_file, file_suffix, email, @secret)
+      @conn.upload_app(archived_file, file_suffix, @secret)
     }
   end
 

--- a/AppController/lib/user_app_client.rb
+++ b/AppController/lib/user_app_client.rb
@@ -41,7 +41,7 @@ class UserAppClient
     @conn.options["protocol.http.ssl_config.verify_mode"] = nil
     @conn.add_method("change_password", "user", "password", "secret")
     @conn.add_method("commit_new_user", "user", "passwd", "utype", "secret")
-    @conn.add_method("commit_new_app", "user", "appname", "language", "secret")
+    @conn.add_method("commit_new_app", "appname", "language", "secret")
     @conn.add_method("commit_tar", "app_name", "tar", "secret")
     @conn.add_method("delete_app", "appname", "secret")
     @conn.add_method("does_app_exist", "appname", "secret")
@@ -108,15 +108,15 @@ class UserAppClient
     return result
   end
 
-  def commit_new_app(user, app_name, language, file_location)
-    commit_new_app_name(user, app_name, language)
+  def commit_new_app(app_name, language, file_location)
+    commit_new_app_name(app_name, language)
     commit_tar(app_name, file_location)
   end
 
-  def commit_new_app_name(user, app_name, language, retry_on_except=true)
+  def commit_new_app_name(app_name, language, retry_on_except=true)
     result = ""
     make_call(DS_MIN_TIMEOUT, retry_on_except, "commit_new_app_name") {
-      result = @conn.commit_new_app(user, app_name, language, @secret)
+      result = @conn.commit_new_app(app_name, language, @secret)
     }
 
     if result == "true"

--- a/AppDB/appscale/datastore/backup/backup_recovery_helper.py
+++ b/AppDB/appscale/datastore/backup/backup_recovery_helper.py
@@ -358,7 +358,6 @@ def deploy_apps(app_paths):
     True on success, False otherwise.
   """
   secret = appscale_info.get_secret()
-  ua_client = UAClient(appscale_info.get_db_master_ip(), secret)
   acc = AppControllerClient(appscale_info.get_headnode_ip(), secret)
 
   # Wait for Cassandra to come up after a restore.
@@ -372,21 +371,10 @@ def deploy_apps(app_paths):
         "application recovery for '{}'. Aborting...".format(app_path))
       return False
 
-    # Retrieve app admin via uaserver.
-    app_data = ua_client.get_app_data(app_id)
-
-    if 'owner' in app_data:
-      app_admin = app_data['owner']
-    else:
-      logging.error("Missing application data. Cannot complete application "
-        "recovery for '{}'. Aborting...".format(app_id))
-      return False
-
     file_suffix = re.search("\.(.*)\Z", app_path).group(1)
 
-    logging.warning("Restoring app '{}', from '{}', with owner '{}'.".
-      format(app_id, app_path, app_admin))
+    logging.warning("Restoring app '{}', from '{}'".format(app_id, app_path))
 
-    acc.upload_app(app_path, file_suffix, app_admin)
+    acc.upload_app(app_path, file_suffix)
 
   return True

--- a/AppDB/appscale/datastore/scripts/ua_server.py
+++ b/AppDB/appscale/datastore/scripts/ua_server.py
@@ -405,7 +405,6 @@ def add_admin_for_app(user, app, secret):
 
 def commit_new_app(appname, language, secret):
   global db
-  global user_schema
   global app_schema
   global super_secret
   if secret != super_secret:

--- a/AppDB/appscale/datastore/scripts/ua_server.py
+++ b/AppDB/appscale/datastore/scripts/ua_server.py
@@ -403,7 +403,7 @@ def add_admin_for_app(user, app, secret):
     return "Error: Unable to update the user."
 
 
-def commit_new_app(appname, user, language, secret):
+def commit_new_app(appname, language, secret):
   global db
   global user_schema
   global app_schema
@@ -421,39 +421,16 @@ def commit_new_app(appname, user, language, secret):
   if does_app_exist(appname, secret) == "true":
     return EXISTING_PROJECT_MESSAGE
 
-  ret = "true"
-
-  try:
-    user_result = db.get_entity(USER_TABLE, user, user_schema)
-  except AppScaleDBConnectionError as db_error:
-    return 'Error: {}'.format(db_error)
-
-  if user_result[0] in ERROR_CODES and len(user_result) > 1:
-    user_result = user_result[1:]
-    n_user = Users("a", "b", "c")
-    n_user.unpackit(user_result)
-    n_user.applications_.append(appname)
-    t = datetime.datetime.now()
-    n_user.date_change_ = str(time.mktime(t.timetuple()))
-    n_app = Apps(appname, user, language)
-    array = n_user.arrayit()
-
-    result = db.put_entity(USER_TABLE, user, user_schema, array)
-    if result[0] in ERROR_CODES:
-      ret = "true"
-    else:
-      return "false"
-
-    array = n_app.arrayit()
-    result = db.put_entity(APP_TABLE, appname, app_schema, array)
-    if result[0] in ERROR_CODES:
-      ret = "true"
-    else:
-      return "false"
-    return ret
+  # User is not needed, but a placeholder is used to keep the same schema.
+  user = ''
+  n_app = Apps(appname, user, language)
+  array = n_app.arrayit()
+  result = db.put_entity(APP_TABLE, appname, app_schema, array)
+  if result[0] in ERROR_CODES:
+    ret = "true"
   else:
-    error = "Error: User not found"
-    return error
+    return "false"
+  return ret
 
 
 def get_tar(app_name, secret):

--- a/AppDashboard/lib/app_dashboard_helper.py
+++ b/AppDashboard/lib/app_dashboard_helper.py
@@ -433,7 +433,7 @@ class AppDashboardHelper(object):
         tgz_file.write(upload_file.read())
 
       try:
-        upload_info = acc.upload_app(tgz_file.name, file_suffix, user.email())
+        upload_info = acc.upload_app(tgz_file.name, file_suffix)
         status = upload_info['status']
 
         while status == AppUploadStatuses.STARTING:

--- a/AppServer/google/appengine/api/appcontroller_client.py
+++ b/AppServer/google/appengine/api/appcontroller_client.py
@@ -172,7 +172,7 @@ class AppControllerClient():
                      appid, http_port, https_port, self.secret))
     return res
 
-  def upload_app(self, filename, file_suffix, email):
+  def upload_app(self, filename, file_suffix):
     """Tells the AppController to use the AppScale Tools to upload the Google
     App Engine application at the specified location.
 
@@ -180,14 +180,12 @@ class AppControllerClient():
       filename: A str that points to a compressed file on the local filesystem
         containing the user's Google App Engine application.
       file_suffix: A str that names the suffix this file should have.
-      email: A str containing an e-mail address that should be registered as the
-        administrator of this application.
     Returns:
       A str that indicates either that the app was successfully uploaded, or the
       reason why the application upload failed.
     """
     return json.loads(self.call(self.MAX_RETRIES, self.server.upload_app,
-      filename, file_suffix, email, self.secret))
+      filename, file_suffix, self.secret))
 
 
   def get_app_upload_status(self, reservation_id):

--- a/Hermes/appscale/hermes/__init__.py
+++ b/Hermes/appscale/hermes/__init__.py
@@ -123,8 +123,7 @@ def deploy_sensor_app():
     try:
       logging.info("Deploying the sensor app for registered deployments.")
       acc = appscale_info.get_appcontroller_client()
-      acc.upload_app(app_dir_location, constants.FILE_SUFFIX,
-                     constants.USER_EMAIL)
+      acc.upload_app(app_dir_location, constants.FILE_SUFFIX)
     except AppControllerException:
       logging.exception("AppControllerException while trying to deploy "
         "appscalesensor app.")

--- a/common/appscale/common/ua_client.py
+++ b/common/appscale/common/ua_client.py
@@ -59,15 +59,14 @@ class UAClient(object):
     if response.lower() != 'true':
       raise UAException(response)
 
-  def commit_new_app(self, app_id, email, language):
+  def commit_new_app(self, app_id, language):
     """ Creates new project.
 
     Args:
       app_id: A string specifying an application ID.
-      email: A string specifying the user's email address.
       language: A string specifying the project's language.
     """
-    response = self.server.commit_new_app(app_id, email, language, self.secret)
+    response = self.server.commit_new_app(app_id, language, self.secret)
 
     # If the project already exists, consider the operation a success.
     if response == EXISTING_PROJECT_MESSAGE:

--- a/scripts/fast-start.sh
+++ b/scripts/fast-start.sh
@@ -267,7 +267,7 @@ KEYNAME=$(grep keyname /root/AppScalefile | cut -f 2 -d ":")
 
 # Deploy sample app.
 [ -z "${ADMIN_EMAIL}" ] && ADMIN_EMAIL="a@a.com"
-[ -e ${GUESTBOOK_APP} ] && ${APPSCALE_UPLOAD} --keyname ${KEYNAME} --email ${ADMIN_EMAIL} --file ${GUESTBOOK_APP}
+[ -e ${GUESTBOOK_APP} ] && ${APPSCALE_UPLOAD} --keyname ${KEYNAME} --file ${GUESTBOOK_APP}
 
 # Relocate to port 80.
 ${APPSCALE_CMD} relocate guestbook 80 443


### PR DESCRIPTION
This will make it easier to remove app metadata from the UAServer since it's stored in ZooKeeper now.