### PR TITLE
Remove routing for AppServer before stopping it

### DIFF
--- a/AppController/djinnServer.rb
+++ b/AppController/djinnServer.rb
@@ -85,6 +85,8 @@ class DjinnServer < SOAP::RPC::HTTPServer
     add_method(@djinn, "gather_logs", "secret")
     add_method(@djinn, "add_routing_for_appserver", "app_id", "ip", "port",
       "secret")
+    add_method(@djinn, 'remove_routing_for_appserver', 'version_key', 'ip',
+               'port', 'secret')
     add_method(@djinn, "add_routing_for_blob_server", "secret")
     add_method(@djinn, "run_groomer", "secret")
     add_method(@djinn, "get_property", "property_regex", "secret")

--- a/AppController/lib/app_controller_client.rb
+++ b/AppController/lib/app_controller_client.rb
@@ -85,6 +85,8 @@ class AppControllerClient
     @conn.add_method("get_node_stats_json", "secret")
     @conn.add_method("get_instance_info", "secret")
     @conn.add_method("get_request_info", "app_id", "secret")
+    @conn.add_method('remove_routing_for_appserver', 'version_key', 'ip',
+                     'port', 'secret')
   end
 
 
@@ -241,4 +243,10 @@ class AppControllerClient
     }
   end
 
+  # Instructs Nginx and HAProxy to stop routing traffic for the AppServer.
+  def remove_routing_for_appserver(version_key, ip, port)
+    make_call(10, RETRY_ON_FAIL, 'remove_routing_for_appserver') {
+      @conn.remove_routing_for_appserver(version_key, ip, port, @secret)
+    }
+  end
 end

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -23,6 +23,9 @@ from tornado.httpclient import HTTPError
 from tornado.ioloop import IOLoop
 from tornado.options import options
 
+from appscale.admin.constants import DEFAULT_SERVICE
+from appscale.admin.constants import DEFAULT_VERSION
+from appscale.admin.constants import VERSION_PATH_SEPARATOR
 from appscale.admin.instance_manager.constants import (
   APP_LOG_SIZE,
   DASHBOARD_LOG_SIZE,
@@ -375,6 +378,12 @@ def stop_app_instance(app_name, port):
     return False
 
   logging.info("Stopping application %s" % app_name)
+
+  acc = appscale_info.get_appcontroller_client()
+  version_key = VERSION_PATH_SEPARATOR.join(
+    [app_name, DEFAULT_SERVICE, DEFAULT_VERSION])
+  acc.remove_routing_for_appserver(version_key, options.private_ip, port)
+
   watch = '{}{}-{}'.format(MONIT_INSTANCE_PREFIX, app_name, port)
 
   pid_location = os.path.join(constants.PID_DIR, '{}.pid'.format(watch))

--- a/AppManager/test/unit/test_app_manager_server.py
+++ b/AppManager/test/unit/test_app_manager_server.py
@@ -235,6 +235,11 @@ class TestAppManager(unittest.TestCase):
   def test_stop_app_instance(self):
     app_id = 'test'
     port = 20000
+
+    acc = flexmock(remove_routing_for_appserver=lambda key, ip, port: None)
+    flexmock(appscale_info).should_receive('get_appcontroller_client').\
+      and_return(acc)
+
     flexmock(misc).should_receive('is_app_name_valid').and_return(False)
     self.assertFalse(app_manager_server.stop_app_instance(app_id, port))
 

--- a/AppServer/google/appengine/api/appcontroller_client.py
+++ b/AppServer/google/appengine/api/appcontroller_client.py
@@ -329,6 +329,19 @@ class AppControllerClient():
       app_id, appserver_ip, port, self.secret)
 
 
+  def remove_routing_for_appserver(self, version_key, ip, port):
+    """ Instructs the AppController to stop routing traffic to an AppServer.
+
+    Args:
+      version_key: A string specifying the version key.
+      ip: A string specifying the location of the AppServer instance.
+      port: An integer specifying the location of the AppServer instance.
+    """
+    return self.call(
+      self.MAX_RETRIES, self.server.remove_routing_for_appserver, version_key,
+      ip, port, self.secret)
+
+
   def add_routing_for_blob_server(self):
     """ Tells the AppController to begin routing traffic to the
         BlobServer(s).

--- a/AppServer/google/appengine/api/appcontroller_client.py
+++ b/AppServer/google/appengine/api/appcontroller_client.py
@@ -334,8 +334,8 @@ class AppControllerClient():
 
     Args:
       version_key: A string specifying the version key.
-      ip: A string specifying the location of the AppServer instance.
-      port: An integer specifying the location of the AppServer instance.
+      ip: A string specifying the IP address or hostname of the AppServer.
+      port: An integer specifying the port the AppServer instance is using.
     """
     return self.call(
       self.MAX_RETRIES, self.server.remove_routing_for_appserver, version_key,


### PR DESCRIPTION
Typically, the routing has already been removed. However, there are rare cases when the instance in in the app_info_map and the AppServer is not running.

During the euca reboot test, the app_info_map ended up with two AppServers (for two different apps) assigned to the same port on the same machine. The autoscaler did not know anything was amiss because the AppServer for the first app was running. The controller on the appengine machine knew that the AppServer was not running for the second app, but it was not able to remove the routing. This should fix that issue.