### PR TITLE
Fix JSP compilation under Java 8

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -264,6 +264,15 @@ installappserverjava()
 
     echo "Extracting Java SDK"
     unzip -q "${PACKAGE_CACHE}/${JAVA_SDK_PACKAGE}" -d ${JAVA_SDK_DIR}
+    EXTRACTED_SDK="${JAVA_SDK_DIR}/appengine-java-sdk-1.8.4"
+
+    # The jar included in the 1.8.4 SDK cannot compile JSP files under Java 8.
+    JSP_JAR="repackaged-appengine-eclipse-jdt-ecj.jar"
+    JSP_JAR_MD5="e85db8329dccbd18b8174a3b99513393"
+    cachepackage ${JSP_JAR} ${JSP_JAR_MD5}
+    OLD_JAR="repackaged-appengine-jasper-jdt-6.0.29.jar"
+    rm ${EXTRACTED_SDK}/lib/tools/jsp/${OLD_JAR}
+    cp ${PACKAGE_CACHE}/${JSP_JAR} ${EXTRACTED_SDK}/lib/tools/jsp/${JSP_JAR}
 
     # Compile source file.
     (cd ${JAVA_SDK_DIR} && ant install && ant clean-build)

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -262,6 +262,9 @@ installappserverjava()
     JAVA_SDK_PACKAGE_MD5="f5750b0c836870a3089096fd537a1272"
     cachepackage ${JAVA_SDK_PACKAGE} ${JAVA_SDK_PACKAGE_MD5}
 
+    # Remove older build target to prevent jar conflicts.
+    (cd ${JAVA_SDK_DIR} && ant clean-all)
+
     echo "Extracting Java SDK"
     unzip -q "${PACKAGE_CACHE}/${JAVA_SDK_PACKAGE}" -d ${JAVA_SDK_DIR}
     EXTRACTED_SDK="${JAVA_SDK_DIR}/appengine-java-sdk-1.8.4"


### PR DESCRIPTION
This replaces the 1.8.4 JSP jar with the one included in the 1.9.44 SDK.