### PR TITLE
add type for collection for build

### DIFF
--- a/AppServer_Java/src/com/google/apphosting/utils/config/QueueXml.java
+++ b/AppServer_Java/src/com/google/apphosting/utils/config/QueueXml.java
@@ -44,7 +44,7 @@ public class QueueXml {
       this.validateLastEntry();
    }
 
-   public Collection getEntries() {
+   public Collection<QueueXml.Entry> getEntries() {
       this.validateLastEntry();
       return this.entries.values();
    }


### PR DESCRIPTION
https://ocd.appscale.com:8080/job/Daily%20Build/3792/
Create-Eucalyptus-Image fails without this because `required: Entry found:    Object` as shown in https://ocd.appscale.com:8080/job/Create-Eucalyptus-Image/4790/console