### PR TITLE
Stop group after terminating process

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/constants.py
+++ b/AdminServer/appscale/admin/instance_manager/constants.py
@@ -38,6 +38,10 @@ REPACKED_LIB_DIR = os.path.join(
 # The maximum number of threads to use for executing blocking tasks.
 MAX_BACKGROUND_WORKERS = 4
 
+# The number of seconds an instance is allowed to finish serving requests after
+# it receives a shutdown signal.
+MAX_INSTANCE_RESPONSE_TIME = 600
+
 # Patterns that match jars that should be copied to version sources.
 MODIFIED_JARS = [
   os.path.join(REPACKED_LIB_DIR, 'user', '*.jar'),

--- a/AdminServer/appscale/admin/instance_manager/stop_instance.py
+++ b/AdminServer/appscale/admin/instance_manager/stop_instance.py
@@ -1,0 +1,51 @@
+""" Stops an AppServer instance. """
+import argparse
+import os
+import psutil
+import signal
+
+from appscale.common.constants import PID_DIR
+
+# The number of seconds to wait for an instance to terminate.
+DEFAULT_WAIT_TIME = 20
+
+
+def stop_instance(watch, timeout):
+  """ Stops an AppServer process.
+
+  Args:
+    watch: A string specifying the Monit watch entry.
+    timeout: An integer specifying the time to wait for requests to finish.
+  Raises:
+    IOError if the pidfile does not exist.
+    OSError if the process does not exist.
+  """
+  pidfile_location = os.path.join(PID_DIR, '{}.pid'.format(watch))
+  with open(pidfile_location) as pidfile:
+    pid = int(pidfile.read().strip())
+
+  group = os.getpgid(pid)
+  process = psutil.Process(pid)
+  process.terminate()
+  try:
+    process.wait(timeout)
+  except psutil.TimeoutExpired:
+    process.kill()
+
+  try:
+    os.killpg(group, signal.SIGKILL)
+  except OSError:
+    # In most cases, the group will already be gone.
+    pass
+
+  os.remove(pidfile_location)
+
+
+def main():
+  """ Stops an AppServer instance. """
+  parser = argparse.ArgumentParser(description='Stops an AppServer instance')
+  parser.add_argument('--watch', required=True, help='The Monit watch entry')
+  parser.add_argument('--timeout', default=20,
+                      help='The seconds to wait before killing the instance')
+  args = parser.parse_args()
+  stop_instance(args.watch, args.timeout)

--- a/AdminServer/setup.py
+++ b/AdminServer/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup
 install_requires = [
   'appscale-common',
   'kazoo',
+  'psutil',
   'PyYaml',
   'SOAPpy',
   'tornado'
@@ -33,5 +34,8 @@ setup(
   packages=['appscale',
             'appscale.admin',
             'appscale.admin.instance_manager'],
-  entry_points={'console_scripts': ['appscale-admin=appscale.admin:main']}
+  entry_points={'console_scripts': [
+    'appscale-admin=appscale.admin:main',
+    'appscale-stop-instance=appscale.admin.instance_manager.stop_instance:main'
+  ]}
 )

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -318,23 +318,6 @@ def setup_logrotate(app_name, log_size):
 
   return True
 
-@gen.coroutine
-def kill_instance(watch, instance_pid):
-  """ Stops an AppServer process.
-
-  Args:
-    watch: A string specifying the monit entry for the process.
-    instance_pid: An integer specifying the process ID.
-  """
-  process = psutil.Process(instance_pid)
-  process.terminate()
-  try:
-    yield thread_pool.submit(process.wait, MAX_INSTANCE_RESPONSE_TIME)
-  except psutil.TimeoutExpired:
-    process.kill()
-
-  logging.info('Finished stopping {}'.format(watch))
-
 def unmonitor(process_name, retries=5):
   """ Unmonitors a process.
 

--- a/AppManager/test/unit/test_app_manager_server.py
+++ b/AppManager/test/unit/test_app_manager_server.py
@@ -225,6 +225,12 @@ class TestAppManager(AsyncTestCase):
     flexmock(misc).should_receive('is_app_name_valid').and_return(True)
     flexmock(app_manager_server).should_receive('unmonitor').\
       and_raise(HTTPError)
+
+    unmonitor_future = Future()
+    unmonitor_future.set_exception(HTTPError(500))
+    flexmock(app_manager_server).should_receive('unmonitor_and_terminate').\
+      and_return(unmonitor_future)
+
     entries_response = Future()
     entries_response.set_result(['app___test_default_v1_revid-20000'])
     flexmock(MonitOperator).should_receive('get_entries').\
@@ -233,11 +239,6 @@ class TestAppManager(AsyncTestCase):
     with self.assertRaises(HTTPError):
       yield app_manager_server.stop_app_instance(version_key, port)
 
-    builtins = flexmock(sys.modules['__builtin__'])
-    builtins.should_call('open')
-    builtins.should_receive('open').\
-      with_args('/var/run/appscale/app___test_default_v1_revid-20000.pid').\
-      and_return(flexmock(read=lambda: '20000'))
     flexmock(app_manager_server).should_receive('unmonitor')
     flexmock(os).should_receive('remove')
     flexmock(monit_interface).should_receive('run_with_retry')

--- a/common/appscale/common/monit_app_configuration.py
+++ b/common/appscale/common/monit_app_configuration.py
@@ -51,8 +51,7 @@ def create_config_file(watch, start_cmd, pidfile, port=None, env_vars=None,
   logfile = os.path.join(
     '/', 'var', 'log', 'appscale', '{}.log'.format(process_name))
 
-  stop = ('start-stop-daemon --stop --pidfile {0} --retry=TERM/20/KILL/5 && '
-          'rm {0}'.format(pidfile))
+  stop = 'appscale-stop-instance --watch {}'.format(process_name)
   if syslog_server is None:
     bash_exec = 'exec env {vars} {start_cmd} >> {log} 2>&1'.format(
       vars=env_vars_str, start_cmd=start_cmd, log=logfile)


### PR DESCRIPTION
There are times when killing the main AppServer process does not stop all of the processes in the group.