### PR TITLE
Don't remove dict items while iterate over it

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/projects_manager.py
+++ b/AdminServer/appscale/admin/instance_manager/projects_manager.py
@@ -125,7 +125,7 @@ class ServiceManager(dict):
 
   def stop(self):
     """ Stops all watches associated with this service. """
-    for version_id in self:
+    for version_id in self.keys():
       del self[version_id]
 
     self._stopped = True
@@ -187,7 +187,7 @@ class ProjectManager(dict):
 
   def stop(self):
     """ Stops all watches associated with this service. """
-    for service_id in self:
+    for service_id in self.keys():
       self[service_id].stop()
       del self[service_id]
 


### PR DESCRIPTION
```
d = {1: 2, 3: 4, 5: 6}
for k in d:
  del d[k]
print d
----------------------------------
RuntimeError: dictionary changed size during iteration
```
```
d = {1: 2, 3: 4, 5: 6}
for k in d.keys():
  del d[k]
print d
----------------------------------
{}
```
```
d = {1: 2, 3: 4, 5: 6}
print id(d)
print id(d.keys())
----------------------------------
140684452645136
140684452614440
```