### PR TITLE
Use custom template for combined app log messages

### DIFF
--- a/common/appscale/common/templates/rsyslog-app.conf
+++ b/common/appscale/common/templates/rsyslog-app.conf
@@ -1,5 +1,5 @@
 # Log application output to its own file.
-{property}, isequal, "app___{version}" /var/log/appscale/app___{version}.log
+{property}, isequal, "app___{version}" /var/log/appscale/app___{version}.log;APPSCALE
 
 # The following is to prevent further processing.
 & ~

--- a/common/appscale/common/templates/rsyslog-template.conf
+++ b/common/appscale/common/templates/rsyslog-template.conf
@@ -1,0 +1,11 @@
+# Formats messages for combined application logs. Instead of using the
+# timestamp that the logger client provides, this uses a generated timestamp.
+# It also discards the syslog tag.
+template(name="APPSCALE" type="list") {
+  property(name="timegenerated")
+  constant(value=" ")
+  property(name="hostname")
+  constant(value=" ")
+  property(name="msg")
+  constant(value="\n")
+}

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -521,6 +521,10 @@ postinstallrsyslog()
     sed -i 's/#module(load="imtcp")/module(load="imtcp")/' /etc/rsyslog.conf
     sed -i 's/#input(type="imtcp" port="514")/input(type="imtcp" port="514")/' /etc/rsyslog.conf
 
+    # Set up template for formatting combined application log messages.
+    cp ${APPSCALE_HOME}/common/appscale/common/templates/rsyslog-template.conf\
+        /etc/rsyslog.d/09-appscale.conf
+
     # Restart the service
     service rsyslog restart || true
 }


### PR DESCRIPTION
This fixes the issue with outdated timestamps being used in the combined app log. The version of logger in Xenial does not generate new timestamps when sending each log line, so this template uses a generated timestamp instead of the one that logger provides.