### PR TITLE
Add a datastore viewer to the dashboard

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4411,8 +4411,10 @@ HOSTS
     my_public = my_node.public_ip
     my_private = my_node.private_ip
 
+    datastore_location = [get_load_balancer.private_ip,
+                          DatastoreServer::PROXY_PORT].join(':')
     source_archive = AppDashboard.prep(
-      my_public, my_private, PERSISTENT_MOUNT_POINT)
+      my_public, my_private, PERSISTENT_MOUNT_POINT, datastore_location)
 
     begin
       ZKInterface.get_version_details(

--- a/AppController/lib/app_dashboard.rb
+++ b/AppController/lib/app_dashboard.rb
@@ -41,7 +41,7 @@ module AppDashboard
       " #{lib_dir}/uaserver_host.py")
 
     File.open(File.join(lib_dir, 'datastore_location.py'), 'w') { |file|
-      file.write("LOAD_BALANCER_IP = '#{datastore_location}'")
+      file.write("DATASTORE_LOCATION = '#{datastore_location}'")
     }
 
     # TODO: tell the tools to disallow uploading apps called

--- a/AppController/lib/app_dashboard.rb
+++ b/AppController/lib/app_dashboard.rb
@@ -28,15 +28,21 @@ module AppDashboard
   #   public_ip: This machine's public IP address or FQDN.
   #   private_ip: This machine's private IP address or FQDN.
   #   persistent_storage: Where we store the application tarball.
+  #   datastore_location: The location of a datastore load balancer.
   # Returns:
   #   A string specifying the location of the prepared archive.
-  def self.prep(public_ip, private_ip, persistent_storage)
+  def self.prep(public_ip, private_ip, persistent_storage, datastore_location)
     # Pass our public IP address (needed to connect to the AppController)
     # to the app.
+    lib_dir = File.join(APPSCALE_HOME, 'AppDashboard', 'lib')
     Djinn.log_run("echo \"MY_PUBLIC_IP = '#{public_ip}'\" > " \
-      "#{APPSCALE_HOME}/AppDashboard/lib/local_host.py")
+      "#{lib_dir}/local_host.py")
     Djinn.log_run("echo \"UA_SERVER_IP = '#{private_ip}'\" >" \
-      " #{APPSCALE_HOME}/AppDashboard/lib/uaserver_host.py")
+      " #{lib_dir}/uaserver_host.py")
+
+    File.open(File.join(lib_dir, 'datastore_location.py'), 'w') { |file|
+      file.write("LOAD_BALANCER_IP = '#{datastore_location}'")
+    }
 
     # TODO: tell the tools to disallow uploading apps called
     # APP_NAME, and have start_appengine to do the same.

--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -36,6 +36,9 @@ from app_dashboard_helper import AppDashboardHelper
 from app_dashboard_helper import AppHelperException
 from app_dashboard_data import RequestInfo
 from dashboard_logs import RequestLogLine
+from datastore_viewer import DatastoreEditRequestHandler
+from datastore_viewer import DatastoreViewer
+from datastore_viewer import DatastoreViewerSelector
 
 
 # The maximum number of datapoints we send to be rendered in a graph
