### PR TITLE
Monitor also the cron daemon

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -542,7 +542,9 @@ EOF
     sed -i 's/set daemon.*/set daemon 5/' /etc/monit/monitrc
 
     # Monitor cron.
-    if [ -e /etc/monit/conf-available/cron -a ! -e /etc/monit/conf-enabled/cron ]; then
+    if [ -e /etc/monit/conf-available/cron ] &&
+            [ -e /etc/monit/conf-enabled ] &&
+            [ ! -e /etc/monit/conf-enabled/cron ]; then
         ln -s /etc/monit/conf-available/cron /etc/monit/conf-enabled
     fi
 

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -541,6 +541,11 @@ EOF
     # Check services every 5 seconds
     sed -i 's/set daemon.*/set daemon 5/' /etc/monit/monitrc
 
+    # Monitor cron.
+    if [ -e /etc/monit/conf-available/cron -a ! -e /etc/monit/conf-enabled/cron ]; then
+        ln -s /etc/monit/conf-available/cron /etc/monit/conf-enabled
+    fi
+
     # Monit cannot start at boot time: in case of accidental reboot, it
     # would start processes out of order. The controller will restart
     # monit as soon as it starts.


### PR DESCRIPTION
This is to ensure cron won't be accidentally stop, and to avoid extra
logs from monit on xenial machines.