### PR TITLE
Only take port from pending_appservers when checking availability

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5029,8 +5029,7 @@ HOSTS
   # Returns:
   def is_port_assigned(port_to_check)
     @pending_appservers.each { |appserver, _|
-      host, port = appserver.split(":")
-      next if @my_private_ip != host
+      port = appserver.split(':')[1]
       return true if port_to_check == Integer(port)
     }
     return false


### PR DESCRIPTION
The app engine controllers only keep track of their own pending instances. The first part of the instance key does not contain an IP address.