### PR TITLE
Wait after a restore for cluster to be ready

### DIFF
--- a/AppDB/appscale/datastore/backup/cassandra_backup.py
+++ b/AppDB/appscale/datastore/backup/cassandra_backup.py
@@ -10,6 +10,7 @@ import time
 from appscale.common import appscale_info
 from appscale.common import monit_interface
 from appscale.common.constants import APPSCALE_DATA_DIR
+from appscale.common.constants import SCHEMA_CHANGE_TIMEOUT
 from appscale.common.unpackaged import INFRASTRUCTURE_MANAGER_DIR
 from subprocess import CalledProcessError
 from . import backup_recovery_helper
@@ -240,7 +241,7 @@ def restore_data(path, keyname, force=False):
 
   logging.info('Waiting for Cassandra cluster to be ready')
   db_ip = db_ips[0]
-  deadline = time.time() + 120
+  deadline = time.time() + SCHEMA_CHANGE_TIMEOUT
   while True:
     ready = True
     try:

--- a/AppDB/appscale/datastore/backup/cassandra_backup.py
+++ b/AppDB/appscale/datastore/backup/cassandra_backup.py
@@ -244,7 +244,8 @@ def restore_data(path, keyname, force=False):
   while True:
     ready = True
     try:
-      output = utils.ssh(db_ip, keyname, '{} status'.format(NODE_TOOL))
+      output = utils.ssh(db_ip, keyname, '{} status'.format(NODE_TOOL),
+                         method=subprocess.check_output)
       nodes_ready = len([line for line in output.split('\n')
                          if line.startswith('UN')])
       if nodes_ready < len(db_ips):

--- a/AppDB/test/unit/test_cassandra_backup.py
+++ b/AppDB/test/unit/test_cassandra_backup.py
@@ -105,6 +105,10 @@ class TestCassandraBackup(unittest.TestCase):
 
     flexmock(time).should_receive('sleep')
 
+    flexmock(utils).should_receive('ssh').with_args(
+      re.compile('^192.*'), keyname, re.compile('.*nodetool status')).\
+      and_return('UN 192.168.33.10\nUN 192.168.33.11')
+
     cassandra_backup.restore_data(path, keyname)
 
 

--- a/AppDB/test/unit/test_cassandra_backup.py
+++ b/AppDB/test/unit/test_cassandra_backup.py
@@ -106,7 +106,8 @@ class TestCassandraBackup(unittest.TestCase):
     flexmock(time).should_receive('sleep')
 
     flexmock(utils).should_receive('ssh').with_args(
-      re.compile('^192.*'), keyname, re.compile('.*nodetool status')).\
+      re.compile('^192.*'), keyname, re.compile('.*nodetool status'),
+      method=subprocess.check_output).\
       and_return('UN 192.168.33.10\nUN 192.168.33.11')
 
     cassandra_backup.restore_data(path, keyname)


### PR DESCRIPTION
This should improve the stability of the Jenkins Migration job.