### PR TITLE
Mock out blocking calls in unit tests

### DIFF
--- a/AppDB/test/unit/test_cassandra_backup.py
+++ b/AppDB/test/unit/test_cassandra_backup.py
@@ -3,6 +3,7 @@
 import re
 import sys
 import subprocess
+import time
 import unittest
 from flexmock import flexmock
 
@@ -101,6 +102,8 @@ class TestCassandraBackup(unittest.TestCase):
       re.compile('^192.*'), keyname, re.compile('^chown -R cassandra /opt/.*'))
     flexmock(rebalance).should_receive('get_status').and_return(
       [{'state': 'UN'} for _ in db_ips])
+
+    flexmock(time).should_receive('sleep')
 
     cassandra_backup.restore_data(path, keyname)
 

--- a/InfrastructureManager/tests/test_ec2_agent.py
+++ b/InfrastructureManager/tests/test_ec2_agent.py
@@ -123,6 +123,7 @@ class TestEC2Agent(TestCase):
     reservation.instances = [instance]
     self.fake_ec2.should_receive('get_all_instances').and_return([reservation])
 
+    flexmock(i).should_receive('_InfrastructureManager__kill_vms')
     result = i.terminate_instances(params2, 'secret')
     if not blocking:
       time.sleep(.1)


### PR DESCRIPTION
This reduces unit test times from 36 seconds to 19 seconds.