### PR TITLE
Stop Monit entries one at a time

### DIFF
--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -24,7 +24,7 @@ module TerminateHelper
       all_stopped = true
       monit_output.each_line do |line|
         # Leave cron-related entries alone.
-        next if line.start_with?('cron')
+        next if line.include?('cron')
         next if line.start_with?('System')
         next unless line.include?('Running')
         all_stopped = false

--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -27,10 +27,13 @@ module TerminateHelper
         next if line.include?('cron')
         next if line.start_with?('System')
         next unless line.include?('Running')
+
         all_stopped = false
+        next if line.include?('stop pending')
         entry = line.split[1][1..-2]
         `monit stop #{entry} 2>&1`
         sleep(0.5)
+        break
       end
       break if all_stopped
     end

--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -17,11 +17,22 @@ module TerminateHelper
     `rm -f /etc/nginx/sites-enabled/appscale-*.conf`
     `rm -f /etc/haproxy/sites-enabled/*.cfg`
     `service nginx reload`
-    while system("monit summary | grep Running > /dev/null") do
-      # Stop and then remove the service we configured with monit.
-      `monit stop all`
-      puts "Waiting for monit to stop services ..."
-      Kernel.sleep(10)
+
+    puts "Waiting for monit to stop services ..."
+    loop do
+      monit_output = `monit summary`
+      all_stopped = true
+      monit_output.each_line do |line|
+        # Leave cron-related entries alone.
+        next if line.start_with?('cron')
+        next if line.start_with?('System')
+        next unless line.include?('Running')
+        all_stopped = false
+        entry = line.split[1][1..-2]
+        `monit stop #{entry} 2>&1`
+        sleep(0.5)
+      end
+      break if all_stopped
     end
 
     `rm -f /etc/monit/conf.d/appscale*.cfg`


### PR DESCRIPTION
`monit stop all` fails for Monit 5.16 when the combine list of entry names is longer than 1kb.

https://bitbucket.org/tildeslash/monit/issues/327