### PR TITLE
Kill instances when they exceed memory limit

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/stop_instance.py
+++ b/AdminServer/appscale/admin/instance_manager/stop_instance.py
@@ -28,6 +28,7 @@ def stop_instance(watch, timeout, force=False):
   if force:
     os.killpg(group, signal.SIGKILL)
     os.remove(pidfile_location)
+    return
 
   process = psutil.Process(pid)
   process.terminate()

--- a/AdminServer/appscale/admin/instance_manager/stop_instance.py
+++ b/AdminServer/appscale/admin/instance_manager/stop_instance.py
@@ -10,7 +10,7 @@ from appscale.common.constants import PID_DIR
 DEFAULT_WAIT_TIME = 20
 
 
-def stop_instance(watch, timeout):
+def stop_instance(watch, timeout, force=False):
   """ Stops an AppServer process.
 
   Args:
@@ -25,6 +25,10 @@ def stop_instance(watch, timeout):
     pid = int(pidfile.read().strip())
 
   group = os.getpgid(pid)
+  if force:
+    os.killpg(group, signal.SIGKILL)
+    os.remove(pidfile_location)
+
   process = psutil.Process(pid)
   process.terminate()
   try:
@@ -47,5 +51,7 @@ def main():
   parser.add_argument('--watch', required=True, help='The Monit watch entry')
   parser.add_argument('--timeout', default=20,
                       help='The seconds to wait before killing the instance')
+  parser.add_argument('--force', action='store_true',
+                      help='Stop the process immediately')
   args = parser.parse_args()
-  stop_instance(args.watch, args.timeout)
+  stop_instance(args.watch, args.timeout, args.force)

--- a/AdminServer/appscale/admin/instance_manager/stop_instance.py
+++ b/AdminServer/appscale/admin/instance_manager/stop_instance.py
@@ -16,6 +16,8 @@ def stop_instance(watch, timeout, force=False):
   Args:
     watch: A string specifying the Monit watch entry.
     timeout: An integer specifying the time to wait for requests to finish.
+    force: A boolean indicating that the instance should be killed immediately
+      instead of being allowed to finish ongoing requests.
   Raises:
     IOError if the pidfile does not exist.
     OSError if the process does not exist.

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -264,7 +264,8 @@ def start_app(version_key, config):
     env_vars,
     max_memory,
     options.syslog_server,
-    check_port=True)
+    check_port=True,
+    kill_exceeded_memory=True)
 
   # We want to tell monit to start the single process instead of the
   # group, since monit can get slow if there are quite a few processes in

--- a/common/appscale/common/monit_app_configuration.py
+++ b/common/appscale/common/monit_app_configuration.py
@@ -33,7 +33,8 @@ def create_config_file(watch, start_cmd, pidfile, port=None, env_vars=None,
     syslog_server: The IP address of the remote syslog server to use.
     check_port: A boolean specifying that monit should check host and port.
     kill_exceeded_memory: A boolean indicating that a process should be killed
-      (instead of terminated) if its memory exceeds the limit.
+      (instead of terminated). This is used when the process exceeds its memory
+      limit.
   """
   if check_port:
     assert port is not None, 'When using check_port, port must be defined'


### PR DESCRIPTION
Previously, Monit would just try to teminate it gently, allowing the instance to finish serving open requests. In some cases, this limit was not long enough (30 seconds). In other cases, it was too long. It triggered the controller to try to stop the instance through the AppManger, resulting in a sequence that caused monit to restart the instance after the AppManger unmonitored it.