### PR TITLE
Be persistent when handling zk watch update

### DIFF
--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -312,7 +312,7 @@ class ProjectHandler(BaseVersionHandler):
   @gen.coroutine
   def wait_for_delete(self, ports_to_close, project_id):
     """ Tracks the progress of removing version(s).
-  
+
     Args:
       ports_to_close: A list of integers specifying the ports to wait for.
       project_id: The id of the project we are deleting.
@@ -359,7 +359,7 @@ class ProjectHandler(BaseVersionHandler):
   @gen.coroutine
   def delete(self, project_id):
     """ Deletes a project.
-    
+
     Args:
       project_id: The id of the project to delete.
     """
@@ -615,7 +615,7 @@ class VersionsHandler(BaseHandler):
 
   def begin_deploy(self, project_id, service_id, version_id):
     """ Triggers the deployment process.
-    
+
     Args:
       project_id: A string specifying a project ID.
       service_id: A string specifying a service ID.
@@ -666,7 +666,7 @@ class VersionsHandler(BaseHandler):
   @gen.coroutine
   def post(self, project_id, service_id):
     """ Creates or updates a version.
-    
+
     Args:
       project_id: A string specifying a project ID.
       service_id: A string specifying a service ID.
@@ -936,7 +936,7 @@ class OperationsHandler(BaseHandler):
   """ Retrieves operations. """
   def get(self, project_id, operation_id):
     """ Retrieves operation status.
-    
+
     Args:
       project_id: A string specifying a project ID.
       operation_id: A string specifying an operation ID.

--- a/AdminServer/appscale/admin/instance_manager/projects_manager.py
+++ b/AdminServer/appscale/admin/instance_manager/projects_manager.py
@@ -79,7 +79,7 @@ class VersionManager(object):
       return False
 
     persistent_update_version = utils.retry_data_watch_coroutine(
-      self.zk_client, self.version_node, self.update_version
+      self.version_node, self.update_version
     )
     main_io_loop = IOLoop.instance()
     main_io_loop.add_callback(persistent_update_version, new_version)
@@ -149,7 +149,7 @@ class ServiceManager(dict):
       return False
 
     persistent_update_versions = utils.retry_children_watch_coroutine(
-      self.zk_client, self.versions_node, self.update_versions
+      self.versions_node, self.update_versions
     )
     main_io_loop = IOLoop.instance()
     main_io_loop.add_callback(persistent_update_versions, new_versions_list)
@@ -215,7 +215,7 @@ class ProjectManager(dict):
       return False
 
     persistent_update_services = utils.retry_children_watch_coroutine(
-      self.zk_client, self.services_node, self.update_services
+      self.services_node, self.update_services
     )
     main_io_loop = IOLoop.instance()
     main_io_loop.add_callback(persistent_update_services, new_services_list)
@@ -264,7 +264,7 @@ class GlobalProjectsManager(dict):
       new_projects_list: A fresh list of strings specifying existing projects.
     """
     persistent_update_project = utils.retry_children_watch_coroutine(
-      self.zk_client, '/appscale/projects', self.update_projects
+      '/appscale/projects', self.update_projects
     )
     main_io_loop = IOLoop.instance()
     main_io_loop.add_callback(persistent_update_project, new_projects_list)

--- a/AdminServer/appscale/admin/push_worker_manager.py
+++ b/AdminServer/appscale/admin/push_worker_manager.py
@@ -18,6 +18,8 @@ from appscale.common.constants import (
 )
 from appscale.common.monit_app_configuration import create_config_file
 from appscale.common.monit_app_configuration import MONIT_CONFIG_DIR
+
+from appscale.admin import utils
 from .utils import ensure_path
 
 # The number of tasks the Celery worker can handle at a time.
@@ -178,8 +180,6 @@ class ProjectPushWorkerManager(object):
     Args:
       queue_config: A JSON string specifying queue configuration.
     """
-    main_io_loop = IOLoop.instance()
-
     # Prevent further watches if they are no longer needed.
     if queue_config is None:
       try:
@@ -193,7 +193,11 @@ class ProjectPushWorkerManager(object):
         self._stopped = True
         return False
 
-    main_io_loop.add_callback(self.update_worker, queue_config)
+    persistent_update_worker = utils.retry_data_watch_coroutine(
+      self.zk_client, self.queues_node, self.update_worker
+    )
+    main_io_loop = IOLoop.instance()
+    main_io_loop.add_callback(persistent_update_worker, queue_config)
 
 
 class GlobalPushWorkerManager(object):
