### PR TITLE
Provide pidfile hint for systemd's unit converter

### DIFF
--- a/AppController/scripts/appcontroller
+++ b/AppController/scripts/appcontroller
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+# pidfile: /var/run/appscale/controller.pid
+
 ### BEGIN INIT INFO
 # Provides:          appscale-controller
 # Required-Start:    $local_fs


### PR DESCRIPTION
systemd-sysv-generator supports the Red Hat-style pidfile hint at the top of init scripts when generating systemd unit files. This generates a unit file with the "PIDFile=" option, allowing systemd to recognize the main pid for a forking service.

https://www.freedesktop.org/wiki/Software/systemd/Incompatibilities/ has more information.