### PR TITLE
Write the secret for the dashboard at runtime

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/source_manager.py
+++ b/AdminServer/appscale/admin/instance_manager/source_manager.py
@@ -11,10 +11,15 @@ from tornado import gen
 from tornado.options import options
 
 from appscale.common.appscale_utils import get_md5
+from appscale.common.appscale_info import get_secret
 from .utils import fetch_file
-from ..constants import InvalidSource
-from ..constants import SOURCES_DIRECTORY
-from ..constants import UNPACK_ROOT
+from ..constants import (
+  DASHBOARD_APP_ID,
+  InvalidSource,
+  SOURCES_DIRECTORY,
+  UNPACK_ROOT,
+  VERSION_PATH_SEPARATOR
+)
 from ..utils import extract_source
 
 
@@ -94,6 +99,10 @@ class SourceManager(object):
     yield self.thread_pool.submit(extract_source, revision_key, location,
                                   runtime)
 
+    project_id = revision_key.split(VERSION_PATH_SEPARATOR)[0]
+    if project_id == DASHBOARD_APP_ID:
+      self.update_secret(revision_key)
+
   @gen.coroutine
   def ensure_source(self, revision_key, location, runtime):
     """ Wait until the revision source is ready.
@@ -149,3 +158,16 @@ class SourceManager(object):
 
     for revision_key in futures_to_clear:
       del self.source_futures[revision_key]
+
+  def update_secret(self, revision_key):
+    """ Ensures the revision's secret matches the deployment secret. """
+    deployment_secret = get_secret()
+    revision_base = os.path.join(UNPACK_ROOT, revision_key)
+    secret_module = os.path.join(revision_base, 'app', 'lib', 'secret_key.py')
+    with open(secret_module) as secret_file:
+      revision_secret = secret_file.read().split()[-1][1:-1]
+      if revision_secret == deployment_secret:
+        return
+
+    with open(secret_module, 'w') as secret_file:
+      secret_file.write("GLOBAL_SECRET_KEY = '{}'".format(deployment_secret))

--- a/AppController/lib/app_dashboard.rb
+++ b/AppController/lib/app_dashboard.rb
@@ -43,7 +43,6 @@ module AppDashboard
 
     # Pass the secret key and our public IP address (needed to connect to the
     # AppController) to the app.
-    Djinn.log_run("echo \"GLOBAL_SECRET_KEY = '#{secret}'\" > #{APPSCALE_HOME}/AppDashboard/lib/secret_key.py")
     Djinn.log_run("echo \"MY_PUBLIC_IP = '#{public_ip}'\" > #{APPSCALE_HOME}/AppDashboard/lib/local_host.py")
     Djinn.log_run("echo \"UA_SERVER_IP = '#{private_ip}'\" > #{APPSCALE_HOME}/AppDashboard/lib/uaserver_host.py")
 
@@ -57,7 +56,6 @@ module AppDashboard
     HelperFunctions.write_file(port_file, "#{LISTEN_PORT}")
 
     # Restore repo template values.
-    Djinn.log_run("echo \"GLOBAL_SECRET_KEY = 'THIS VALUE WILL BE OVERWRITTEN ON STARTUP'\" > #{APPSCALE_HOME}/AppDashboard/lib/secret_key.py")
     Djinn.log_run("echo \"MY_PUBLIC_IP = 'THIS VALUE WILL BE OVERWRITTEN ON STARTUP'\" > #{APPSCALE_HOME}/AppDashboard/lib/local_host.py")
     Djinn.log_run("echo \"UA_SERVER_IP = 'THIS VALUE WILL BE OVERWRITTEN ON STARTUP'\" > #{APPSCALE_HOME}/AppDashboard/lib/uaserver_host.py")
 


### PR DESCRIPTION
This fixes an issue where the dashboard did not have the correct secret after restarting the deployment.