### PR TITLE
Handle missing WEB-INF directory

### DIFF
--- a/AppController/lib/cron_helper.rb
+++ b/AppController/lib/cron_helper.rb
@@ -1,7 +1,10 @@
 require 'digest/sha1'
 require 'rexml/document'
-require 'helperfunctions'
 require 'uri'
+
+require 'custom_exceptions'
+require 'helperfunctions'
+
 include REXML
 
 
@@ -96,7 +99,13 @@ CRON
       }
 
     elsif lang == "java"
-      web_inf_dir = HelperFunctions.get_web_inf_dir(source_dir)
+      begin
+        web_inf_dir = HelperFunctions.get_web_inf_dir(source_dir)
+      rescue InvalidSource => error
+        Djinn.log_warn(error.message)
+        Djinn.log_app_error(app, error.message)
+        return
+      end
       cron_file = "#{web_inf_dir}/cron.xml"
       return unless File.exists?(cron_file)
 

--- a/AppController/lib/custom_exceptions.rb
+++ b/AppController/lib/custom_exceptions.rb
@@ -13,6 +13,11 @@ class AppScaleSCPException < StandardError
 end
 
 
+# Indicates that a revision's source code is invalid.
+class InvalidSource < StandardError
+end
+
+
 # A class of exceptions that can be thrown if the AppController believes that
 # the node it is talking to has failed.
 class FailedNodeException < AppScaleException

--- a/AppController/lib/ejabberd.rb
+++ b/AppController/lib/ejabberd.rb
@@ -60,8 +60,13 @@ module Ejabberd
         return false
       end
     elsif runtime == "java"
-      appengine_web_xml_file = HelperFunctions.get_appengine_web_xml(
-        source_dir)
+      begin
+        appengine_web_xml_file = HelperFunctions.get_appengine_web_xml(
+          source_dir)
+      rescue InvalidSource => error
+        Djinn.log_warn(error.message)
+        return false
+      end
       xml_contents = HelperFunctions.read_file(appengine_web_xml_file).force_encoding 'utf-8'
 
       begin

--- a/AppController/lib/helperfunctions.rb
+++ b/AppController/lib/helperfunctions.rb
@@ -1127,7 +1127,12 @@ module HelperFunctions
     Djinn.log_debug("Made static file dir for #{version_key} at #{cache_path}")
 
     untar_dir = "#{APPLICATIONS_DIR}/#{revision_key}/app"
-    war_dir = self.get_web_inf_dir(untar_dir)
+    begin
+      war_dir = self.get_web_inf_dir(untar_dir)
+    rescue InvalidSource => error
+      Djinn.log_error(error.message)
+      return []
+    end
 
     # Copy static files.
     handlers = []


### PR DESCRIPTION
The tools should prevent the user from uploading a tarball with this issue, but it makes sense to handle it anyway.