@@ -241,5 +245,8 @@ class GlobalPushWorkerManager(object):
     Args:
       new_projects: A list of strings specifying all existing project IDs.
     """
+    persistent_update_project = utils.retry_children_watch_coroutine(
+      self.zk_client, '/appscale/projects', self.update_projects
+    )
     main_io_loop = IOLoop.instance()
-    main_io_loop.add_callback(self.update_projects, new_projects)
+    main_io_loop.add_callback(persistent_update_project, new_projects)

--- a/AdminServer/appscale/admin/push_worker_manager.py
+++ b/AdminServer/appscale/admin/push_worker_manager.py
@@ -194,7 +194,7 @@ class ProjectPushWorkerManager(object):
         return False
 
     persistent_update_worker = utils.retry_data_watch_coroutine(
-      self.zk_client, self.queues_node, self.update_worker
+      self.queues_node, self.update_worker
     )
     main_io_loop = IOLoop.instance()
     main_io_loop.add_callback(persistent_update_worker, queue_config)
@@ -246,7 +246,7 @@ class GlobalPushWorkerManager(object):
       new_projects: A list of strings specifying all existing project IDs.
     """
     persistent_update_project = utils.retry_children_watch_coroutine(
-      self.zk_client, '/appscale/projects', self.update_projects
+      '/appscale/projects', self.update_projects
     )
     main_io_loop = IOLoop.instance()
     main_io_loop.add_callback(persistent_update_project, new_projects)

--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -10,10 +10,6 @@ import tarfile
 
 import random
 
-import traceback
-
-import weakref
-
 import collections
 from appscale.common.constants import HTTPCodes
 from appscale.common.constants import VERSION_PATH_SEPARATOR
@@ -21,7 +17,6 @@ from appscale.taskqueue import constants as tq_constants
 from appscale.taskqueue.constants import InvalidQueueConfiguration
 from kazoo.exceptions import NoNodeError
 from tornado import gen, locks
