### PR TITLE
Include version headers when making TQ requests

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
+++ b/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
@@ -1100,13 +1100,15 @@ class DatastoreProxy(AppDBInterface):
       logging.exception(message)
       raise AppScaleDBConnectionError(message)
 
-  def add_transactional_tasks(self, app, txid, tasks):
+  def add_transactional_tasks(self, app, txid, tasks, service_id, version_id):
     """ Add tasks to be enqueued upon the completion of a transaction.
 
     Args:
       app: A string specifying an application ID.
       txid: An integer specifying a transaction ID.
       tasks: A list of TaskQueueAddRequest objects.
+      service_id: A string specifying the client's service ID.
+      version_id: A string specifying the client's version ID.
     """
     batch = BatchStatement(consistency_level=ConsistencyLevel.QUORUM,
                            retry_policy=BASIC_RETRIES)
@@ -1122,11 +1124,12 @@ class DatastoreProxy(AppDBInterface):
       # The path for the task entry doesn't matter as long as it's unique.
       path = bytearray(str(uuid.uuid4()))
 
+      task_payload = '_'.join([service_id, version_id, task.Encode()])
       args = (tx_partition(app, txid),
               TxnActions.ENQUEUE_TASK,
               '',
               path,
-              task.Encode())
+              task_payload)
       batch.add(insert, args)
 
     try:
@@ -1212,6 +1215,10 @@ class DatastoreProxy(AppDBInterface):
         group_key = create_key(app, result.namespace, result.path)
         metadata['reads'].add(group_key.Encode())
       if result.operation == TxnActions.ENQUEUE_TASK:
-        metadata['tasks'].append(
-          taskqueue_service_pb.TaskQueueAddRequest(result.task))
+        service_id, version_id, task_pb = result.task.split('_', 2)
+        task_metadata = {
+          'service_id': service_id,
+          'version_id': version_id,
+          'task': taskqueue_service_pb.TaskQueueAddRequest(task_pb)}
+        metadata['tasks'].append(task_metadata)
     return metadata

--- a/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
+++ b/AppServer/google/appengine/api/taskqueue/taskqueue_distributed.py
@@ -423,7 +423,8 @@ class TaskQueueServiceStub(apiproxy_stub.APIProxyStub):
     """
     self._RemoteSend(request, response, "ModifyTaskLease", request_id)
 
-  def _RemoteSend(self, request, response, method, request_id=None):
+  def _RemoteSend(self, request, response, method, request_id=None,
+                  service_id=None, version_id=None):
     """Sends a request remotely to the taskqueue server.
 
     Args:
@@ -431,6 +432,8 @@ class TaskQueueServiceStub(apiproxy_stub.APIProxyStub):
       response: A protocol buffer response.
       method: The function which is calling the remote server.
       request_id: A string specifying a request ID.
+      service_id: A string specifying the client service ID.
+      version_id: A string specifying the client version ID.
     Raises:
       taskqueue_service_pb.InternalError:
     """

--- a/AppServer_Java/src/com/google/appengine/api/datastore/dev/HTTPClientDatastoreProxy.java
+++ b/AppServer_Java/src/com/google/appengine/api/datastore/dev/HTTPClientDatastoreProxy.java
@@ -43,6 +43,8 @@ public class HTTPClientDatastoreProxy
     private final int           MAX_CONNECTIONS_PER_ROUTE_LOCALHOST = 80;
     private final int           INPUT_STREAM_SIZE                   = 10240;
     private final String        APPDATA_HEADER                      = "AppData";
+    private final String        MODULE_HEADER                       = "Module";
+    private final String        VERSION_HEADER                      = "Version";
     private final String        SERVICE_NAME                        = "datastore_v3";
     private final String        PROTOCOL_BUFFER_HEADER              = "ProtocolBufferType";
     private final String        PROTOCOL_BUFFER_VALUE               = "Request";
@@ -78,6 +80,8 @@ public class HTTPClientDatastoreProxy
             tag += ":" + user.getAuthDomain();
         }
         post.addHeader(APPDATA_HEADER, tag);
+        post.addHeader(MODULE_HEADER, System.getProperty("MODULE"));
+        post.addHeader(VERSION_HEADER, System.getProperty("VERSION"));
 
         Request remoteRequest = new Request();
         remoteRequest.setMethod(method);

--- a/AppServer_Java/src/com/google/appengine/api/datastore/dev/LocalDatastoreService.java
+++ b/AppServer_Java/src/com/google/appengine/api/datastore/dev/LocalDatastoreService.java
@@ -729,18 +729,13 @@ public final class LocalDatastoreService extends AbstractLocalRpcService
             return;
         }
 
-        String nginxPort = ResourceLoader.getNginxPort();
-
         String app = request.addRequests().get(0).getTransaction().getApp();
         TaskQueuePb.TaskQueueBulkAddRequest bulkAddRequest = request.clone();
         TaskQueuePb.TaskQueueBulkAddResponse bulkAddResponse = new TaskQueuePb.TaskQueueBulkAddResponse();
 
-        // Prepend task URLs with host and port.
+        // Set project ID for tasks.
         for (TaskQueuePb.TaskQueueAddRequest addRequest : bulkAddRequest.addRequests())
         {
-            String nginxHost = System.getProperty("NGINX_ADDR");
-            String fullTaskPath = "http://" + nginxHost + ":" + nginxPort + addRequest.getUrl();
-            addRequest.setUrl(fullTaskPath);
             addRequest.setAppId(app);
         }
 


### PR DESCRIPTION
Since the Java AppServer enqueues transactional tasks through the datastore API, it needs to include its version info in the request.