### PR TITLE
Use datastore proxy on load balancer

### DIFF
--- a/AppDB/appscale/datastore/groomer.py
+++ b/AppDB/appscale/datastore/groomer.py
@@ -1097,8 +1097,9 @@ def main():
   zookeeper = zk.ZKTransaction(host=zk_connection_locations, start_gc=False)
   db_info = appscale_info.get_db_info()
   table = db_info[':table']
-  master = appscale_info.get_db_master_ip()
-  datastore_path = "{0}:8888".format(master)
+
+  datastore_path = ':'.join([appscale_info.get_db_proxy(),
+                             str(constants.DB_SERVER_PORT)])
   ds_groomer = DatastoreGroomer(zookeeper, table, datastore_path)
 
   logging.debug("Trying to get groomer lock.")

--- a/AppDB/appscale/datastore/scripts/groomer_service.py
+++ b/AppDB/appscale/datastore/scripts/groomer_service.py
@@ -2,12 +2,10 @@
 import logging
 
 from appscale.common import appscale_info
+from appscale.common.constants import DB_SERVER_PORT
 from appscale.common.constants import LOG_FORMAT
 from .. import groomer
 from ..zkappscale import zktransaction as zk
-
-# Location to find the datastore service.
-LOCAL_DATASTORE = "localhost:8888"
 
 
 def main():
@@ -16,7 +14,11 @@ def main():
   zookeeper_locations = appscale_info.get_zk_locations_string()
   gc_zookeeper = zk.ZKTransaction(host=zookeeper_locations, start_gc=False)
   logger.info("Using ZK locations {0}".format(zookeeper_locations))
-  ds_groomer = groomer.DatastoreGroomer(gc_zookeeper, "cassandra", LOCAL_DATASTORE)
+
+  datastore_location = ':'.join([appscale_info.get_db_proxy(),
+                                 str(DB_SERVER_PORT)])
+  ds_groomer = groomer.DatastoreGroomer(gc_zookeeper, "cassandra",
+                                        datastore_location)
   try:
     ds_groomer.start()
   except Exception, exception:


### PR DESCRIPTION
Previously, the groomer would try to use a datastore location that may not exist.