@@ -1166,6 +1169,10 @@ dashboard_pages = [
   ('/gather-logs', LogDownloader),
   ('/groomer', RunGroomer),
   ('/change-password', ChangePasswordPage),
+  ('/datastore_viewer', DatastoreViewerSelector),
+  ('/datastore_viewer/(.+)/edit/(.*)', DatastoreEditRequestHandler),
+  ('/datastore_viewer/(.+)/edit', DatastoreEditRequestHandler),
+  ('/datastore_viewer/(.+)', DatastoreViewer),
   ('/ajax/panel/render', AjaxRenderPanel),
   ('/ajax/layout/save', AjaxSaveLayoutSettings),
   ('/ajax/layout/reset', AjaxResetLayoutSettings)

--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -30,6 +30,8 @@ from google.appengine.ext import ndb
 from google.appengine.datastore.datastore_query import Cursor
 
 sys.path.append(os.path.dirname(__file__) + '/lib')
+from app_dashboard import AppDashboard
+from app_dashboard import jinja_environment
 from app_dashboard_helper import AppDashboardHelper
 from app_dashboard_helper import AppHelperException
 from app_dashboard_data import AppDashboardData
@@ -38,9 +40,6 @@ from app_dashboard_data import RequestInfo
 from dashboard_logs import AppLogLine
 from dashboard_logs import RequestLogLine
 
-jinja_environment = jinja2.Environment(
-  loader=jinja2.FileSystemLoader(os.path.dirname(__file__) + \
-                                 os.sep + 'templates'))
 
 # The maximum number of datapoints we send to be rendered in a graph
 # charting requests per second.
@@ -56,106 +55,6 @@ class LoggedService(ndb.Model):
       a FQDN) of a machine running in this AppScale cloud.
   """
   hosts = ndb.StringProperty(repeated=True)
-
-
-class AppDashboard(webapp2.RequestHandler):
-  """ Class that all pages in the Dashboard must inherit from. """
-
-  # Regular expression to capture the continue url.
-  CONTINUE_URL_REGEX = 'continue=(.*)$'
-
-  # Regular expression for updating user permissions.
-  USER_PERMISSION_REGEX = '^user_permission_'
-
-  # Regular expression that matches email addresses.
-  USER_EMAIL_REGEX = '^\w[^@\s]*@[^@\s]{2,}$'
-
-  # The frequency, in seconds, that defines how often Task Queue tasks are fired
-  # to update the Dashboard's Datastore cache.
-  REFRESH_WAIT_TIME = 10
-
-  def __init__(self, request, response):
-    """ Constructor.
-
-    Args:
-      request: The webapp2.Request object that contains information about the
-        current web request.
-      response: The webapp2.Response object that contains the response to be
-        sent back to the browser.
-    """
-    self.initialize(request, response)
-    self.helper = AppDashboardHelper()
-    self.dstore = AppDashboardData(self.helper)
-
-  def render_template(self, template_file, values=None):
-    """ Renders a template file with all variables loaded.
-
-    Args:
-      template_file: A str with the relative path to template file.
-      values: A dict with key/value pairs used as variables in the jinja
-        template files.
-    Returns:
-      A str with the rendered template.
-    """
-    if values is None:
-      values = {}
-
-    is_cloud_admin = self.helper.is_user_cloud_admin()
-    apps_user_is_admin_on = self.helper.get_application_info()
-    if not is_cloud_admin:
-      apps_user_owns = self.helper.get_owned_apps()
-      new_app_dict = {}
-      for app_name in apps_user_owns:
-        if app_name in apps_user_is_admin_on:
-          new_app_dict[app_name] = apps_user_is_admin_on.get(app_name)
-      apps_user_is_admin_on = new_app_dict
-
-    self.helper.update_cookie_app_list(apps_user_is_admin_on.keys(),
-                                       self.request, self.response)
-    template = jinja_environment.get_template(template_file)
-    sub_vars = {
-      'logged_in': self.helper.is_user_logged_in(),
-      'user_email': self.helper.get_user_email(),
-      'is_user_cloud_admin': self.dstore.is_user_cloud_admin(),
-      'can_upload_apps': self.dstore.can_upload_apps(),
-      'apps_user_is_admin_on': apps_user_is_admin_on,
-      'user_layout_pref': self.dstore.get_dash_layout_settings(),
-      'flower_url': self.dstore.get_flower_url(),
-      'monit_url': self.dstore.get_monit_url()
-    }
-    for key in values.keys():
-      sub_vars[key] = values[key]
-    return template.render(sub_vars)
-
-  def get_shared_navigation(self, page):
-    """ Renders the shared navigation.
-
-    Returns:
-      A str with the navigation bar rendered.
-    """
-    show_create_account = True
-    if AppDashboardHelper.USE_SHIBBOLETH:
-      show_create_account = False
-    return self.render_template(template_file='shared/navigation.html',
-                                values={'show_create_account':
-                                        show_create_account,
-                                        'page_name': page})
-
-  def render_page(self, page, template_file, values=None):
-    """ Renders a template with the main layout and nav bar. """
-    if values is None:
-      values = {}
-    self.response.headers['Content-Type'] = 'text/html'
-    template = jinja_environment.get_template('layouts/main.html')
-    self.response.out.write(template.render(
-      page_name=page,
-      page_body=self.render_template(template_file, values),
-      shared_navigation=self.get_shared_navigation(page)
-    ))
-
-  def render_app_page(self, page, values=None):
-    self.render_page(page=page, template_file="layouts/app_page.html",
-                     values=values)
 
 
 class IndexPage(AppDashboard):

--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -10,10 +10,7 @@ Engine applications.
 # pylint: disable-msg=W0613
 
 import cgi
-from collections import defaultdict
-import crontab
 import datetime
-import jinja2
 import json
 import logging
 import os
@@ -21,23 +18,23 @@ import re
 import sys
 import time
 import urllib
+from collections import defaultdict
+
+import crontab
 import webapp2
 
 from google.appengine.api import memcache
 from google.appengine.api import taskqueue
-from google.appengine.ext.db.stats import KindStat
-from google.appengine.ext import ndb
 from google.appengine.datastore.datastore_query import Cursor
+from google.appengine.ext import ndb
+from google.appengine.ext.db.stats import KindStat
 
 sys.path.append(os.path.dirname(__file__) + '/lib')
 from app_dashboard import AppDashboard
 from app_dashboard import jinja_environment
 from app_dashboard_helper import AppDashboardHelper
 from app_dashboard_helper import AppHelperException
-from app_dashboard_data import AppDashboardData
 from app_dashboard_data import RequestInfo
-
-from dashboard_logs import AppLogLine
 from dashboard_logs import RequestLogLine
 
 

--- a/AppDashboard/lib/app_dashboard.py
+++ b/AppDashboard/lib/app_dashboard.py
@@ -1,0 +1,133 @@
+""" A base class for all Dashboard pages. """
+import os
+
+import jinja2
+import webapp2
+
+from app_dashboard_data import AppDashboardData
+from app_dashboard_helper import AppDashboardHelper
+
+templates_dir = os.path.join(os.path.dirname(__file__), '..', 'templates')
+jinja_environment = jinja2.Environment(
+  loader=jinja2.FileSystemLoader(templates_dir))
+
+
+class AppDashboard(webapp2.RequestHandler):
+  """ Class that all pages in the Dashboard must inherit from. """
+
+  # Regular expression to capture the continue url.
+  CONTINUE_URL_REGEX = 'continue=(.*)$'
+
+  # The dashboard's project ID.
+  PROJECT_ID = 'appscaledashboard'
+
+  # Regular expression for updating user permissions.
+  USER_PERMISSION_REGEX = '^user_permission_'
+
+  # Regular expression that matches email addresses.
+  USER_EMAIL_REGEX = '^\w[^@\s]*@[^@\s]{2,}$'
+
+  # The frequency, in seconds, that defines how often Task Queue tasks are fired
+  # to update the Dashboard's Datastore cache.
+  REFRESH_WAIT_TIME = 10
+
+  def __init__(self, request, response):
+    """ Constructor.
+
+    Args:
+      request: The webapp2.Request object that contains information about the
+        current web request.
+      response: The webapp2.Response object that contains the response to be
+        sent back to the browser.
+    """
+    self.initialize(request, response)
+    self.helper = AppDashboardHelper()
+    self.dstore = AppDashboardData(self.helper)
+
+  def render_template(self, template_file, values=None):
+    """ Renders a template file with all variables loaded.
+
+    Args:
+      template_file: A str with the relative path to template file.
+      values: A dict with key/value pairs used as variables in the jinja
+        template files.
+    Returns:
+      A str with the rendered template.
+    """
+    if values is None:
+      values = {}
+
+    is_cloud_admin = self.helper.is_user_cloud_admin()
+    apps_user_is_admin_on = self.helper.get_application_info()
+    if not is_cloud_admin:
+      apps_user_owns = self.helper.get_owned_apps()
+      new_app_dict = {}
+      for app_name in apps_user_owns:
+        if app_name in apps_user_is_admin_on:
+          new_app_dict[app_name] = apps_user_is_admin_on.get(app_name)
+      apps_user_is_admin_on = new_app_dict
+
+    self.helper.update_cookie_app_list(apps_user_is_admin_on.keys(),
+                                       self.request, self.response)
+    template = jinja_environment.get_template(template_file)
+    sub_vars = {
+      'logged_in': self.helper.is_user_logged_in(),
+      'user_email': self.helper.get_user_email(),
+      'is_user_cloud_admin': self.dstore.is_user_cloud_admin(),
+      'can_upload_apps': self.dstore.can_upload_apps(),
+      'apps_user_is_admin_on': apps_user_is_admin_on,
+      'user_layout_pref': self.dstore.get_dash_layout_settings(),
+      'flower_url': self.dstore.get_flower_url(),
+      'monit_url': self.dstore.get_monit_url()
+    }
+    for key in values.keys():
+      sub_vars[key] = values[key]
+    return template.render(sub_vars)
+
+  def get_shared_navigation(self, page):
+    """ Renders the shared navigation.
+
+    Args:
+      page: A string specifying the page ID.
+    Returns:
+      A str with the navigation bar rendered.
+    """
+    show_create_account = True
+    if AppDashboardHelper.USE_SHIBBOLETH:
+      show_create_account = False
+
+    # These sections do not lend themselves well to having panels.
+    panel_blacklist = ['monit', 'taskqueue', 'datastore_viewer']
+    return self.render_template(template_file='shared/navigation.html',
+                                values={'show_create_account':
+                                        show_create_account,
+                                        'page_name': page,
+                                        'panel_blacklist': panel_blacklist})
+
+  def render_page(self, page, template_file, values=None):
+    """ Renders a template with the main layout and nav bar.
+
+    Args:
+      page: A string specifying the page ID.
+      template_file: A string specifying the template to use.
+      values: A dictionary containing template variables.
+    """
+    if values is None:
+      values = {}
+    self.response.headers['Content-Type'] = 'text/html'
+    template = jinja_environment.get_template('layouts/main.html')
+    self.response.out.write(template.render(
+      page_name=page,
+      page_body=self.render_template(template_file, values),
+      shared_navigation=self.get_shared_navigation(page)
+    ))
+
+  def render_app_page(self, page, values=None):
+    """ Render a typical page using the app_page template.
+
+    Args:
+      page: A string specifying the page ID.
+      values: A dictionary containing template variables.
+    """
+    self.render_page(page=page, template_file="layouts/app_page.html",
+                     values=values)

--- a/AppDashboard/lib/app_dashboard_data.py
+++ b/AppDashboard/lib/app_dashboard_data.py
@@ -163,17 +163,12 @@ class AppDashboardData():
                                                {"manage_users": lookup_dict[
                                                    "manage_users"]}]}
       if user_info.owned_apps or user_info.is_user_cloud_admin:
-        lookup_dict["debugging_monitoring"] = {"Debugging/Monitoring":
-                                               [{"monit": lookup_dict[
-                                                 "monit"]},
-                                                {"taskqueue": lookup_dict[
-                                                  "taskqueue"]},
-                                                {"logging": lookup_dict[
-                                                  "logging"]},
-                                                {"app_console": lookup_dict[
-                                                    "app_console"]},
-                                                {"cron": lookup_dict[
-                                                  "cron"]}]}
+        sections = ['monit', 'taskqueue', 'logging', 'app_console', 'cron',
+                    'datastore_viewer']
+        lookup_dict["debugging_monitoring"] = {
+          "Debugging/Monitoring": [{section: lookup_dict[section]}
+                                   for section in sections]
+        }
       return lookup_dict
     else:
       return {}

--- a/AppDashboard/lib/app_dashboard_data.py
+++ b/AppDashboard/lib/app_dashboard_data.py
@@ -146,7 +146,9 @@ class AppDashboardData():
                  "template": "cron/console.html"},
         "app_console": {"title": "Application Statistics",
                         "template": "apps/console.html",
-                        "link": "/apps/"}
+                        "link": "/apps/"},
+        "datastore_viewer": {"title": "Datastore Viewer",
+                             "link": "/datastore_viewer"}
       }
       if user_info.can_upload_apps:
         lookup_dict["app_management"] = {"App Management":

--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -1,0 +1,637 @@
+""" Implements the datastore viewer interface. """
+import math
+import urllib
+
+from app_dashboard import AppDashboard
+from datastore_location import DATASTORE_LOCATION
+from google.appengine.api import datastore
+from google.appengine.api import memcache
+from google.appengine.api.datastore_distributed import DatastoreDistributed
+from google.appengine.api import api_base_pb
+from google.appengine.datastore import datastore_pb
+
+from google.appengine.tools.devappserver2.admin.datastore_viewer import (
+  _property_name_to_value,
+  DataType)
+
+
+def _format_datastore_key(key):
+  """Return a nicely formatted decomposition of a datastore key.
+
+  Args:
+    key: The datastore_types.Key object to format.
+
+  Returns:
+    A string or Unicode object containing nicely formatted information about
+    the given key e.g. "ParentKind: name=Animal > ChildKind: id=123".
+  """
+  path = key.to_path()  # [kind, id/name, kind, id/name, ...]
+  parts = []
+  for i in range(0, len(path)//2):
+    kind = path[i*2]
+    value = path[i*2 + 1]
+    if isinstance(value, (int, long)):
+      parts.append('%s: id=%d' % (kind, value))
+    else:
+      parts.append('%s: name=%s' % (kind, value))
+  return ' > '.join(parts)
+
+
+def _property_name_to_values(entities):
+  """Returns a a mapping of entity property names to a list of their values.
+
+  For example:
+    _property_name_to_values([{'cat': 5, 'dog': 10},
+                              {'dog': 15, 'mouse': 'happy'}])
+    => {'cat': [5], 'dog': [10, 15], 'mouse': ['happy']}
+
+  Args:
+    entities: A sequence of mappings (i.e. datastore.Entity) that represent
+        datastore properties and their values.
+
+  Returns:
+    A dict whose keys are the union of the keys of the given entities and
+    whose values are the list of values for those keys.
+  """
+  property_name_to_values = {}
+  for entity in entities:
+    for property_name, value in entity.iteritems():
+      property_name_to_values.setdefault(property_name, []).append(value)
+
+  return property_name_to_values
+
+
+def _delete_entities(ds_access, entity_keys):
+  """ Deletes a list of datastre entities.
+
+  Args:
+    ds_access: A DatastoreDistributed client.
+    entity_keys: A list of datastore.Key objects.
+  Raises:
+    ApplicationError if unable to delete entities.
+  """
+  request = datastore_pb.DeleteRequest()
+  for entity_key in entity_keys:
+    key = request.add_key()
+    key.CopyFrom(entity_key._ToPb())
+
+  response = datastore_pb.DeleteResponse()
+  ds_access._Dynamic_Delete(request, response)
+
+
+def _get_entity_by_key(ds_access, entity_key):
+  """ Fetches an entity.
+
+  Args:
+    ds_access: A DatastoreDistributed client.
+    entity_key: A datastore.Key object.
+  Returns:
+    A datastore.Entity object.
+  Raises:
+    ApplicationError if unable to fetch entity.
+  """
+  reference = entity_key._ToPb()
+  request = datastore_pb.GetRequest()
+  key = request.add_key()
+  key.CopyFrom(reference)
+
+  response = datastore_pb.GetResponse()
+  ds_access._Dynamic_Get(request, response)
+  entity = datastore.Entity.FromPb(response.entity(0).entity())
+  return entity
+
+
+def _put_entity(ds_access, entity):
+  """ Updates or creates an entity.
+
+  Args:
+    ds_access: A DatastoreDistributed client.
+    entity: A datastore.Entity object.
+  Raises:
+    ApplicationError if unable to put entity.
+  """
+  request = datastore_pb.PutRequest()
+  new_entity = request.add_entity()
+  new_entity.CopyFrom(entity.ToPb())
+
+  response = datastore_pb.PutResponse()
+  ds_access._Dynamic_Put(request, response)
+
+
+def _get_entities(ds_access, kind, namespace, order, start, count):
+  """Returns a list and a count of entities of the given kind.
+
+  Args:
+    kind: A string representing the name of the kind of the entities to
+        return.
+    namespace: A string representing the namespace of the entities to return.
+    order: A string containing the name of the property to sorted the results
+        by. A "-" prefix indicates descending order e.g. "-age".
+    start: The number of initial entities to skip in the result set.
+    count: The maximum number of entities to return.
+
+  Returns:
+    A tuple of (list of datastore.Entity, total entity count).
+  """
+  query = datastore_pb.Query()
+  query.set_name_space(namespace)
+  query.set_app(ds_access.project_id)
+  query.set_kind(kind)
+  query.set_compile(True)
+
+  if order:
+    query_order = query.add_order()
+    if order.startswith('-'):
+      query_order.set_direction(datastore_pb.Query_Order.DESCENDING)
+      query_order.set_property(order[1:])
+    else:
+      query_order.set_direction(datastore_pb.Query_Order.ASCENDING)
+      query_order.set_property(order)
+
+  # Count queries just take note of the skipped results.
+  count_query = datastore_pb.Query()
+  count_query.CopyFrom(query)
+  count_query.set_offset(1000)
+  count_query.set_limit(0)
+  result = datastore_pb.QueryResult()
+  ds_access._Dynamic_RunQuery(count_query, result)
+  total = result.skipped_results()
+
+  query.set_limit(count)
+  query.set_offset(start)
+  result = datastore_pb.QueryResult()
+  ds_access._Dynamic_RunQuery(query, result)
+  entities = [datastore.Entity.FromPb(entity_pb)
+              for entity_pb in result.result_list()]
+
+  return entities, total
+
+
+class DatastoreViewerPage(AppDashboard):
+  """ A base class for datastore viewer pages. """
+  def ensure_user_has_admin(self, project_id):
+    """ Returns an error page if user does not have project permissions.
+
+    Args:
+      project_id: A string specifying a project ID.
+    """
+    if self.helper.is_user_cloud_admin():
+      version_keys = self.helper.get_application_info().keys()
+      owned_projects = [version.split('_')[0] for version in version_keys]
+    else:
+      owned_projects = self.helper.get_owned_apps()
+
+    if project_id not in owned_projects:
+      self.response.set_status(403)
+      self.response.write(
+        'You do not have permission to view data for {}.'.format(project_id))
+      return
+
+
+class DatastoreViewerSelector(AppDashboard):
+  """ Handles requests for the Datastore Viewer project selection page. """
+  TEMPLATE = 'datastore/project_selector.html'
+
+  def get(self):
+    """ Presents a list of projects to view data for. """
+    if self.helper.is_user_cloud_admin():
+      version_keys = self.helper.get_application_info().keys()
+      owned_projects = [version.split('_')[0] for version in version_keys
+                        if version.split('_')[0] != self.PROJECT_ID]
+    else:
+      owned_projects = self.helper.get_owned_apps()
+
+    context = {
+      'page_content': self.TEMPLATE,
+      'owned_projects': owned_projects,
+    }
+    self.render_app_page(page='datastore_viewer_selector', values=context)
+
+
+class DatastoreViewer(DatastoreViewerPage):
+  """ Handles requests for the Datastore Viewer page. """
+  NUM_ENTITIES_PER_PAGE = 20
+
+  TEMPLATE = 'datastore/viewer.html'
+
+  @staticmethod
+  def _calculate_writes_for_built_in_indices(entity):
+    """ Estimates number of write operations for standard properties.
+
+    Args:
+      entity: A datastore.Entity object.
+    Returns:
+      An integer specifying the number of datastore write operations.
+    """
+    writes = 0
+    for prop_name in entity.keys():
+      if not prop_name in entity.unindexed_properties():
+        # 2 writes per property value, one for EntitiesByProperty and one for
+        # EntitiesbyPropertyDesc
+        prop_vals = entity[prop_name]
+        if isinstance(prop_vals, (list)):
+          num_prop_vals = len(prop_vals)
+        else:
+          num_prop_vals = 1
+        writes += 2 * num_prop_vals
+    return writes
+
+  @staticmethod
+  def _calculate_writes_for_composite_index(entity, index):
+    """ Estimates the number of write operations for composite index entries.
+
+    Args:
+      entity: A datastore.Entity object.
+    Returns:
+      An integer specifying the number of datastore write operations.
+    """
+    composite_index_value_count = 1
+    for prop_name, _ in index.Properties():
+      if not prop_name in entity.keys() or (
+          prop_name in entity.unindexed_properties()):
+        return 0
+      prop_vals = entity[prop_name]
+      if isinstance(prop_vals, (list)):
+        composite_index_value_count *= len(prop_vals)
+
+    # If this is an ancestor index we're going to duplicate all these index
+    # writes for every key in the hierarchy.  So if the entity key has no
+    # parent we write the index values once, if the entity key has a depth of
+    # 2 then we write the index values twice, and so on.
+    ancestor_count = 1  # A key is its own ancestor.
+    if index.HasAncestor():
+      key = entity.key().parent()
+      while key is not None:
+        ancestor_count += 1
+        key = key.parent()
+    return composite_index_value_count * ancestor_count
+
+  def _construct_url(self, remove=None, add=None):
+    """Returns a URL referencing the current resource with the same params.
+
+    For example, if the request URL is
+    "http://foo/bar?animal=cat&color=redirect" then
+    _construct_url(['animal'], {'vehicle': 'car'}) will return
+    "http://foo/bar?vehicle=car&color=redirect"
+
+    Args:
+      remove: A sequence of query parameters to remove from the query string.
+      add: A mapping of query parameters to add to the query string.
+
+    Returns:
+      A new query string suitable for use in "GET" requests.
+    """
+    remove = remove or []
+    add = add or {}
+    params = dict(self.request.params)
+    for arg in remove:
+      if arg in params:
+        del params[arg]
+
+    params.update(add)
+    return str('%s?%s' % (self.request.path,
+                          urllib.urlencode(sorted(params.iteritems()))))
+
+  @classmethod
+  def _get_entity_template_data(cls, ds_access, request_uri, kind, namespace,
+                                order, start):
+    """ Fetches template variables for datastore viewer page for a given kind.
+
+    Args:
+      ds_access: A DatastoreDistributed client.
+      request_uri: A string specifying the current request location.
+      kind: A string specifying the entity kind.
+      namespace: A string specifying the datastore namespace.
+      order: A string containing the name of the property to sorted the results
+        by. A "-" prefix indicates descending order e.g. "-age".
+      start: The number of initial entities to skip in the result set.
+    Returns:
+      A tuple containing headers, entities, and total entity count.
+    """
+    entities, total_entities = _get_entities(
+      ds_access, kind, namespace, order, start, cls.NUM_ENTITIES_PER_PAGE)
+
+    property_name_to_value = _property_name_to_value(entities)
+
+    headers = [{'name': property_name}
+               for property_name in sorted(property_name_to_value)]
+
+    template_entities = []
+    for entity in entities:
+      attributes = []
+      for property_name in sorted(property_name_to_value):
+        if property_name in entity:
+          raw_value = entity[property_name]
+          data_type = DataType.get(raw_value)
+          value = data_type.format(raw_value)
+          short_value = data_type.short_format(raw_value)
+        else:
+          value = ''
+          short_value = ''
+        attributes.append({'name': property_name,
+                           'value': value,
+                           'short_value': short_value,
+                          })
+      edit_uri = '/datastore_viewer/%s/edit/%s?next=%s' % (
+          ds_access.project_id, entity.key(), urllib.quote(request_uri))
+      template_entities.append(
+          {'attributes': attributes,
+           'edit_uri': edit_uri,
+           'key': entity.key(),
+           'key_id': entity.key().id(),
+           'key_name': entity.key().name(),
+           'shortened_key': str(entity.key())[:8] + '...',
+           'write_ops': cls._get_write_ops(ds_access, entity)})
+    return headers, template_entities, total_entities
+
+  @classmethod
+  def _get_indexes(cls, ds_access):
+    """ Retrieves a list of composite indexes for a project.
+
+    Args:
+      ds_access: A DatastoreDistributed client.
+    Returns:
+      A list of datastore.Index objects.
+    """
+    request = api_base_pb.StringProto()
+    request.set_value(ds_access.project_id)
+    response = datastore_pb.CompositeIndices()
+    ds_access._Dynamic_GetIndices(request, response)
+    indexes = []
+    for index in response.index_list():
+      props = [(prop.name(), prop.direction())
+               for prop in index.definition().property_list()]
+      new_index = datastore.Index(index.id(), index.definition().entity_type(),
+                                  index.definition().ancestor(), props)
+      indexes.append((new_index, None))
+
+    return indexes
+
+  @classmethod
+  def _get_kinds(cls, ds_access, namespace):
+    """ Returns a sorted list of kind names present in the given namespace.
+
+    Args:
+      ds_access: A DatastoreDistributed client.
+      namespace: A string specifying the datastore namespace.
+    Returns:
+      A list of string specifying kind names.
+    """
+    assert namespace is not None
+    query = datastore_pb.Query()
+    query.set_name_space(namespace)
+    query.set_app(ds_access.project_id)
+    query.set_kind('__kind__')
+    result = datastore_pb.QueryResult()
+    ds_access._Dynamic_RunQuery(query, result)
+    kinds = [entity.entity_group().element(0).name()
+             for entity in result.result_list()]
+    return sorted(kinds)
+
+  @classmethod
+  def _get_write_ops(cls, ds_access, entity):
+    """ Estimates the number of write operations for an entity.
+
+    Args:
+      ds_access: A DatastoreDistributed client.
+      entity: A datastore.Entity object.
+    Returns:
+      An integer specifying the number of write operations.
+    """
+    # Minimum 2 writes, one for the entity and one for the EntitiesByKind index.
+    writes = 2 + cls._calculate_writes_for_built_in_indices(entity)
+
+    # Account for composite indices.
+    for index, _ in cls._get_indexes(ds_access):
+      if index.Kind() != entity.kind():
+        continue
+      writes += cls._calculate_writes_for_composite_index(entity, index)
+    return writes
+
+  def get(self, project_id):
+    """ Displays a list of entities for a given kind.
+
+    Args:
+      project_id: A string specifying the project ID.
+    """
+    self.ensure_user_has_admin(project_id)
+
+    ds_access = DatastoreDistributed(project_id, DATASTORE_LOCATION,
+                                     require_indexes=False, trusted=True)
+
+    kind = self.request.get('kind', None)
+    namespace = self.request.get('namespace', '')
+    order = self.request.get('order', None)
+    message = self.request.get('message', None)
+
+    try:
+      page = int(self.request.get('page', '1'))
+    except ValueError:
+      page = 1
+
+    kinds = self._get_kinds(ds_access, namespace)
+    if not kind and kinds:
+      self.redirect(self._construct_url(add={'kind': kinds[0]}))
+      return
+
+    if kind:
+      start = (page-1) * self.NUM_ENTITIES_PER_PAGE
+      headers, template_entities, total_entities = (
+          self._get_entity_template_data(ds_access, self.request.uri, kind,
+                                         namespace, order, start))
+      num_pages = int(math.ceil(float(total_entities) /
+                                self.NUM_ENTITIES_PER_PAGE))
+    else:
+      start = 0
+      headers = []
+      template_entities = []
+      total_entities = 0
+      num_pages = 0
+
+    select_namespace_url = self._construct_url(
+      remove=['message'],
+      add={'namespace': self.request.get('namespace')})
+    context = {
+      'entities': template_entities,
+      'headers': headers,
+      'kind': kind,
+      'kinds': kinds,
+      'message': message,
+      'namespace': namespace,
+      'num_pages': num_pages,
+      'order': order,
+      'order_base_url': self._construct_url(remove=['message', 'order']),
+      'page': page,
+      'page_content': self.TEMPLATE,
+      'paging_base_url': self._construct_url(remove=['message', 'page']),
+      'project_id': project_id,
+      'request': self.request,
+      'select_namespace_url': select_namespace_url,
+      'show_namespace': self.request.get('namespace', None) is not None,
+      'start': start,
+      'total_entities': total_entities
+    }
+    self.render_app_page(page='datastore_viewer', values=context)
+
+  def post(self, project_id):
+    """ Handle modifying actions and redirect to a GET page.
+
+    Args:
+      project_id: A string specifyng the project ID.
+    """
+    self.ensure_user_has_admin(project_id)
+
+    if self.request.get('action:flush_memcache'):
+      if memcache.flush_all():
+        message = 'Cache flushed, all keys dropped.'
+      else:
+        message = 'Flushing the cache failed. Please try again.'
+      self.redirect(self._construct_url(remove=['action:flush_memcache'],
+                                        add={'message': message}))
+    elif self.request.get('action:delete_entities'):
+      ds_access = DatastoreDistributed(project_id, DATASTORE_LOCATION,
+                                       require_indexes=False, trusted=True)
+
+      entity_keys = [datastore.Key(key)
+                     for key in self.request.params.getall('entity_key')]
+      _delete_entities(ds_access, entity_keys)
+      self.redirect(self._construct_url(
+          remove=['action:delete_entities'],
+          add={'message': '%d entities deleted' % len(entity_keys)}))
+    else:
+      self.error(404)
+
+
+class DatastoreEditRequestHandler(DatastoreViewerPage):
+  """A handler that allows datastore entities to be created and edited."""
+  TEMPLATE = 'datastore/edit.html'
+
+  def get(self, project_id, entity_key_string=None):
+    """ Displays the fields for a given entity.
+
+    Args:
+      project_id: A string specifying the project ID.
+      entity_key_string: A string specifying the entity key.
+    """
+    self.ensure_user_has_admin(project_id)
+
+    ds_access = DatastoreDistributed(project_id, DATASTORE_LOCATION,
+                                     require_indexes=False, trusted=True)
+
+    if entity_key_string:
+      entity_key = datastore.Key(entity_key_string)
+      entity_key_name = entity_key.name()
+      entity_key_id = entity_key.id()
+      namespace = entity_key.namespace()
+      kind = entity_key.kind()
+      entities = [_get_entity_by_key(ds_access, entity_key)]
+      parent_key = entity_key.parent()
+      if parent_key:
+        parent_key_string = _format_datastore_key(parent_key)
+      else:
+        parent_key_string = None
+    else:
+      entity_key = None
+      entity_key_string = None
+      entity_key_name = None
+      entity_key_id = None
+      namespace = self.request.get('namespace')
+      kind = self.request.get('kind')
+      entities, _ = _get_entities(ds_access, kind, namespace, order=None,
+                                  start=0, count=20)
+      parent_key = None
+      parent_key_string = None
+
+      if not entities:
+        params = urllib.urlencode(
+          [('kind', kind),
+           ('message', 'Cannot create the kind "%s" in the "%s" namespace '
+                       'because no template entity '
+                       'exists.' % (kind, namespace)),
+           ('namespace', namespace)])
+        self.redirect('/datastore_viewer/%s?%s' % (project_id, params))
+        return
+
+    property_name_to_values = _property_name_to_values(entities)
+    fields = []
+    for property_name, values in sorted(property_name_to_values.iteritems()):
+      data_type = DataType.get(values[0])
+      field = data_type.input_field('%s|%s' % (data_type.name(), property_name),
+                                    values[0] if entity_key else None,
+                                    values,
+                                    self.request.uri)
+      fields.append((property_name, data_type.name(), field))
+
+    context = {
+      'page_content': self.TEMPLATE,
+      'project_id': project_id,
+      'fields': fields,
+      'key': entity_key_string,
+      'key_id': entity_key_id,
+      'key_name': entity_key_name,
+      'kind': kind,
+      'namespace': namespace,
+      'next': self.request.get('next',
+                               '/datastore_viewer/{}'.format(project_id)),
+      'parent_key': parent_key,
+      'parent_key_string': parent_key_string,
+      'request': self.request
+    }
+    self.render_app_page(page='datastore_editor', values=context)
+
+  def post(self, project_id, entity_key_string=None):
+    """ Handles mutations to a given entity.
+
+    Args:
+      project_id: A string specifying the project ID.
+      entity_key_string: A string specifying the entity key.
+    """
+    self.ensure_user_has_admin(project_id)
+
+    ds_access = DatastoreDistributed(project_id, DATASTORE_LOCATION,
+                                     require_indexes=False, trusted=True)
+
+    if self.request.get('action:delete'):
+      if entity_key_string:
+        _delete_entities(ds_access, [datastore.Key(entity_key_string)])
+        redirect_url = self.request.get(
+          'next', '/datastore_viewer/{}'.format(project_id))
+        self.redirect(str(redirect_url))
+      else:
+        self.response.set_status(400)
+      return
+
+    if entity_key_string:
+      entity = _get_entity_by_key(ds_access, datastore.Key(entity_key_string))
+    else:
+      kind = self.request.get('kind')
+      namespace = self.request.get('namespace', None)
+      entity = datastore.Entity(kind, _namespace=namespace)
+
+    for arg_name in self.request.arguments():
+      # Arguments are in <property_type>|<property_name>=<value> format.
+      if '|' not in arg_name:
+        continue
+      data_type_name, property_name = arg_name.split('|')
+      form_value = self.request.get(arg_name)
+      data_type = DataType.get_by_name(data_type_name)
+      if (entity and
+          property_name in entity and
+          data_type.format(entity[property_name]) == form_value):
+        # If the property is unchanged then don't update it. This will prevent
+        # empty form values from causing the property to be deleted if the
+        # property was already empty.
+        continue
+
+      if form_value:
+        # TODO: Handle parse exceptions.
+        entity[property_name] = data_type.parse(form_value)
+      elif property_name in entity:
+        # TODO: Treating empty input as deletion is a not a good
+        # interface.
+        del entity[property_name]
+
+    _put_entity(ds_access, entity)
+    redirect_url = self.request.get(
+      'next', '/datastore_viewer/{}'.format(project_id))
+    self.redirect(str(redirect_url))

--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -38,7 +38,7 @@ def _format_datastore_key(key):
 
 
 def _property_name_to_values(entities):
-  """Returns a a mapping of entity property names to a list of their values.
+  """Returns a mapping of entity property names to a list of their values.
 
   For example:
     _property_name_to_values([{'cat': 5, 'dog': 10},
@@ -62,7 +62,7 @@ def _property_name_to_values(entities):
 
 
 def _delete_entities(ds_access, entity_keys):
-  """ Deletes a list of datastre entities.
+  """ Deletes a list of datastore entities.
 
   Args:
     ds_access: A DatastoreDistributed client.

--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -363,7 +363,7 @@ class DatastoreViewer(DatastoreViewerPage):
                for prop in index.definition().property_list()]
       new_index = datastore.Index(index.id(), index.definition().entity_type(),
                                   index.definition().ancestor(), props)
-      indexes.append((new_index, None))
+      indexes.append(new_index)
 
     return indexes
 
@@ -402,7 +402,7 @@ class DatastoreViewer(DatastoreViewerPage):
     writes = 2 + cls._calculate_writes_for_built_in_indices(entity)
 
     # Account for composite indices.
-    for index, _ in cls._get_indexes(ds_access):
+    for index in cls._get_indexes(ds_access):
       if index.Kind() != entity.kind():
         continue
       writes += cls._calculate_writes_for_composite_index(entity, index)

--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -11,7 +11,6 @@ from google.appengine.api import memcache
 from google.appengine.api.datastore_distributed import DatastoreDistributed
 from google.appengine.datastore import datastore_pb
 from google.appengine.tools.devappserver2.admin.datastore_viewer import (
-  _property_name_to_value,
   DataType)
 
 
@@ -311,15 +310,15 @@ class DatastoreViewer(DatastoreViewerPage):
     entities, total_entities = _get_entities(
       ds_access, kind, namespace, order, start, cls.NUM_ENTITIES_PER_PAGE)
 
-    property_name_to_value = _property_name_to_value(entities)
+    prop_names = sorted({prop for entity in entities for prop in entity})
 
     headers = [{'name': property_name}
-               for property_name in sorted(property_name_to_value)]
+               for property_name in prop_names]
 
     template_entities = []
     for entity in entities:
       attributes = []
-      for property_name in sorted(property_name_to_value):
+      for property_name in prop_names:
         if property_name in entity:
           raw_value = entity[property_name]
           data_type = DataType.get(raw_value)

--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -4,12 +4,12 @@ import urllib
 
 from app_dashboard import AppDashboard
 from datastore_location import DATASTORE_LOCATION
+
+from google.appengine.api import api_base_pb
 from google.appengine.api import datastore
 from google.appengine.api import memcache
 from google.appengine.api.datastore_distributed import DatastoreDistributed
-from google.appengine.api import api_base_pb
 from google.appengine.datastore import datastore_pb
-
 from google.appengine.tools.devappserver2.admin.datastore_viewer import (
   _property_name_to_value,
   DataType)

--- a/AppDashboard/static/css/Styles.css
+++ b/AppDashboard/static/css/Styles.css
@@ -359,3 +359,280 @@ body.errorPage, body.loginPage {
 .errorContainer h1 {font-size: 10em; line-height: 1em;}
 .errorContainer.offline h1 {font-size: 5em;}
 .errorContainer h1 small {font-weight: 700; font-size: 0.3em;}
+
+/*Datastore Viewer*/
+#datastore-viewer #entity-manager table {
+  margin: 10px 0px;
+}
+#datastore-viewer #entity-manager table td {
+  vertical-align: bottom;
+}
+#datastore-viewer #entity-manager th {
+  font-weight: bold;
+  padding: 5px 0px;
+}
+#datastore-viewer select#kind_input {
+  text-align: left;
+}
+#datastore-viewer .ae-result-count {
+  float: left;
+  color: #999;
+}
+#datastore-viewer .ae-paginator {
+  float: right;
+}
+
+.ae-button {
+  display: inline-block;
+  min-width: 54px;
+  border:1px solid #DCDCDC;
+  border: 1px solid rgba(0,0,0,0.1);
+  text-align: center;
+  color: #444;
+  font-size: 11px;
+  font-weight: bold;
+  height: 27px;
+  padding: 0 8px;
+  line-height: 27px;
+  -webkit-border-radius:2px;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  -webkit-transition: all 0.218s;
+  -moz-transition: all 0.218s;
+  -o-transition: all 0.218s;
+  transition: all 0.218s;
+  background-color: #f5f5f5;
+  background-image: -webkit-gradient(linear,left top,left bottom,from(#f5f5f5),to(#f1f1f1));
+  background-image: -webkit-linear-gradient(top,#f5f5f5,#f1f1f1);
+  background-image: -moz-linear-gradient(top,#f5f5f5,#f1f1f1);
+  background-image: -ms-linear-gradient(top,#f5f5f5,#f1f1f1);
+  background-image: -o-linear-gradient(top,#f5f5f5,#f1f1f1);
+  background-image: linear-gradient(top,#f5f5f5,#f1f1f1);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#f5f5f5',EndColorStr='#f1f1f1');
+  -webkit-user-select:none;
+  -moz-user-select:none;
+  cursor:default;
+}
+.ae-button:hover, .ae-button.hover {
+  border: 1px solid #C6C6C6;
+  color: #222;
+  -webkit-transition: all 0.0s;
+  -moz-transition: all 0.0s;
+  -o-transition: all 0.0s;
+  transition: all 0.0s;
+  background-color: #f8f8f8;
+  background-image: -webkit-gradient(linear,left top,left bottom,from(#f8f8f8),to(#f1f1f1));
+  background-image: -webkit-linear-gradient(top,#f8f8f8,#f1f1f1);
+  background-image: -moz-linear-gradient(top,#f8f8f8,#f1f1f1);
+  background-image: -ms-linear-gradient(top,#f8f8f8,#f1f1f1);
+  background-image: -o-linear-gradient(top,#f8f8f8,#f1f1f1);
+  background-image: linear-gradient(top,#f8f8f8,#f1f1f1);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#f8f8f8',EndColorStr='#f1f1f1');
+  -webkit-box-shadow: 0px 1px 1px rgba(0,0,0,0.1);
+  -moz-box-shadow: 0px 1px 1px rgba(0,0,0,0.1);
+  box-shadow: 0px 1px 1px rgba(0,0,0,0.1);
+}
+.ae-button:active, .ae-button.active {
+  background-color: #f6f6f6;
+  background-image: -webkit-gradient(linear,left top,left bottom,from(#f6f6f6),to(#f1f1f1));
+  background-image: -webkit-linear-gradient(top,#f6f6f6,#f1f1f1);
+  background-image: -moz-linear-gradient(top,#f6f6f6,#f1f1f1);
+  background-image: -ms-linear-gradient(top,#f6f6f6,#f1f1f1);
+  background-image: -o-linear-gradient(top,#f6f6f6,#f1f1f1);
+  background-image: linear-gradient(top,#f6f6f6,#f1f1f1);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#f6f6f6',EndColorStr='#f1f1f1');
+  -webkit-box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+  -moz-box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+  box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+}
+.ae-button.active{
+  border: 1px solid #C6C6C6;
+  color: #333;
+}
+
+.ae-button:visited {
+  color: #666;
+}
+.ae-button.focus, .ae-button.right.focus, .ae-button.mid.focus, .ae-button.left.focus{
+  outline: none;
+  border: 1px solid #4d90fe;
+  z-index:4 !important;
+}
+
+.ae-button.selected {
+  background-color: #EEEEEE;
+  background-image: -webkit-gradient(linear,left top,left bottom,from(#EEEEEE),to(#E0E0E0));
+  background-image: -webkit-linear-gradient(top,#EEEEEE,#E0E0E0);
+  background-image: -moz-linear-gradient(top,#EEEEEE,#E0E0E0);
+  background-image: -ms-linear-gradient(top,#EEEEEE,#E0E0E0);
+  background-image: -o-linear-gradient(top,#EEEEEE,#E0E0E0);
+  background-image: linear-gradient(top,#EEEEEE,#E0E0E0);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#EEEEEE',EndColorStr='#E0E0E0');
+  -webkit-box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+  -moz-box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+  box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+  border: 1px solid #CCC;
+  color: #333;
+}
+/* Disabled buttons */
+.ae-button.disabled, .ae-button.disabled:hover, .ae-button.disabled:active {
+  background: none;
+  color: #b8b8b8;
+  border: 1px solid #f3f3f3;
+  border: 1px solid rgba(0,0,0,0.05);
+  cursor: default;
+  pointer-events: none;
+}
+.ae-button.disabled.active{
+  -webkit-box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+  -moz-box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+  box-shadow: inset 0px 1px 2px rgba(0,0,0,0.1);
+}
+
+.ae-button-submit {
+  color: #FFF;
+  border-color: #3079ed;
+  background-color: #4d90fe;
+  background-image: -webkit-gradient(linear,left top,left bottom,from(#4d90fe),to(#4787ed));
+  background-image: -webkit-linear-gradient(top,#4d90fe,#4787ed);
+  background-image: -moz-linear-gradient(top,#4d90fe,#4787ed);
+  background-image: -ms-linear-gradient(top,#4d90fe,#4787ed);
+  background-image: -o-linear-gradient(top,#4d90fe,#4787ed);
+  background-image: linear-gradient(top,#4d90fe,#4787ed);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#4d90fe',EndColorStr='#4787ed');
+}
+.ae-button-submit:hover {
+  color: #FFF;
+  border-color: #2f5bb7;
+  background-color: #357ae8;
+  background-image: -webkit-gradient(linear,left top,left bottom,from(#4d90fe),to(#357ae8));
+  background-image: -webkit-linear-gradient(top,#4d90fe,#357ae8);
+  background-image: -moz-linear-gradient(top,#4d90fe,#357ae8);
+  background-image: -ms-linear-gradient(top,#4d90fe,#357ae8);
+  background-image: -o-linear-gradient(top,#4d90fe,#357ae8);
+  background-image: linear-gradient(top,#4d90fe,#357ae8);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#4d90fe',EndColorStr='#357ae8');
+}
+
+.ae-table-plain {
+  border-collapse: collapse;
+  width: 100%;
+}
+.ae-table {
+  border: 1px solid #c5d7ef;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+#bd h2.ae-table-title {
+  background: #e5ecf9;
+  margin: 0;
+  color: #000;
+  font-size: 1em;
+  padding: 3px 0 3px 5px;
+  border-left: 1px solid #c5d7ef;
+  border-right: 1px solid #c5d7ef;
+  border-top: 1px solid #c5d7ef;
+}
+.ae-table-caption,
+.ae-table caption {
+  border: 1px solid #c5d7ef;
+  background: #e5ecf9;
+  /**
+   * Fixes the caption margin ff display bug.
+   * see www.aurora-il.org/table_test.htm
+   * this is a slight variation to specifically target FF since Safari
+   * was shifting the caption over in an ugly fashion with margin-left: -1px
+   */
+  -moz-margin-start: -1px;
+}
+.ae-table caption {
+  padding: 3px 5px;
+  text-align: left;
+}
+.ae-table th,
+.ae-table td {
+  background-color: #fff;
+  padding: .35em 1em .25em .35em;
+  margin: 0;
+}
+.ae-table thead th {
+  font-weight: bold;
+  text-align: left;
+  background: #c5d7ef;
+  vertical-align: bottom;
+}
+.ae-table tfoot tr td {
+  border-top: 1px solid #c5d7ef;
+  background-color: #e5ecf9;
+}
+.ae-table td {
+  border-top: 1px solid #c5d7ef;
+  border-bottom: 1px solid #c5d7ef;
+}
+.ae-even td,
+.ae-even th,
+.ae-even-top td,
+.ae-even-tween td,
+.ae-even-bottom td,
+ol.ae-even {
+  background-color: #e9e9e9;
+  border-top: 1px solid #c5d7ef;
+  border-bottom: 1px solid #c5d7ef;
+}
+.ae-even-top td {
+  border-bottom: 0;
+}
+.ae-even-bottom td {
+  border-top: 0;
+}
+.ae-even-tween td {
+  border: 0;
+}
+.ae-table .ae-tween td {
+  border: 0;
+}
+.ae-table .ae-tween-top td {
+  border-bottom: 0;
+}
+.ae-table .ae-tween-bottom td {
+  border-top: 0;
+}
+.ae-table #ae-live td {
+  background-color: #ffeac0;
+}
+.ae-table-fixed {
+  table-layout: fixed;
+}
+.ae-table-fixed td,
+.ae-table-nowrap {
+  overflow: hidden;
+  white-space: nowrap;
+}
+.ae-new-usr td {
+  border-top: 1px solid #ccccce;
+  background-color: #ffe;
+}
+.ae-error-td td {
+  border: 2px solid #f00;
+  background-color: #fee;
+}
+.ae-table .ae-pager {
+  background-color: #c5d7ef;
+}
+
+.ae-errorbox {
+  border: 1px solid #f00;
+  background-color: #fee;
+  margin-bottom: 1em;
+  padding: 1em;
+  display: inline-block;
+}
+
+.ae-message {
+  border: 1px solid #e5ecf9;
+  background-color: #f6f9ff;
+  margin-bottom: 1em;
+  padding: 1em;
+  display: inline-block;
+}

--- a/AppDashboard/templates/datastore/edit.html
+++ b/AppDashboard/templates/datastore/edit.html
@@ -1,0 +1,85 @@
+<div id="datastore-viewer">
+  <div class="page-header">
+    <h1>Datastore Editor - {% if key %}Edit Entity{% else %}New Entity{% endif %}</h1>
+    <h3>{{ project_id }} >
+      {% if key %}Edit &quot;{{ kind }}&quot; Entity{% else %}New &quot;{{ kind }}&quot; Entity{% endif %}</h3>
+  </div>
+
+  <form action="{{ request.path }}" method="post">
+    <input type="hidden" name="xsrf_token" value="{{ xsrf_token }}"/>
+    <input type="hidden" name="next" value="{{ next }}"/>
+    {% if key and namespace %}
+      <div class="ae-settings-block">
+        <label>Namespace</label>
+        <div>{{ namespace }}</div>
+      </div>
+    {% endif %}
+    <div class="ae-settings-block">
+      <label>Entity Kind</label>
+      <div>
+        {{ kind }}
+        <input type="hidden" name="kind" value="{{ kind }}"/>
+      </div>
+    </div>
+    {% if key %}
+      <div class="ae-settings-block">
+        <label>Entity Key</label>
+        <div>
+          {{ key }}
+          <input type="hidden" name="key" value="{{ key }}"/>
+        </div>
+      </div>
+    {% endif %}
+    {% if key_name %}
+      <div class="ae-settings-block">
+        <label>Key Name</label>
+        <div>
+          {{ key_name }}
+        </div>
+      </div>
+    {% endif %}
+    {% if key_id %}
+      <div class="ae-settings-block">
+        <label>ID</label>
+        <div>
+          {{ key_id }}
+        </div>
+      </div>
+    {% endif %}
+    {% if parent_key %}
+      <div class="ae-settings-block">
+        <label>Parent</label>
+        <div>
+          {{ parent_key }}<br />
+          <a href="/datastore/edit/{{parent_key}}?next={{ request.uri }}">{{ parent_key_string }}</a>
+        </div>
+      </div>
+    {% endif %}
+    {% if not key %}
+      {% if namespace %}
+        <div class="ae-settings-block">
+          <label>Namespace ({{ namespace }})</label>
+          <div><input type="text" name="namespace" value="{{ namespace }}"/></div>
+        </div>
+      {% endif %}
+    {% endif %}
+    <div class="ae-settings-block ae-settings-block"></div>
+    {% for field in fields %}
+      <div class="ae-settings-block">
+        <label>
+          {{ field.0 }}&nbsp;({{ field.1 }})
+        </label>
+        <div>{{ field.2|safe }}</div>
+      </div>
+    {% endfor %}
+    <div class="ae-settings-block">
+      <div>
+        <input class="ae-button ae-button-submit" type="submit" value="Save Changes"/>
+        {% if key %}
+          <input id="delete_button" class="ae-button" type="submit" name="action:delete" value="Delete"/>
+        {% endif %}
+      </div>
+    </div>
+  </form>
+</div>
+<script>{% include "datastore/edit.js" %}</script>

--- a/AppDashboard/templates/datastore/edit.js
+++ b/AppDashboard/templates/datastore/edit.js
@@ -1,0 +1,12 @@
+/**
+ * @fileoverview Supporting Javascript for the datastore editor.
+ * @author bquinlan@google.com (Brian Quinlan)
+ */
+$(document).ready(function() {
+  $('#delete_button').click(function() {
+    return confirm(
+        'Are you sure you wish to delete this entity? If your app uses ' +
+        'memcache to cache entities (e.g. uses ndb) then you may see stale ' +
+        'results unless you flush memcache.');
+  });
+});

--- a/AppDashboard/templates/datastore/project_selector.html
+++ b/AppDashboard/templates/datastore/project_selector.html
@@ -1,0 +1,11 @@
+<div class="page-header"><h1>Datastore Viewer</h1></div>
+{% if owned_projects %}
+  <ul>
+  {% for project_id in owned_projects %}
+    <li><a href="/datastore_viewer/{{ project_id }}">{{ project_id }}</a></li>
+  {% endfor %}
+  </ul>
+{% else %}
+  <p>There are either no deployed projects, or you do not have ownership of any
+      of them.</p>
+{% endif %}

--- a/AppDashboard/templates/datastore/viewer.html
+++ b/AppDashboard/templates/datastore/viewer.html
@@ -1,0 +1,186 @@
+<div id="datastore-viewer">
+  <div class="page-header">
+    <h1>Datastore Viewer</h1>
+    <h3>{{ project_id }}</h3>
+  </div>
+
+  {% if message %}
+  <div>
+    {{ message }}
+  </div>
+  {% endif %}
+
+  <form action="{{ request.path }}" method="get">
+  {% if kinds %}
+    <div id="entity-manager" class="ae-settings-block">
+      <table>
+        <thead>
+          <tr>
+            {% if show_namespace %}
+              <th>
+                Namespace
+              </th>
+            {% endif %}
+            <th>
+              Entity Kind
+            </th>
+            <th>
+              &nbsp;
+            </th>
+          </tr>
+        </thead>
+        <tr>
+          {% if show_namespace %}
+            <td>
+              <input id="namespace_input" name="namespace" type="text" size="20" value="{{ namespace }}"/>
+            </td>
+          {% endif %}
+          <td>
+            <select name="kind" class="ae-button" id="kind_input">
+              {% for a_kind in kinds %}
+              <option value="{{ a_kind }}"{% if a_kind == kind %} selected="selected"{% endif %}>{{ a_kind }}</option>
+              {% endfor %}
+            </select>
+          </td>
+          <td>
+            <input type="submit" class="ae-button" value="List Entities"/>
+            <input type="button" id="create_button" class="ae-button" value="Create New Entity"/>
+            {% if not show_namespace %}
+              <a href="{{ select_namespace_url }}">Select a different namespace</a>
+            {% endif %}
+          </td>
+        </tr>
+      </table>
+    </div>
+    {% else %}
+    <p id="datastore_empty">
+      {% if namespace %}
+        Either {{ project_id }} has no entities in namespace &quot;{{ namespace }}&quot;
+        or entities have been added after the last time statistics were
+        generated.
+      {% else %}
+        Either {{ project_id }} has no entities in the Empty namespace or
+        entities have been added after the last time statistics were generated.
+      {% endif %}
+      <br>
+      {% if show_namespace %}
+        <input id="namespace_input" name="namespace" type="text" size="20" value="{{ namespace }}"/>
+        <input type="submit" class="ae-button" value="Change Namespace"/>
+      {% else %}
+      <a href="{{ select_namespace_url }}">Select different namespace</a>
+      {% endif %}
+    </p>
+  {% endif %}
+  </form>
+
+  {% if entities %}
+    <form action="{{ request.path }}" method="post">
+      <input type="hidden" name="xsrf_token" value="{{ xsrf_token }}"/>
+      <input type="hidden" name="kind" value="{{ kind }}"/>
+      <table class="ae-table ae-settings-block">
+        <thead>
+        <tr>
+          <th><input id="allkeys" type="checkbox" /></th>
+          <th>Key</th>
+          <th>Write Ops</th>
+          <th>ID</th>
+          <th>Key Name</th>
+          {% for header in headers %}
+            <th ><a href="{{ order_base_url }}&amp;order={% if order == header.name %}-{% endif %}{{ header.name }}">{{ header.name }}</a></th>
+          {% endfor %}
+          {% if property_overflow %}
+            <th>Properties Elided&hellip;</th>
+          {% endif %}
+        </tr>
+        {% for entity in entities %}
+          <tr>
+            <td>
+              <input id="key{{ loop.index }}" type="checkbox" name="entity_key" value="{{ entity.key }}"/>
+            </td>
+            <td>
+              <a href="{{ entity.edit_uri }}">{{ entity.shortened_key }}</a>
+            </td>
+            <td>
+              {{entity.write_ops}}
+            </td>
+            <td>
+              {% if entity.key_id %}
+                {{entity.key_id}}
+              {% endif %}
+            </td>
+            <td>
+              {% if entity.key_name %}
+                {{entity.key_name}}
+              {% endif %}
+            </td>
+            {% for attribute in entity.attributes %}
+              <td>{{ attribute.short_value }}</td>
+            {% endfor %}
+            {% if property_overflow %}
+              <td></td>
+            {% endif %}
+          </tr>
+        {% endfor %}
+      </table>
+      <div>
+          <div class="ae-settings-block">
+            <div>
+              <input id="delete_button" class="ae-button" name="action:delete_entities" type="submit" value="Delete" />
+              <input id="memcache_flush_button" class="ae-button" type="submit" name="action:flush_memcache" value="Flush Memcache" />
+            </div>
+          </div>
+          <div class="ae-settings-block">
+            <div>
+              {% if num_pages > 1 %}
+                <div class="ae-paginator">
+                  {% if page != 1 %}
+                    <a href="{{ paging_base_url }}&amp;page={{ page - 1 }}">Previous</a>
+                  {% endif %}
+
+                  {% for page_count in range(1, num_pages+1) %}
+                    {% if page_count == page %}
+                      {{ page_count }}
+                    {% else %}
+                      <a href="{{ paging_base_url }}&amp;page={{ page_count }}">{{ page_count }}</a>
+                    {% endif %}
+                  {% endfor %}
+
+                  {% if page != num_pages %}
+                    <a href="{{ paging_base_url }}&amp;page={{ page + 1 }}">Next</a>
+                  {% endif %}
+                </div>
+              {% endif %}
+            </div>
+            <div class="ae-result-count">
+              {% if entities %}
+                <div>
+                  Results {{ start + 1 }} - {{ entities|length + start }} of
+                  {{ total_entities }}
+                </div>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+    </form>
+  {% else %}
+    {% if kind and kinds %}
+    <p>
+      Datastore contains no entities of kind &quot;{{ kind }}&quot; in the
+      {% if namespace %}
+        namespace &quot;<strong>{{ namespace }}</strong>&quot;.
+      {% else %}
+        <strong>Empty</strong> namespace.
+      {% endif %}
+    </p>
+    {% endif %}
+  <form action="" method="post">
+    <input type="hidden" name="xsrf_token" value="{{ xsrf_token }}"/>
+    <input type="hidden" name="kind" value="{{ kind }}"/>
+    {% if show_namespace %}
+      <input type="hidden" name="namespace" value="{{ namespace }}"/>
+    {% endif %}
+    <input id="memcache_flush_button" class="ae-button" type="submit" name="action:flush_memcache" value="Flush Memcache" />
+  </form>
+  {% endif %}
+</div>
+<script>{% include "datastore/viewer.js" %}</script>

--- a/AppDashboard/templates/datastore/viewer.js
+++ b/AppDashboard/templates/datastore/viewer.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Supporting Javascript for the datastore viewer.
+ * @author bquinlan@google.com (Brian Quinlan)
+ */
+function checkAllEntities() {
+  var check = $('#allkeys').prop('checked');
+  $('input[name="entity_key"]').attr('checked', check);
+  updateDeleteButtonAndCheckbox();
+}
+
+function updateDeleteButtonAndCheckbox() {
+  var checkboxes = $('input[name="entity_key"]');
+  var checked_checkboxes = checkboxes.filter(':checked');
+
+  if (checked_checkboxes.length) {
+    $('#delete_button').removeAttr('disabled');
+    $('#delete_button').removeClass('disabled');
+  } else {
+    $('#delete_button').attr('disabled', 'disabled');
+    $('#delete_button').addClass('disabled');
+  }
+
+  $('#allkeys').attr('checked',
+                     checkboxes.length == checked_checkboxes.length);
+}
+
+$(document).ready(function() {
+  var projectId = '{{ project_id }}';
+  $('#allkeys').click(checkAllEntities);
+
+  $('#create_button').click(function() {
+    params = {'kind' : $('#kind_input').attr('value'),
+              'next': '{{ request.uri }}'};
+
+    if ($('#namespace_input').length) {
+      params['namespace'] = $('#namespace_input').attr('value');
+    }
+
+    window.location = '/datastore_viewer/' + projectId + '/edit?' +
+      $.param(params);
+    return false;
+  });
+
+  $('#delete_button').click(function() {
+    return confirm(
+        'Are you sure you wish to delete these entities? If your app uses ' +
+        'memcache to cache entities (e.g. uses ndb) then you may see stale ' +
+        'results unless you flush memcache.');
+  });
+
+  $('#memcache_flush_button').click(function() {
+    return confirm('Are you sure you want to flush all keys from the cache?');
+  });
+
+  $('input[name="entity_key"]').change(function() {
+    updateDeleteButtonAndCheckbox();
+  });
+
+  if ($('#delete_button').length) {
+    updateDeleteButtonAndCheckbox();
+  }
+
+  $('kind_input').focus();
+});

--- a/AppDashboard/templates/shared/navigation.html
+++ b/AppDashboard/templates/shared/navigation.html
@@ -73,7 +73,7 @@
                             <div align="center" class="list-group-item">
                               <div class="btn-group">
                               {% if page_name=="dash" %}
-                                {% if dict_key=="taskqueue" or dict_key=="monit" %}
+                                {% if dict_key in panel_blacklist %}
                                   <a class="btn btn-info" href="{{menuitem.link}}"
                                      style="width:100%;">{{ menuitem.title }}</a>
                                 {% else %}


### PR DESCRIPTION
This bypasses the API server to make calls directly to the datastore server on behalf of a given project. Most of the interface was taken from the Python SDK's admin server, but calls to the datastore API were replaced with urlfetch calls to the datastore server.