### PR TITLE
Do not raise HttpError outside context of HTTP request

### DIFF
--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -329,8 +329,9 @@ class ProjectHandler(BaseVersionHandler):
     ports = ports_to_close[:]
     while True:
       if time.time() > deadline:
-        message = 'Delete operation took too long.'
-        raise CustomHTTPError(HTTPCodes.INTERNAL_ERROR, message=message)
+        logger.error('Delete operation took too long (project_id: {}).'
+                     .format(project_id))
+        raise gen.Return()
       to_remove = []
       for http_port in ports:
         # If the port is open, continue to process other ports.


### PR DESCRIPTION
wait_for_delete coroutine is run as a background job, it shouldn't raise HttpError - writing error to logs and raising `gen.Return() ` is enough.