### PR TITLE
Close KazooClient when stopping servers

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/appscale_taskqueue.py
+++ b/AppTaskQueue/appscale/taskqueue/appscale_taskqueue.py
@@ -34,6 +34,9 @@ server = None
 # Global for Distributed TaskQueue.
 task_queue = None
 
+# A KazooClient for watching queue configuration.
+zk_client = None
+
 # Global stats.
 STATS = {}
 
@@ -208,6 +211,7 @@ def graceful_shutdown(*_):
   of requests as soon as the server has asynchronous handlers.
   """
   logger.info('Stopping server')
+  zk_client.stop()
   server.stop()
   io_loop = IOLoop.instance()
   io_loop.add_callback_from_signal(io_loop.stop)
@@ -225,7 +229,7 @@ def main():
   if args.verbose:
     logger.setLevel(logging.DEBUG)
 
-  global task_queue
+  global task_queue, zk_client
 
   zk_client = KazooClient(
     hosts=','.join(appscale_info.get_zk_node_ips()),

--- a/Hermes/appscale/hermes/__init__.py
+++ b/Hermes/appscale/hermes/__init__.py
@@ -35,6 +35,9 @@ from appscale.hermes.stats import constants as stats_constants
 sys.path.append(APPSCALE_PYTHON_APPSERVER)
 from google.appengine.api.appcontroller_client import AppControllerException
 
+# A KazooClient for detecting configuration changes.
+zk_client = None
+
 
 class SensorDeployer(object):
   """ Uploads the sensor app for registered deployments. """
@@ -187,6 +190,7 @@ def create_xmpp_user(password, uaserver):
 def signal_handler(signal, frame):
   """ Signal handler for graceful shutdown. """
   logging.warning("Caught signal: {0}".format(signal))
+  zk_client.stop()
   IOLoop.instance().add_callback(shutdown)
 
 
@@ -226,6 +230,7 @@ def main():
     # Only master Hermes node handles /do_task route
     task_route = ('/do_task', TaskHandler)
 
+    global zk_client
     zk_client = KazooClient(
       hosts=','.join(appscale_info.get_zk_node_ips()),
       connection_retry=ZK_PERSISTENT_RECONNECTS)

--- a/Hermes/appscale/hermes/test/unit/test_hermes.py
+++ b/Hermes/appscale/hermes/test/unit/test_hermes.py
@@ -70,6 +70,7 @@ class TestHelper(unittest.TestCase):
     poll()
 
   def test_signal_handler(self):
+    hermes.zk_client = flexmock(stop=lambda: None)
     flexmock(IOLoop.instance()).should_receive('add_callback').and_return()\
       .times(1)
     signal_handler(15, None)


### PR DESCRIPTION
When trying to reconnect, the client can block the servers from shutting down.