-from tornado.gen import BadYieldError
 
 from . import constants
 from .constants import (

--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -510,7 +510,7 @@ def retry_coroutine(func, async=True, backoff_base=2, backoff_multiplier=0.2,
                     retry_on_exception=None, refresh_args_kwargs_func=None):
   """ Wraps func with retry mechanism which runs up to max_retries attempts
   with exponential backoff (sleep = backoff_multiplier * backoff_base**X).
-  
+
   Args:
     func: function or coroutine to wrap.
     async: a boolean indicating if result of function should be yielded.

--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -575,7 +575,7 @@ def retry_coroutine(func, async=True, backoff_base=2, backoff_multiplier=0.2,
 def retry_data_watch_coroutine(zk_client, node, func, **kwargs):
   """ Prepares retry coroutine which will do retries with the newest
   state of node.
-  
+
   Args:
     zk_client: an instance of KazooClient.
     node: a string representing zk node path.
@@ -601,7 +601,7 @@ def retry_data_watch_coroutine(zk_client, node, func, **kwargs):
 def retry_children_watch_coroutine(zk_client, node, func, **kwargs):
   """ Prepares retry coroutine which will do retries with the newest
   children list.
-  
+
   Args:
     zk_client: an instance of KazooClient.
     node: a string representing zk node path.

--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -559,7 +559,7 @@ def retry_coroutine(func, async=True, backoff_base=2, backoff_multiplier=0.2,
         retries += 1
 
         # Proceed with exponential backoff
-        sleep_time = backoff * random.gauss(1, 0.3)
+        sleep_time = backoff * (random.random()*0.3 + 0.85)
         backoff *= backoff_base
         if backoff > backoff_threshold:
           backoff = backoff_threshold
@@ -585,7 +585,10 @@ def retry_data_watch_coroutine(zk_client, node, func, **kwargs):
     A tornado coroutine wrapping function with retry mechanism.
   """
   def refresh_data():
-    data = zk_client.get(node)
+    try:
+      data = zk_client.get(node)
+    except NoNodeError:
+      data = None
     args = (data, )
     keyword_args = {}
     return args, keyword_args

--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -510,8 +510,8 @@ class _PersistentWatch(object):
 
     class CompliantLock(object):
       """
-      A container for three pieces which makes possible to
-      organize compliant locking of zk_node:
+      A container which allows to organize compliant locking
+      of zk_node by making sure:
        - update function won't be interrupted by another;
        - sleep between retries can be interrupted by newer update;
        - _PersistentWatch is able to identify and remove unused locks.
@@ -586,7 +586,7 @@ class _PersistentWatch(object):
             logger.exception(u"Retry #{retry} in {sleep:0.1f}s"
                              .format(retry=retries, sleep=sleep_time))
 
-            # (*) Sleep with one eye open, give up if newer update wake you
+            # (*) Sleep with one eye open, give up if newer update wakes you
             interrupted = yield node_lock.condition.wait(sleep_time)
             if interrupted or node_lock.waiters:
               logger.info("Giving up retrying because newer update came up")

--- a/AdminServer/setup.py
+++ b/AdminServer/setup.py
@@ -8,14 +8,15 @@ install_requires = [
   'psutil',
   'PyYaml',
   'SOAPpy',
-  'tornado'
+  'tornado',
+  'mock',
 ]
 if sys.version_info < (3,):
   install_requires.append('futures')
 
 setup(
   name='appscale-admin',
-  version='0.0.1',
+  version='0.0.2',
   description='An implementation of the Google App Engine Admin API',
   author='AppScale Systems, Inc.',
   url='https://github.com/AppScale/appscale',

--- a/AdminServer/tests/test_utils.py
+++ b/AdminServer/tests/test_utils.py
@@ -79,10 +79,10 @@ class TestRetryCoroutine(testing.AsyncTestCase):
 
   @patch.object(utils.gen, 'sleep')
   @patch.object(utils.logger, 'error')
-  @patch.object(utils.random, 'gauss')
+  @patch.object(utils.random, 'random')
   @testing.gen_test
   def test_backoff_and_logging(self, gauss_mock, logger_mock, gen_sleep_mock):
-    random_value = 1.1
+    random_value = 0.84
     gauss_mock.return_value = random_value
     gen_sleep_mock.side_effect = testing.gen.coroutine(lambda sec: sec)
 
@@ -101,10 +101,10 @@ class TestRetryCoroutine(testing.AsyncTestCase):
 
     # Check backoff sleep calls (0.1 * (3 ** attempt) * random_value).
     sleep_args = [args[0] for args, kwargs in gen_sleep_mock.call_args_list]
-    self.assertAlmostEqual(sleep_args[0], 0.33, 5)
-    self.assertAlmostEqual(sleep_args[1], 0.99, 5)
-    self.assertAlmostEqual(sleep_args[2], 2.2, 5)
-    self.assertAlmostEqual(sleep_args[3], 2.2, 5)
+    self.assertAlmostEqual(sleep_args[0], 0.33, 2)
+    self.assertAlmostEqual(sleep_args[1], 0.99, 2)
+    self.assertAlmostEqual(sleep_args[2], 2.2, 2)
+    self.assertAlmostEqual(sleep_args[3], 2.2, 2)
 
     # Verify logged errors.
     expected_logs = [

--- a/AdminServer/tests/test_utils.py
+++ b/AdminServer/tests/test_utils.py
@@ -1,8 +1,6 @@
 import unittest
 
-import re
-from mock import call, patch
-from mock.mock import MagicMock
+from mock import patch
 from tornado import testing, gen
 
 from appscale.admin import utils

--- a/AdminServer/tests/test_utils.py
+++ b/AdminServer/tests/test_utils.py
@@ -115,9 +115,9 @@ class TestRetryCoroutine(testing.AsyncTestCase):
     ]
     self.assertEqual(len(expected_logs), len(logger_mock.call_args_list))
     expected_messages = iter(expected_logs)
-    for call_args, call_kwargs in logger_mock.call_args_list:
+    for call_args_kwargs in logger_mock.call_args_list:
       error_message = expected_messages.next()
-      self.assertRegexpMatches(call_args[0], error_message)
+      self.assertRegexpMatches(call_args_kwargs[0][0], error_message)
 
   @patch.object(utils.gen, 'sleep')
   @testing.gen_test


### PR DESCRIPTION
Before this PR data watch and children watch never retried to react on zk update.
Particularly, if you run multiple deploy and undeploy actions in short period of time, there is a chance that handling undeploy operation fail and deploy operation won't be handled at all.