### PR TITLE
Allow Java AppServer to use an external API Server

### DIFF
--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -130,6 +130,7 @@
       <include name="com/google/apphosting/utils/config/*" />
       <include name="com/google/appengine/tools/development/DevAppServerMain*" />
       <include name="com/google/appengine/tools/development/DevAppServerFactory*" />
+      <include name="com/google/appengine/tools/development/SharedMain*" />
     </jar>
   </target>
 

--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -129,6 +129,7 @@
     <jar destfile="${gae_dist}/lib/appengine-tools-api.jar" basedir="${build}" update="true">
       <include name="com/google/apphosting/utils/config/*" />
       <include name="com/google/appengine/tools/development/ApiUtils*" />
+      <include name="com/google/appengine/tools/development/ApiServer*" />
       <include name="com/google/appengine/tools/development/DevAppServerMain*" />
       <include name="com/google/appengine/tools/development/DevAppServerFactory*" />
       <include name="com/google/appengine/tools/development/SharedMain*" />

--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -129,6 +129,7 @@
     <jar destfile="${gae_dist}/lib/appengine-tools-api.jar" basedir="${build}" update="true">
       <include name="com/google/apphosting/utils/config/*" />
       <include name="com/google/appengine/tools/development/ApiUtils*" />
+      <include name="com/google/appengine/tools/development/ApiProxyLocalFactory*" />
       <include name="com/google/appengine/tools/development/ApiServer*" />
       <include name="com/google/appengine/tools/development/ApiServerFactory*" />
       <include name="com/google/appengine/tools/development/DevAppServerMain*" />

--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -128,6 +128,7 @@
   <target name="update-tools-api-jar" depends="compile, repack-sdk">
     <jar destfile="${gae_dist}/lib/appengine-tools-api.jar" basedir="${build}" update="true">
       <include name="com/google/apphosting/utils/config/*" />
+      <include name="com/google/appengine/tools/development/ApiUtils*" />
       <include name="com/google/appengine/tools/development/DevAppServerMain*" />
       <include name="com/google/appengine/tools/development/DevAppServerFactory*" />
       <include name="com/google/appengine/tools/development/SharedMain*" />

--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -130,6 +130,7 @@
       <include name="com/google/apphosting/utils/config/*" />
       <include name="com/google/appengine/tools/development/ApiUtils*" />
       <include name="com/google/appengine/tools/development/ApiServer*" />
+      <include name="com/google/appengine/tools/development/ApiServerFactory*" />
       <include name="com/google/appengine/tools/development/DevAppServerMain*" />
       <include name="com/google/appengine/tools/development/DevAppServerFactory*" />
       <include name="com/google/appengine/tools/development/SharedMain*" />

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalFactory.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalFactory.java
@@ -1,0 +1,9 @@
+package com.google.appengine.tools.development;
+
+public class ApiProxyLocalFactory {
+    LocalServerEnvironment localServerEnvironment;
+
+    public ApiProxyLocal create(LocalServerEnvironment localServerEnvironment) {
+        return new ApiProxyLocalImpl(localServerEnvironment);
+    }
+}

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalFactory.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalFactory.java
@@ -1,9 +1,15 @@
 package com.google.appengine.tools.development;
 
+import java.util.Set;
+
 public class ApiProxyLocalFactory {
     LocalServerEnvironment localServerEnvironment;
 
     public ApiProxyLocal create(LocalServerEnvironment localServerEnvironment) {
         return new ApiProxyLocalImpl(localServerEnvironment);
+    }
+
+    public ApiProxyLocal create(LocalServerEnvironment localServerEnvironment, Set apisUsingPythonStubs) {
+        return ApiProxyLocalImpl.getApiProxyLocal(localServerEnvironment, apisUsingPythonStubs);
     }
 }

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
@@ -1,5 +1,6 @@
 package com.google.appengine.tools.development;
 
+import com.google.appengine.api.capabilities.CapabilityStatus;
 import com.google.appengine.repackaged.com.google.io.protocol.ProtocolMessage;
 import com.google.appengine.repackaged.com.google.protobuf.Message;
 import com.google.apphosting.api.ApiProxy;
@@ -7,6 +8,7 @@ import com.google.apphosting.api.ApiProxy.ApiConfig;
 import com.google.apphosting.api.ApiProxy.ApiDeadlineExceededException;
 import com.google.apphosting.api.ApiProxy.CallNotFoundException;
 import com.google.apphosting.api.ApiProxy.CancelledException;
+import com.google.apphosting.api.ApiProxy.CapabilityDisabledException;
 import com.google.apphosting.api.ApiProxy.Environment;
 import com.google.apphosting.api.ApiProxy.LogRecord;
 import com.google.apphosting.api.ApiProxy.RequestTooLargeException;
@@ -390,6 +392,12 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
                 LocalRpcService service = ApiProxyLocalImpl.this.getService(this.packageName);
                 if (service == null) {
                     throw new CallNotFoundException(this.packageName, this.methodName);
+                }
+
+                LocalCapabilitiesEnvironment capEnv = ApiProxyLocalImpl.this.context.getLocalCapabilitiesEnvironment();
+                CapabilityStatus capabilityStatus = capEnv.getStatusFromMethodName(this.packageName, this.methodName);
+                if (!CapabilityStatus.ENABLED.equals(capabilityStatus)) {
+                    throw new CapabilityDisabledException("Setup in local configuration.", this.packageName, this.methodName);
                 }
 
                 if (this.requestBytes.length > ApiProxyLocalImpl.this.getMaxApiRequestSize(service)) {

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
+import java.util.Formatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +197,7 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
             Method method = requestClass.getMethod("parseFrom", BYTE_ARRAY_CLASS);
             return requestClass.cast(method.invoke((Object)null, bytes));
         } else {
-            throw new UnsupportedOperationException("Cannot convert byte[] to " + requestClass);
+            throw new UnsupportedOperationException(format("Cannot assign %s to either %s or %s", classDescription(requestClass), ProtocolMessage.class, Message.class));
         }
     }
 
@@ -212,8 +213,16 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
         } else if (object instanceof Message) {
             return ((Message)object).toByteArray();
         } else {
-            throw new UnsupportedOperationException("Cannot convert " + object + " to byte[].");
+            throw new UnsupportedOperationException(format("%s is neither %s nor %s", classDescription(object.getClass()), ProtocolMessage.class, Message.class));
         }
+    }
+
+    private static String classDescription(Class<?> klass) {
+        return format("(%s extends %s loaded from %s)", klass, klass.getSuperclass(), klass.getProtectionDomain().getCodeSource().getLocation());
+    }
+
+    private static String format(String format, Object... args) {
+        return (new Formatter()).format(format, args).toString();
     }
 
     public void setProperty(String property, String value) {

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
@@ -82,7 +82,20 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
 
     static ApiProxyLocal getApiProxyLocal(LocalServerEnvironment environment, Set<String> apisUsingPythonStubs) {
         if (!apisUsingPythonStubs.isEmpty()) {
-            ApiServer apiServer = ApiServerFactory.getApiServer(System.getProperty("appengine.pathToPythonApiServer"));
+            // AppScale: Check if an external API server should be used.
+            int externalApiPort;
+            try {
+                externalApiPort = Integer.valueOf(System.getProperty("appscale.externalApiPort"));
+            } catch (NumberFormatException e) {
+                externalApiPort = -1;
+            }
+
+            ApiServer apiServer;
+            if (externalApiPort != -1) {
+                apiServer = ApiServerFactory.getApiServer(externalApiPort);
+            } else {
+                apiServer = ApiServerFactory.getApiServer(System.getProperty("appengine.pathToPythonApiServer"));
+            }
             return new ApiProxyLocalImpl(environment, apisUsingPythonStubs, apiServer);
         } else {
             return new ApiProxyLocalImpl(environment);

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
@@ -18,7 +18,6 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
-import java.util.Formatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -197,7 +196,7 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
             Method method = requestClass.getMethod("parseFrom", BYTE_ARRAY_CLASS);
             return requestClass.cast(method.invoke((Object)null, bytes));
         } else {
-            throw new UnsupportedOperationException(format("Cannot assign %s to either %s or %s", classDescription(requestClass), ProtocolMessage.class, Message.class));
+            throw new UnsupportedOperationException(String.format("Cannot assign %s to either %s or %s", classDescription(requestClass), ProtocolMessage.class, Message.class));
         }
     }
 
@@ -213,16 +212,12 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
         } else if (object instanceof Message) {
             return ((Message)object).toByteArray();
         } else {
-            throw new UnsupportedOperationException(format("%s is neither %s nor %s", classDescription(object.getClass()), ProtocolMessage.class, Message.class));
+            throw new UnsupportedOperationException(String.format("%s is neither %s nor %s", classDescription(object.getClass()), ProtocolMessage.class, Message.class));
         }
     }
 
     private static String classDescription(Class<?> klass) {
-        return format("(%s extends %s loaded from %s)", klass, klass.getSuperclass(), klass.getProtectionDomain().getCodeSource().getLocation());
-    }
-
-    private static String format(String format, Object... args) {
-        return (new Formatter()).format(format, args).toString();
+        return String.format("(%s extends %s loaded from %s)", klass, klass.getSuperclass(), klass.getProtectionDomain().getCodeSource().getLocation());
     }
 
     public void setProperty(String property, String value) {

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
@@ -182,7 +182,10 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
     }
 
     private double resolveDeadline(String packageName, ApiConfig apiConfig, boolean isOffline) {
-        LocalRpcService service = this.getService(packageName);
+        // AppScale: Avoid using getService here. If the datastore is the first to be initialized, the setupIndexes
+        // will try to initialize the remote_socket service. Trying to get the remote_socket service while the datastore
+        // is being initialized will block since getService is synchronized.
+        LocalRpcService service = this.serviceCache.getOrDefault(packageName, null);
         Double deadline = null;
         if (apiConfig != null) {
             deadline = apiConfig.getDeadlineInSeconds();

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiProxyLocalImpl.java
@@ -87,7 +87,7 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
             apiConfig.setDeadlineInSeconds(deadline);
         }
 
-        Future<byte[]> future = this.doAsyncCall(environment, packageName, methodName, requestBytes, apiConfig);
+        Future<byte[]> future = this.makeAsyncCall(environment, packageName, methodName, requestBytes, apiConfig);
 
         try {
             return (byte[])future.get();
@@ -106,17 +106,8 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
         }
     }
 
-    public Future<byte[]> makeAsyncCall(Environment environment, String packageName, String methodName, byte[] requestBytes, ApiConfig apiConfig) {
-        return this.doAsyncCall(environment, packageName, methodName, requestBytes, apiConfig);
-    }
-
-    public List<Thread> getRequestThreads(Environment environment) {
-        return Arrays.asList(Thread.currentThread());
-    }
-
-    private Future<byte[]> doAsyncCall(Environment environment, final String packageName, final String methodName, byte[] requestBytes, ApiConfig apiConfig) {
+    public Future<byte[]> makeAsyncCall(Environment environment, final String packageName, final String methodName, byte[] requestBytes, ApiConfig apiConfig) {
         Semaphore semaphore = (Semaphore) environment.getAttributes().get(LocalEnvironment.API_CALL_SEMAPHORE);
-
         if (semaphore != null) {
             try {
                 semaphore.acquire();
@@ -152,6 +143,10 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
         }
 
         return result;
+    }
+
+    public List<Thread> getRequestThreads(Environment environment) {
+        return Arrays.asList(Thread.currentThread());
     }
 
     private double resolveDeadline(String packageName, ApiConfig apiConfig, boolean isOffline) {
@@ -310,8 +305,7 @@ class ApiProxyLocalImpl implements ApiProxyLocal {
     @SuppressWarnings( { "restriction", "unchecked" })
     private LocalRpcService startServices(String pkg) {
         // @SuppressWarnings( { "unchecked", "sunapi" })
-        for (LocalRpcService service : ServiceLoader.load(LocalRpcService.class, ApiProxyLocalImpl.class.getClassLoader()))
-        {
+        for (LocalRpcService service : ServiceLoader.load(LocalRpcService.class, ApiProxyLocalImpl.class.getClassLoader())) {
             if (service.getPackage().equals(pkg)) {
                 service.init(context, properties);
                 service.start();

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiServer.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiServer.java
@@ -67,6 +67,12 @@ public class ApiServer {
         }
     }
 
+    // AppScale: Use an existing server without starting it.
+    ApiServer(int externalServerPort) {
+        this.port = externalServerPort;
+        this.process = null;
+    }
+
     public Integer getPort() {
         return this.port;
     }
@@ -82,6 +88,11 @@ public class ApiServer {
     }
 
     public void close() {
+        // AppScale: If a server was not started, there is nothing to stop.
+        if (this.process == null) {
+            return;
+        }
+
         try {
             int exitValue = this.process.exitValue();
             if (exitValue != 0) {

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiServer.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiServer.java
@@ -1,0 +1,127 @@
+package com.google.appengine.tools.development;
+
+import com.google.appengine.repackaged.org.apache.commons.httpclient.HttpClient;
+import com.google.appengine.repackaged.org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
+import com.google.appengine.repackaged.org.apache.commons.httpclient.methods.GetMethod;
+import com.google.appengine.repackaged.org.apache.commons.httpclient.methods.PostMethod;
+import com.google.apphosting.utils.remoteapi.RemoteApiPb.Request;
+import com.google.apphosting.utils.remoteapi.RemoteApiPb.Response;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.xml.ws.http.HTTPException;
+
+public class ApiServer {
+    private static final Logger logger = Logger.getLogger(ApiServer.class.getName());
+    private final Process process;
+    private final int port;
+
+    ApiServer(String pathToApiServer) {
+        try {
+            ServerSocket socket = new ServerSocket(0);
+            Throwable error = null;
+
+            try {
+                this.port = socket.getLocalPort();
+            } catch (Throwable e) {
+                error = e;
+                throw e;
+            } finally {
+                if (error != null) {
+                    try {
+                        socket.close();
+                    } catch (Throwable e) {
+                        error.addSuppressed(e);
+                    }
+                } else {
+                    socket.close();
+                }
+
+            }
+
+            String[] cmd = new String[]{
+                    pathToApiServer,
+                    "--api_port", String.valueOf(this.port),
+                    "--clear_datastore",
+                    "--datastore_consistency_policy", "consistent",
+                    "--application", "test",
+                    "--application_prefix", "",
+                    "--datastore_path", (new StringBuilder(16)).append("/tmp/").append(this.port).toString()};
+
+            this.process = new ProcessBuilder().command(cmd).redirectErrorStream(true).start();
+            BufferedReader stdInput = new BufferedReader(new InputStreamReader(this.process.getInputStream(), StandardCharsets.UTF_8));
+
+            String stdInputLine;
+            while((stdInputLine = stdInput.readLine()) != null && !stdInputLine.contains("Starting API server at:")) {
+                ;
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Integer getPort() {
+        return this.port;
+    }
+
+    public void clear() throws IOException {
+        HttpClient httpClient = new HttpClient();
+        int returnCode = this.port;
+        GetMethod request = new GetMethod((new StringBuilder(34)).append("http://localhost:").append(returnCode).append("/clear").toString());
+        returnCode = httpClient.executeMethod(request);
+        if (returnCode != 200) {
+            throw new IOException((new StringBuilder(78)).append("Sending HTTP request to clear the API server failed with response: ").append(returnCode).toString());
+        }
+    }
+
+    public void close() {
+        try {
+            int exitValue = this.process.exitValue();
+            if (exitValue != 0) {
+                logger.logp(Level.WARNING, "com.google.appengine.tools.development.ApiServer", "close", (new StringBuilder(67)).append("The API server process exited with a non-zero value of: ").append(exitValue).toString());
+            }
+        } catch (IllegalThreadStateException var2) {
+            this.process.destroy();
+        }
+
+    }
+
+    byte[] makeSyncCall(String packageName, String methodName, byte[] requestBytes) throws IOException, IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException {
+        Request remoteApiRequest = new Request();
+        remoteApiRequest.setServiceName(packageName);
+        remoteApiRequest.setMethod(methodName);
+        remoteApiRequest.setRequestAsBytes(requestBytes);
+        remoteApiRequest.setRequestId(UUID.randomUUID().toString().substring(0, 10));
+        byte[] remoteApiRequestBytes = ApiUtils.convertPbToBytes(remoteApiRequest);
+        PostMethod post = new PostMethod((new StringBuilder(28)).append("http://localhost:").append(this.port).toString());
+        post.setFollowRedirects(false);
+        post.addRequestHeader("Host", "localhost");
+        post.addRequestHeader("Content-Type", "application/octet-stream");
+        post.setRequestEntity(new ByteArrayRequestEntity(remoteApiRequestBytes));
+
+        try {
+            HttpClient httpClient = new HttpClient();
+            httpClient.executeMethod(post);
+            if (post.getStatusCode() != 200) {
+                throw new HTTPException(post.getStatusCode());
+            }
+        } catch (IOException e) {
+            throw new IOException("Error executing POST to HTTP API server.");
+        }
+
+        Response response = new Response();
+        boolean parsed = response.mergeFrom(post.getResponseBodyAsStream());
+        if (!parsed) {
+            throw new IOException("Error parsing the response from the HTTP API server.");
+        } else {
+            return response.getResponseAsBytes();
+        }
+    }
+}

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiServerFactory.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiServerFactory.java
@@ -2,6 +2,7 @@ package com.google.appengine.tools.development;
 
 public class ApiServerFactory {
     private static ApiServer instance;
+    private static ApiServer externalServer;
 
     public static ApiServer getApiServer(String pathToApiServer) {
         if (instance == null) {
@@ -10,6 +11,14 @@ public class ApiServerFactory {
         }
 
         return instance;
+    }
+
+    public static ApiServer getApiServer(int externalServerPort) {
+        if (externalServer == null) {
+            externalServer = new ApiServer(externalServerPort);
+        }
+
+        return externalServer;
     }
 
     private static void addShutdownHook(final ApiServer apiServer) {

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiServerFactory.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiServerFactory.java
@@ -1,0 +1,22 @@
+package com.google.appengine.tools.development;
+
+public class ApiServerFactory {
+    private static ApiServer instance;
+
+    public static ApiServer getApiServer(String pathToApiServer) {
+        if (instance == null) {
+            instance = new ApiServer(pathToApiServer);
+            addShutdownHook(instance);
+        }
+
+        return instance;
+    }
+
+    private static void addShutdownHook(final ApiServer apiServer) {
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                apiServer.close();
+            }
+        });
+    }
+}

--- a/AppServer_Java/src/com/google/appengine/tools/development/ApiUtils.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/ApiUtils.java
@@ -1,0 +1,40 @@
+package com.google.appengine.tools.development;
+
+import com.google.appengine.repackaged.com.google.io.protocol.ProtocolMessage;
+import com.google.appengine.repackaged.com.google.protobuf.Message;
+import com.google.appengine.repackaged.com.google.protobuf.MessageLite;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ApiUtils {
+    public static <T> T convertBytesToPb(byte[] bytes, Class<T> messageClass) throws IllegalAccessException, InstantiationException, InvocationTargetException, NoSuchMethodException {
+        if (ProtocolMessage.class.isAssignableFrom(messageClass)) {
+            ProtocolMessage<?> proto = (ProtocolMessage)messageClass.getConstructor().newInstance();
+            boolean parsed = proto.mergeFrom(bytes);
+            if (parsed && proto.isInitialized()) {
+                return messageClass.cast(proto);
+            } else {
+                String messageType = String.valueOf(classDescription(messageClass));
+                String error = "Could not parse request bytes into ".concat(messageType);
+                throw new RuntimeException(error);
+            }
+        } else if (Message.class.isAssignableFrom(messageClass)) {
+            Method method = messageClass.getMethod("parseFrom", byte[].class);
+            return messageClass.cast(method.invoke((Object)null, bytes));
+        } else {
+            throw new UnsupportedOperationException(String.format("Cannot assign %s to either %s or %s", classDescription(messageClass), ProtocolMessage.class, Message.class));
+        }
+    }
+
+    public static byte[] convertPbToBytes(Object object) {
+        if (object instanceof MessageLite) {
+            return ((MessageLite)object).toByteArray();
+        } else {
+            throw new UnsupportedOperationException(String.format("%s is neither %s nor %s", classDescription(object.getClass()), ProtocolMessage.class, Message.class));
+        }
+    }
+
+    private static String classDescription(Class<?> klass) {
+        return String.format("(%s extends %s loaded from %s)", klass, klass.getSuperclass(), klass.getProtectionDomain().getCodeSource().getLocation());
+    }
+}

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerImpl.java
@@ -2,6 +2,7 @@ package com.google.appengine.tools.development;
 
 import com.google.appengine.api.labs.modules.dev.LocalModulesService;
 import com.google.appengine.repackaged.com.google.common.base.Joiner;
+import com.google.appengine.repackaged.com.google.common.base.Splitter;
 import com.google.appengine.repackaged.com.google.common.collect.ImmutableMap;
 import com.google.appengine.repackaged.com.google.common.collect.ImmutableSet;
 import com.google.appengine.tools.info.SdkInfo;
@@ -18,7 +19,9 @@ import java.net.BindException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -128,8 +131,14 @@ class DevAppServerImpl implements DevAppServer {
       }
 
       ApiProxyLocalFactory factory = new ApiProxyLocalFactory();
+      Set<String> apisUsingPythonStubs = new HashSet();
+      if (System.getProperty("appengine.apisUsingPythonStubs") != null) {
+        for (String api : Splitter.on(',').split(System.getProperty("appengine.apisUsingPythonStubs"))) {
+          apisUsingPythonStubs.add(api);
+        }
+      }
 
-      this.apiProxyLocal = factory.create(this.modules.getLocalServerEnvironment());
+      this.apiProxyLocal = factory.create(this.modules.getLocalServerEnvironment(), apisUsingPythonStubs);
       this.setInboundServicesProperty();
       this.apiProxyLocal.setProperties(this.serviceProperties);
       ApiProxy.setDelegate(this.apiProxyLocal);

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerImpl.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerImpl.java
@@ -4,17 +4,14 @@ import com.google.appengine.api.labs.modules.dev.LocalModulesService;
 import com.google.appengine.repackaged.com.google.common.base.Joiner;
 import com.google.appengine.repackaged.com.google.common.collect.ImmutableMap;
 import com.google.appengine.repackaged.com.google.common.collect.ImmutableSet;
-import com.google.appengine.repackaged.com.google.common.collect.ImmutableSet.Builder;
 import com.google.appengine.tools.info.SdkInfo;
-import com.google.appengine.tools.info.Version;
 import com.google.apphosting.api.ApiProxy;
+import com.google.apphosting.api.ApiProxy.Delegate;
 import com.google.apphosting.api.ApiProxy.Environment;
 import com.google.apphosting.utils.config.AppEngineConfigException;
 import com.google.apphosting.utils.config.AppEngineWebXml;
 import com.google.apphosting.utils.config.EarHelper;
-import com.google.apphosting.utils.config.WebModule;
 import java.io.File;
-import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.BindException;
@@ -35,9 +32,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-class DevAppServerImpl
-  implements DevAppServer
-{
+class DevAppServerImpl implements DevAppServer {
   private final String APPLICATION_ID_PROPERTY = "APPLICATION_ID";
   public static final String MODULES_FILTER_HELPER_PROPERTY = "com.google.appengine.tools.development.modules_filter_helper";
   private static final Logger logger = Logger.getLogger(DevAppServerImpl.class.getName());
@@ -46,72 +41,67 @@ class DevAppServerImpl
   private Map<String, String> serviceProperties = new HashMap();
   private final Map<String, Object> containerConfigProperties;
   private final int requestedPort;
-  private ServerState serverState = ServerState.INITIALIZING;
+  private DevAppServerImpl.ServerState serverState;
   private final BackendServers backendContainer;
   private ApiProxyLocal apiProxyLocal;
   private final AppEngineConfigException configurationException;
-  private final ScheduledExecutorService shutdownScheduler = Executors.newScheduledThreadPool(1);
+  private final ScheduledExecutorService shutdownScheduler;
+  private CountDownLatch shutdownLatch;
 
-  private CountDownLatch shutdownLatch = null;
-
-  public DevAppServerImpl(File appDir, File externalResourceDir, File webXmlLocation, File appEngineWebXmlLocation, String address, int port, boolean useCustomStreamHandler, Map<String, Object> containerConfigProperties)
-  {
+  public DevAppServerImpl(File appDir, File externalResourceDir, File webXmlLocation, File appEngineWebXmlLocation, String address, int port, boolean useCustomStreamHandler, Map<String, Object> containerConfigProperties) {
+    this.serverState = DevAppServerImpl.ServerState.INITIALIZING;
+    this.shutdownScheduler = Executors.newScheduledThreadPool(1);
+    this.shutdownLatch = null;
     String serverInfo = ContainerUtils.getServerInfo();
     if (useCustomStreamHandler) {
       StreamHandlerFactory.install();
     }
-    DevSocketImplFactory.install();
 
+    DevSocketImplFactory.install();
     this.backendContainer = BackendServers.getInstance();
     this.requestedPort = port;
     ApplicationConfigurationManager tempManager = null;
     File schemaFile = new File(SdkInfo.getSdkRoot(), "docs/appengine-application.xsd");
+
     try {
       if (EarHelper.isEar(appDir.getAbsolutePath())) {
         tempManager = ApplicationConfigurationManager.newEarConfigurationManager(appDir, SdkInfo.getLocalVersion().getRelease(), schemaFile);
         String contextRootWarning = "Ignoring application.xml context-root element, for details see https://developers.google.com/appengine/docs/java/modules/#config";
         logger.info(contextRootWarning);
-      }
-      else {
+      } else {
         tempManager = ApplicationConfigurationManager.newWarConfigurationManager(appDir, appEngineWebXmlLocation, webXmlLocation, externalResourceDir, SdkInfo.getLocalVersion().getRelease());
       }
-    }
-    catch (AppEngineConfigException configurationException)
-    {
+    } catch (AppEngineConfigException configurationException) {
       this.modules = null;
       this.applicationConfigurationManager = null;
       this.containerConfigProperties = null;
       this.configurationException = configurationException;
       return;
     }
+
     this.applicationConfigurationManager = tempManager;
-    this.modules = Modules.createModules(applicationConfigurationManager, serverInfo, externalResourceDir, address, this);
-
-    DelegatingModulesFilterHelper modulesFilterHelper = new DelegatingModulesFilterHelper(backendContainer, modules);
-
+    this.modules = Modules.createModules(this.applicationConfigurationManager, serverInfo, externalResourceDir, address, this);
+    DelegatingModulesFilterHelper modulesFilterHelper = new DelegatingModulesFilterHelper(this.backendContainer, this.modules);
     this.containerConfigProperties = (ImmutableMap<String, Object>)(Map<?,?>)(ImmutableMap.builder().putAll(containerConfigProperties).put(MODULES_FILTER_HELPER_PROPERTY, modulesFilterHelper).put("devappserver.portMappingProvider", this.backendContainer).build());
-
     this.backendContainer.init(address, this.applicationConfigurationManager.getPrimaryModuleConfigurationHandle(), externalResourceDir, this.containerConfigProperties, this);
-
     this.configurationException = null;
   }
 
-  public void setServiceProperties(Map<String, String> properties)
-  {
-    if (this.serverState != ServerState.INITIALIZING) {
+  public void setServiceProperties(Map<String, String> properties) {
+    if (this.serverState != DevAppServerImpl.ServerState.INITIALIZING) {
       String msg = "Cannot set service properties after the server has been started.";
       throw new IllegalStateException(msg);
-    }
+    } else {
+      if (this.configurationException == null) {
+        this.serviceProperties = new ConcurrentHashMap(properties);
+        if (this.requestedPort != 0) {
+          DevAppServerPortPropertyHelper.setPort(this.modules.getMainModule().getModuleName(), this.requestedPort, this.serviceProperties);
+        }
 
-    if (this.configurationException == null)
-    {
-      this.serviceProperties = new ConcurrentHashMap(properties);
-      if (requestedPort != 0) {
-    	DevAppServerPortPropertyHelper.setPort(modules.getMainModule().getModuleName(),
-    	requestedPort, serviceProperties);
+        this.backendContainer.setServiceProperties(properties);
+        DevAppServerDatastorePropertyHelper.setDefaultProperties(this.serviceProperties);
       }
-      this.backendContainer.setServiceProperties(properties);
-      DevAppServerDatastorePropertyHelper.setDefaultProperties(this.serviceProperties);
+
     }
   }
 
@@ -119,76 +109,69 @@ class DevAppServerImpl
     return this.serviceProperties;
   }
 
-  public CountDownLatch start()
-    throws Exception
-  {
-    if (this.serverState != ServerState.INITIALIZING) {
+  public CountDownLatch start() throws Exception {
+    if (this.serverState != DevAppServerImpl.ServerState.INITIALIZING) {
       throw new IllegalStateException("Cannot start a server that has already been started.");
-    }
+    } else {
+      this.reportDeferredConfigurationException();
+      this.initializeLogging();
+      this.modules.configure(this.containerConfigProperties);
 
-    reportDeferredConfigurationException();
-
-    initializeLogging();
-    this.modules.configure(this.containerConfigProperties);
-    try {
-      this.modules.createConnections();
-    } catch (BindException ex) {
-      System.err.println();
-      System.err.println("************************************************");
-      System.err.println("Could not open the requested socket: " + ex.getMessage());
-      System.err.println("Try overriding --address and/or --port.");
-      System.exit(2);
-    }
-
-    ApiProxyLocalFactory factory = new ApiProxyLocalFactory();
-    this.apiProxyLocal = factory.create(this.modules.getLocalServerEnvironment());
-    setInboundServicesProperty();
-    this.apiProxyLocal.setProperties(this.serviceProperties);
-    ApiProxy.setDelegate(this.apiProxyLocal);
-    LocalModulesService localModulesService = (LocalModulesService) apiProxyLocal.getService(LocalModulesService.PACKAGE);
-
-    localModulesService.setModulesController(this.modules);
-    TimeZone currentTimeZone = null;
-    try {
-      currentTimeZone = setServerTimeZone();
-      this.backendContainer.configureAll(this.apiProxyLocal);
-      modules.startup();
-      Module mainServer = modules.getMainModule();
-
-      Map portMapping = this.backendContainer.getPortMapping();
-      AbstractContainerService.installLocalInitializationEnvironment(mainServer.getMainContainer().getAppEngineWebXmlConfig(), -1, getPort(), getPort(), null, -1, portMapping);
-
-      this.backendContainer.startupAll(this.apiProxyLocal);
-    } finally {
-      ApiProxy.clearEnvironmentForCurrentThread();
-      restoreLocalTimeZone(currentTimeZone);
-    }
-
-    // AppScale: Capture sigterm in order to finish requests before exiting.
-    ShutdownThread shutdownThread = new ShutdownThread(this) {
-      public void run() {
-        try {
-          this.server.shutdown();
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
+      try {
+        this.modules.createConnections();
+      } catch (BindException ex) {
+        System.err.println();
+        System.err.println("************************************************");
+        System.err.println("Could not open the requested socket: " + ex.getMessage());
+        System.err.println("Try overriding --address and/or --port.");
+        System.exit(2);
       }
-    };
-    Runtime.getRuntime().addShutdownHook(shutdownThread);
-    // End AppScale.
 
-    this.shutdownLatch = new CountDownLatch(1);
-    this.serverState = ServerState.RUNNING;
+      ApiProxyLocalFactory factory = new ApiProxyLocalFactory();
 
-    // add for AppScale
-    Module mainModule = this.modules.getMainModule();
-    AppEngineWebXml config = mainModule.getMainContainer().getAppEngineWebXmlConfig();
-    if (config == null)
-    {
-        throw new RuntimeException("applciation context config is null");
-    }
-    else
-    {
+      this.apiProxyLocal = factory.create(this.modules.getLocalServerEnvironment());
+      this.setInboundServicesProperty();
+      this.apiProxyLocal.setProperties(this.serviceProperties);
+      ApiProxy.setDelegate(this.apiProxyLocal);
+      LocalModulesService localModulesService = (LocalModulesService)this.apiProxyLocal.getService(LocalModulesService.PACKAGE);
+      localModulesService.setModulesController(this.modules);
+      TimeZone currentTimeZone = null;
+
+      try {
+        currentTimeZone = this.setServerTimeZone();
+        this.backendContainer.configureAll(this.apiProxyLocal);
+        this.modules.startup();
+        Module mainServer = this.modules.getMainModule();
+        Map<String, String> portMapping = this.backendContainer.getPortMapping();
+        AbstractContainerService.installLocalInitializationEnvironment(mainServer.getMainContainer().getAppEngineWebXmlConfig(), -1, this.getPort(), this.getPort(), (String)null, -1, portMapping);
+        this.backendContainer.startupAll(this.apiProxyLocal);
+      } finally {
+        ApiProxy.clearEnvironmentForCurrentThread();
+        this.restoreLocalTimeZone(currentTimeZone);
+      }
+
+      // AppScale: Capture sigterm in order to finish requests before exiting.
+      ShutdownThread shutdownThread = new ShutdownThread(this) {
+        public void run() {
+          try {
+            this.server.shutdown();
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
+        }
+      };
+      Runtime.getRuntime().addShutdownHook(shutdownThread);
+      // End AppScale.
+
+      this.shutdownLatch = new CountDownLatch(1);
+      this.serverState = DevAppServerImpl.ServerState.RUNNING;
+
+      // add for AppScale
+      Module mainModule = this.modules.getMainModule();
+      AppEngineWebXml config = mainModule.getMainContainer().getAppEngineWebXmlConfig();
+      if (config == null) {
+        throw new RuntimeException("application context config is null");
+      } else {
         System.setProperty(APPLICATION_ID_PROPERTY, config.getAppId());
         // AppScale: Set MODULE and VERSION env variables for taskqueue.
         System.setProperty("MODULE", mainModule.getModuleName());
@@ -197,189 +180,179 @@ class DevAppServerImpl
           versionId = "v1";
         System.setProperty("VERSION", versionId);
         // End AppScale
+      }
+
+      logger.info("Dev App Server is now running");
+      return this.shutdownLatch;
     }
-    logger.info("Dev App Server is now running");
-    return this.shutdownLatch;
   }
 
   public void setInboundServicesProperty() {
-    ImmutableSet.Builder setBuilder = ImmutableSet.builder();
+    ImmutableSet.Builder<String> setBuilder = ImmutableSet.builder();
 
     for (Object uncastHandle : applicationConfigurationManager.getModuleConfigurationHandles()) {
-      ApplicationConfigurationManager.ModuleConfigurationHandle moduleConfigurationHandle = (ApplicationConfigurationManager.ModuleConfigurationHandle) uncastHandle;
-      setBuilder.addAll(moduleConfigurationHandle.getModule().getAppEngineWebXml().getInboundServices());
+      ApplicationConfigurationManager.ModuleConfigurationHandle moduleConfigurationHandle = (ApplicationConfigurationManager.ModuleConfigurationHandle)uncastHandle;
+      setBuilder.addAll((Iterable)moduleConfigurationHandle.getModule().getAppEngineWebXml().getInboundServices());
     }
 
-    this.serviceProperties.put("appengine.dev.inbound-services", Joiner.on(",").useForNull("null").join(setBuilder.build()));
+    this.serviceProperties.put("appengine.dev.inbound-services", Joiner.on(",").useForNull("null").join((Iterable)setBuilder.build()));
   }
 
-  private TimeZone setServerTimeZone()
-  {
+  private TimeZone setServerTimeZone() {
     String sysTimeZone = (String)this.serviceProperties.get("appengine.user.timezone.impl");
-    if ((sysTimeZone != null) && (sysTimeZone.trim().length() > 0)) {
+    if (sysTimeZone != null && sysTimeZone.trim().length() > 0) {
       return null;
-    }
+    } else {
+      TimeZone utc = TimeZone.getTimeZone("UTC");
 
-    TimeZone utc = TimeZone.getTimeZone("UTC");
-    assert (utc.getID().equals("UTC")) : "Unable to retrieve the UTC TimeZone";
-    try
-    {
-      Field f = TimeZone.class.getDeclaredField("defaultZoneTL");
-      f.setAccessible(true);
-      ThreadLocal tl = (ThreadLocal)f.get(null);
-      Method getZone = ThreadLocal.class.getMethod("get", new Class[0]);
-      TimeZone previousZone = (TimeZone)getZone.invoke(tl, new Object[0]);
-      Method setZone = ThreadLocal.class.getMethod("set", new Class[] { Object.class });
-      setZone.invoke(tl, new Object[] { utc });
-      return previousZone;
-    }
-    catch (Exception e)
-    {
-      try
-      {
-        Method getZone = TimeZone.class.getDeclaredMethod("getDefaultInAppContext", new Class[0]);
-        getZone.setAccessible(true);
-        TimeZone previousZone = (TimeZone)getZone.invoke(null, new Object[0]);
-        Method setZone = TimeZone.class.getDeclaredMethod("setDefaultInAppContext", new Class[] { TimeZone.class });
-        setZone.setAccessible(true);
-        setZone.invoke(null, new Object[] { utc });
+      assert utc.getID().equals("UTC") : "Unable to retrieve the UTC TimeZone";
+
+      try {
+        Field f = TimeZone.class.getDeclaredField("defaultZoneTL");
+        f.setAccessible(true);
+        ThreadLocal<?> tl = (ThreadLocal)f.get((Object)null);
+        Method getZone = ThreadLocal.class.getMethod("get");
+        TimeZone previousZone = (TimeZone)getZone.invoke(tl, new Object[0]);
+        Method setZone = ThreadLocal.class.getMethod("set", Object.class);
+        setZone.invoke(tl, utc);
         return previousZone;
-      } catch (Exception ex) {
-        throw new RuntimeException("Unable to set the TimeZone to UTC", ex);
+      } catch (Exception e) {
+        try {
+          Method getZone = TimeZone.class.getDeclaredMethod("getDefaultInAppContext");
+          getZone.setAccessible(true);
+          TimeZone previousZone = (TimeZone)getZone.invoke((Object)null, new Object[0]);
+          Method setZone = TimeZone.class.getDeclaredMethod("setDefaultInAppContext", TimeZone.class);
+          setZone.setAccessible(true);
+          setZone.invoke((Object)null, utc);
+          return previousZone;
+        } catch (Exception ex) {
+          throw new RuntimeException("Unable to set the TimeZone to UTC", ex);
+        }
       }
     }
   }
 
-  private void restoreLocalTimeZone(TimeZone timeZone)
-  {
+  private void restoreLocalTimeZone(TimeZone timeZone) {
     String sysTimeZone = (String)this.serviceProperties.get("appengine.user.timezone.impl");
-    if ((sysTimeZone != null) && (sysTimeZone.trim().length() > 0)) {
-      return;
-    }
-    try
-    {
-      Field f = TimeZone.class.getDeclaredField("defaultZoneTL");
-      f.setAccessible(true);
-      ThreadLocal tl = (ThreadLocal)f.get(null);
-      Method setZone = ThreadLocal.class.getMethod("set", new Class[] { Object.class });
-      setZone.invoke(tl, new Object[] { timeZone });
-    }
-    catch (Exception e)
-    {
-      try
-      {
-        Method setZone = TimeZone.class.getDeclaredMethod("setDefaultInAppContext", new Class[] { TimeZone.class });
-        setZone.setAccessible(true);
-        setZone.invoke(null, new Object[] { timeZone });
-      } catch (Exception ex) {
-        throw new RuntimeException("Unable to restore the previous TimeZone", ex);
+    if (sysTimeZone == null || sysTimeZone.trim().length() <= 0) {
+      try {
+        Field f = TimeZone.class.getDeclaredField("defaultZoneTL");
+        f.setAccessible(true);
+        ThreadLocal<?> tl = (ThreadLocal)f.get((Object)null);
+        Method setZone = ThreadLocal.class.getMethod("set", Object.class);
+        setZone.invoke(tl, timeZone);
+      } catch (Exception e) {
+        try {
+          Method setZone = TimeZone.class.getDeclaredMethod("setDefaultInAppContext", TimeZone.class);
+          setZone.setAccessible(true);
+          setZone.invoke((Object)null, timeZone);
+        } catch (Exception ex) {
+          throw new RuntimeException("Unable to restore the previous TimeZone", ex);
+        }
       }
+
     }
   }
 
-  public CountDownLatch restart() throws Exception
-  {
-    if (this.serverState != ServerState.RUNNING) {
+  public CountDownLatch restart() throws Exception {
+    if (this.serverState != DevAppServerImpl.ServerState.RUNNING) {
       throw new IllegalStateException("Cannot restart a server that is not currently running.");
+    } else {
+      this.modules.shutdown();
+      this.backendContainer.shutdownAll();
+      this.shutdownLatch.countDown();
+      this.modules.createConnections();
+      this.backendContainer.configureAll(this.apiProxyLocal);
+      this.modules.startup();
+      this.backendContainer.startupAll(this.apiProxyLocal);
+      this.shutdownLatch = new CountDownLatch(1);
+      return this.shutdownLatch;
     }
-    this.modules.shutdown();
-    this.backendContainer.shutdownAll();
-    this.shutdownLatch.countDown();
-    this.modules.createConnections();
-    this.backendContainer.configureAll(this.apiProxyLocal);
-    this.modules.startup();
-    this.backendContainer.startupAll(this.apiProxyLocal);
-    this.shutdownLatch = new CountDownLatch(1);
-    return this.shutdownLatch;
   }
 
-  public void shutdown() throws Exception
-  {
+  public void shutdown() throws Exception {
     logger.info("Shutting down.");
-    if (this.serverState != ServerState.RUNNING) {
+    if (this.serverState != DevAppServerImpl.ServerState.RUNNING) {
       throw new IllegalStateException("Cannot shutdown a server that is not currently running.");
+    } else {
+      this.modules.shutdown();
+      this.backendContainer.shutdownAll();
+      ApiProxy.setDelegate((Delegate)null);
+      this.apiProxyLocal = null;
+      this.serverState = DevAppServerImpl.ServerState.SHUTDOWN;
+      this.shutdownLatch.countDown();
     }
-    this.modules.shutdown();
-    this.backendContainer.shutdownAll();
-    ApiProxy.setDelegate(null);
-    this.apiProxyLocal = null;
-    this.serverState = ServerState.SHUTDOWN;
-    this.shutdownLatch.countDown();
   }
 
-  public void gracefulShutdown()
-    throws IllegalStateException
-  {
-    AccessController.doPrivileged(new PrivilegedAction()
-    {
+  public void gracefulShutdown() throws IllegalStateException {
+    AccessController.doPrivileged(new PrivilegedAction<Future<Void>>() {
       public Future<Void> run() {
-        return DevAppServerImpl.this.shutdownScheduler.schedule(new Callable()
-        {
+        return DevAppServerImpl.this.shutdownScheduler.schedule(new Callable<Void>() {
           public Void call() throws Exception {
             DevAppServerImpl.this.shutdown();
             return null;
           }
-        }
-        , 1000L, TimeUnit.MILLISECONDS);
+        }, 1000L, TimeUnit.MILLISECONDS);
       }
     });
   }
 
-  public int getPort()
-  {
-    reportDeferredConfigurationException();
+  public int getPort() {
+    this.reportDeferredConfigurationException();
     return this.modules.getMainModule().getMainContainer().getPort();
   }
 
   protected void reportDeferredConfigurationException() {
-    if (this.configurationException != null)
+    if (this.configurationException != null) {
       throw new AppEngineConfigException("Invalid configuration", this.configurationException);
+    }
   }
 
-  public AppContext getAppContext()
-  {
-    reportDeferredConfigurationException();
+  public AppContext getAppContext() {
+    this.reportDeferredConfigurationException();
     return this.modules.getMainModule().getMainContainer().getAppContext();
   }
 
-  public AppContext getCurrentAppContext()
-  {
+  public AppContext getCurrentAppContext() {
     AppContext result = null;
-    ApiProxy.Environment env = ApiProxy.getCurrentEnvironment();
-
-    if ((env != null) && (env.getVersionId() != null)) {
-    	String moduleName = LocalEnvironment.getModuleName(env.getVersionId());
-    	result = modules.getModule(moduleName).getMainContainer().getAppContext();
+    Environment env = ApiProxy.getCurrentEnvironment();
+    if (env != null && env.getVersionId() != null) {
+      String moduleName = LocalEnvironment.getModuleName(env.getVersionId());
+      result = this.modules.getModule(moduleName).getMainContainer().getAppContext();
     }
+
     return result;
   }
 
-  public void setThrowOnEnvironmentVariableMismatch(boolean throwOnMismatch)
-  {
-    if (this.configurationException == null)
+  public void setThrowOnEnvironmentVariableMismatch(boolean throwOnMismatch) {
+    if (this.configurationException == null) {
       this.applicationConfigurationManager.setEnvironmentVariableMismatchReportingPolicy(throwOnMismatch ? EnvironmentVariableChecker.MismatchReportingPolicy.EXCEPTION : EnvironmentVariableChecker.MismatchReportingPolicy.LOG);
+    }
+
   }
 
-  private void initializeLogging()
-  {
-    for (Handler handler : Logger.getLogger("").getHandlers())
-      if ((handler instanceof ConsoleHandler))
+  private void initializeLogging() {
+    for (Handler handler : Logger.getLogger("").getHandlers()) {
+      if (handler instanceof ConsoleHandler) {
         handler.setLevel(Level.FINEST);
+      }
+    }
+
   }
 
-  ServerState getServerState()
-  {
+  DevAppServerImpl.ServerState getServerState() {
     return this.serverState;
   }
 
-  static enum ServerState
-  {
-    INITIALIZING, RUNNING, STOPPING, SHUTDOWN;
+  static enum ServerState {
+    INITIALIZING,
+    RUNNING,
+    STOPPING,
+    SHUTDOWN;
   }
 
   // AppScale: Needed for passing server instance to shutdown thread.
-  private class ShutdownThread extends Thread
-  {
+  private class ShutdownThread extends Thread {
     public DevAppServerImpl server;
 
     public ShutdownThread(DevAppServerImpl server) {

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
@@ -138,6 +138,10 @@ public class DevAppServerMain {
             public void apply() {
                 this.main.propertyOptions = this.getValues();
             }
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "allow_remote_shutdown", true) {
+            public void apply() {
+                System.setProperty("appengine.allowRemoteShutdown", Boolean.TRUE.toString());
+            }
         }, new DevAppServerMain.DevAppServerOption(main, (String)null, "instance_port", false) {
             @Override
             public void apply() {
@@ -348,18 +352,15 @@ public class DevAppServerMain {
                 properties.putAll(DevAppServerMain.parsePropertiesList(DevAppServerMain.this.propertyOptions));
                 server.setServiceProperties(properties);
 
-                server.start();
                 try {
-                    while (true) {
-                        Thread.sleep(3600000L);
-                    }
+                    server.start().await();
+                } catch (InterruptedException var10) {
+                    ;
                 }
-                catch (InterruptedException e) {
-                    System.out.println("Shutting down.");
-                    System.exit(0);
-                }
-            }
-            catch (Exception ex) {
+
+                System.out.println("Shutting down.");
+                System.exit(0);
+            } catch (Exception ex) {
                 ex.printStackTrace();
                 System.exit(1);
             }

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
@@ -56,7 +56,6 @@ public class DevAppServerMain {
     private String appscale_version;
     private String admin_console_version;
     private static final String SECRET_LOCATION = "/etc/appscale/secret.key";
-    private static final String PREFIX = "When generating a war directory,";
 
     private static List<Option> getBuiltInOptions(DevAppServerMain main) {
         return Arrays.asList(new Option("h", "help", true) {
@@ -274,15 +273,6 @@ public class DevAppServerMain {
 
     }
 
-    private void validateArgsForWarGeneration(List<String> args) {
-        ifNotWarGenConditionExit(this.externalResourceDir != null, "--external_resource_dir must also be specified.");
-
-        File appYamlFile = new File(this.externalResourceDir, "app.yaml");
-        ifNotWarGenConditionExit(appYamlFile.isFile(), "the external resource directory must contain a file named app.yaml.");
-
-        ifNotWarGenConditionExit(args.size() == 0, "the command line should not include a war directory argument.");
-    }
-
     @VisibleForTesting
     static Map<String, String> parsePropertiesList(List<String> properties) {
         Map<String, String> parsedProperties = new HashMap();
@@ -300,13 +290,6 @@ public class DevAppServerMain {
         }
 
         return parsedProperties;
-    }
-
-    private static void ifNotWarGenConditionExit( boolean condition, String suffix ) {
-        if (!condition) {
-            System.err.println("When generating a war directory, " + suffix);
-            System.exit(1);
-        }
     }
 
     class StartAction extends Action {

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
@@ -150,6 +150,10 @@ public class DevAppServerMain extends SharedMain {
             public void apply() {
                 System.setProperty("PIDFILE", this.getValue());
             }
+        }, new Option((String)null, "external_api_port", false) {
+            public void apply() {
+                System.setProperty("appscale.externalApiPort", this.getValue());
+            }
         }));
         return options;
     }

--- a/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/DevAppServerMain.java
@@ -1,6 +1,5 @@
 package com.google.appengine.tools.development;
 
-
 import com.google.appengine.repackaged.com.google.common.annotations.VisibleForTesting;
 import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
 import com.google.appengine.tools.info.SdkInfo;
@@ -14,7 +13,10 @@ import com.google.appengine.tools.util.Option;
 import com.google.appengine.tools.util.Parser;
 import com.google.appengine.tools.util.Parser.ParseResult;
 import java.awt.Toolkit;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
@@ -26,314 +28,253 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-
-
-public class DevAppServerMain
-{
-    public static final String  EXTERNAL_RESOURCE_DIR_ARG             = "external_resource_dir";
-    public static final String  GENERATE_WAR_ARG                      = "generate_war";
-    public static final String  GENERATED_WAR_DIR_ARG                 = "generated_war_dir";
-    private static final String DEFAULT_RDBMS_PROPERTIES_FILE         = ".local.rdbms.properties";
+public class DevAppServerMain {
+    public static final String EXTERNAL_RESOURCE_DIR_ARG = "external_resource_dir";
+    public static final String GENERATE_WAR_ARG = "generate_war";
+    public static final String GENERATED_WAR_DIR_ARG = "generated_war_dir";
+    private static final String DEFAULT_RDBMS_PROPERTIES_FILE = ".local.rdbms.properties";
     private static final String RDBMS_PROPERTIES_FILE_SYSTEM_PROPERTY = "rdbms.properties.file";
-
     private static final String SYSTEM_PROPERTY_STATIC_MODULE_PORT_NUM_PREFIX = "com.google.appengine.devappserver_module.";
-
-    private static String       originalTimeZone;
-    private final Action        ACTION                                = new StartAction();
-
-    private String              versionCheckServer                    = SdkInfo.getDefaultServer();
-
-    private String              address                               = "127.0.0.1";
-    private int                 port                                  = 8080;
-    private boolean             disableUpdateCheck;
-    private boolean             disableRestrictedCheck                = true;
+    private static String originalTimeZone;
+    private final Action ACTION = new DevAppServerMain.StartAction();
+    private String versionCheckServer = SdkInfo.getDefaultServer();
+    private String address = "127.0.0.1";
+    private int port = 8080;
+    private boolean disableUpdateCheck;
+    private String generatedDirectory = null;
+    private String defaultGcsBucketName = null;
+    private boolean disableRestrictedCheck = true;
     private boolean noJavaAgent = false;
-    private String              externalResourceDir                   = null;
-    private List<String>        propertyOptions                       = null;
-    private String              generatedDirectory                    = null;
-    private String 				defaultGcsBucketName 				  = null;
+    private String externalResourceDir = null;
+    private List<String> propertyOptions = null;
+    private final List<Option> PARSERS = buildOptions(this);
 
     // add for AppScale
-    private String              db_location;
-    private String              login_server;
-    private String              cookie;
-    private String              appscale_version;
-    private String              admin_console_version;
-    private static final String SECRET_LOCATION                       = "/etc/appscale/secret.key";
+    private String db_location;
+    private String login_server;
+    private String cookie;
+    private String appscale_version;
+    private String admin_console_version;
+    private static final String SECRET_LOCATION = "/etc/appscale/secret.key";
+    private static final String PREFIX = "When generating a war directory,";
 
-    private final List<Option>  PARSERS                               = buildOptions(this);
-    private static final String PREFIX                                = "When generating a war directory,";
-
-    private static List<Option> getBuiltInOptions( DevAppServerMain main )
-    {
-        return Arrays.asList(new Option[] { new Option("h", "help", true)
-        {
-            public void apply()
-            {
+    private static List<Option> getBuiltInOptions(DevAppServerMain main) {
+        return Arrays.asList(new Option("h", "help", true) {
+            public void apply() {
                 DevAppServerMain.printHelp(System.err);
                 System.exit(0);
             }
 
-            public List<String> getHelpLines()
-            {
+            public List<String> getHelpLines() {
                 return ImmutableList.of(" --help, -h                 Show this help message and exit.");
             }
-        }, new DevAppServerOption(main, "s", "server", false)
-        {
-            public void apply()
-            {
-                this.main.versionCheckServer = getValue();
+        }, new DevAppServerMain.DevAppServerOption(main, "s", "server", false) {
+            public void apply() {
+                this.main.versionCheckServer = this.getValue();
             }
 
-            public List<String> getHelpLines()
-            {
+            public List<String> getHelpLines() {
                 return ImmutableList.of(" --server=SERVER            The server to use to determine the latest", "  -s SERVER                   SDK version.");
             }
-        }, new DevAppServerOption(main, "a", "address", false)
-        {
-            public void apply()
-            {
-                this.main.address = getValue();
+        }, new DevAppServerMain.DevAppServerOption(main, "a", "address", false) {
+            public void apply() {
+                this.main.address = this.getValue();
                 System.setProperty("MY_IP_ADDRESS", this.main.address);
             }
 
-            public List<String> getHelpLines()
-            {
+            public List<String> getHelpLines() {
                 return ImmutableList.of(" --address=ADDRESS          The address of the interface on the local machine", "  -a ADDRESS                  to bind to (or 0.0.0.0 for all interfaces).");
             }
-        }, new DevAppServerOption(main, "p", "port", false)
-        {
-            public void apply()
-            {
-                this.main.port = Integer.valueOf(getValue()).intValue();
+        }, new DevAppServerMain.DevAppServerOption(main, "p", "port", false) {
+            public void apply() {
+                this.main.port = Integer.valueOf(this.getValue());
             }
 
-            public List<String> getHelpLines()
-            {
+            public List<String> getHelpLines() {
                 return ImmutableList.of(" --port=PORT                The port number to bind to on the local machine.", "  -p PORT");
             }
-        }, new DevAppServerOption(main, null, "sdk_root", false)
-        {
-            public void apply()
-            {
-                System.setProperty("appengine.sdk.root", getValue());
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "sdk_root", false) {
+            public void apply() {
+                System.setProperty("appengine.sdk.root", this.getValue());
             }
 
-            public List<String> getHelpLines()
-            {
+            public List<String> getHelpLines() {
                 return ImmutableList.of(" --sdk_root=DIR             Overrides where the SDK is located.");
             }
-        }, new DevAppServerOption(main, null, "disable_update_check", true)
-        {
-            public void apply()
-            {
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "disable_update_check", true) {
+            public void apply() {
                 this.main.disableUpdateCheck = true;
             }
 
-            public List<String> getHelpLines()
-            {
+            public List<String> getHelpLines() {
                 return ImmutableList.of(" --disable_update_check     Disable the check for newer SDK versions.");
             }
-        }, new DevAppServerOption(main, null, "generated_dir", false)
-        {
-            public void apply()
-            {
-                this.main.generatedDirectory = getValue();
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "generated_dir", false) {
+            public void apply() {
+                this.main.generatedDirectory = this.getValue();
             }
 
-            public List<String> getHelpLines()
-            {
+            public List<String> getHelpLines() {
                 return ImmutableList.of(" --generated_dir=DIR        Set the directory where generated files are created.");
             }
-        }, new DevAppServerOption(main, null, "default_gcs_bucket", false) {
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "default_gcs_bucket", false) {
             @Override
             public void apply() {
-                this.main.defaultGcsBucketName = getValue();
-                }
+                this.main.defaultGcsBucketName = this.getValue();
+            }
+
             @Override
             public List<String> getHelpLines() {
-                return ImmutableList.of(
-                        " --default_gcs_bucket=NAME  Set the default Google Cloud Storage bucket name.");
-                }
-        },new DevAppServerOption(main, null, "disable_restricted_check", true)
-        {
-            public void apply()
-            {
+                return ImmutableList.of(" --default_gcs_bucket=NAME  Set the default Google Cloud Storage bucket name.");
+            }
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "disable_restricted_check", true) {
+            public void apply() {
                 this.main.disableRestrictedCheck = true;
             }
-        }, new DevAppServerOption(main, null, "external_resource_dir", false)
-        {
-            public void apply()
-            {
-                this.main.externalResourceDir = getValue();
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "external_resource_dir", false) {
+            public void apply() {
+                this.main.externalResourceDir = this.getValue();
             }
-        }, new DevAppServerOption(main, null, "property", false)
-        {
-            public void apply()
-            {
-                this.main.propertyOptions = getValues();
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "property", false) {
+            public void apply() {
+                this.main.propertyOptions = this.getValues();
             }
-            /*
-             * AppScale added all of the below to end of list
-             */
-        }, new DevAppServerOption(main, null, "datastore_path", false)
-        {
-            public void apply()
-            {
-                this.main.db_location = getValue();
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "instance_port", false) {
+            @Override
+            public void apply() {
+                DevAppServerMain.processInstancePorts(this.getValues());
+            }
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "no_java_agent", true) {
+            @Override
+            public void apply() {
+                this.main.noJavaAgent = true;
+            }
+        },
+        /*
+         * AppScale added all of the below to end of list
+         */
+        new DevAppServerMain.DevAppServerOption(main, (String)null, "datastore_path", false) {
+            public void apply() {
+                this.main.db_location = this.getValue();
                 System.setProperty("DB_LOCATION", this.main.db_location);
             }
-        }, new DevAppServerOption(main, null, "login_server", false)
-        {
-            public void apply()
-            {
-                this.main.login_server = getValue();
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "login_server", false) {
+            public void apply() {
+                this.main.login_server = this.getValue();
                 System.setProperty("LOGIN_SERVER", this.main.login_server);
             }
-        }, new DevAppServerOption(main, null, "appscale_version", false)
-        {
-            public void apply()
-            {
-                this.main.appscale_version = getValue();
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "appscale_version", false) {
+            public void apply() {
+                this.main.appscale_version = this.getValue();
                 System.setProperty("APP_SCALE_VERSION", this.main.appscale_version);
             }
-        }, new DevAppServerOption(main, null, "instance_port", false) {
-            @Override
-        	public void apply() {
-        	   processInstancePorts(getValues());
-        	}
-        }, new DevAppServerOption(main, null, "no_java_agent", true) {
-        	@Override
-        	public void apply() {
-        	    this.main.noJavaAgent = true;
-        	}
-        }, new DevAppServerOption(main, null, "admin_console_version", false)
-        { // changed from admin_console_server
-            public void apply()
-            {
-                this.main.admin_console_version = getValue();
+        },
+        // changed from admin_console_server
+        new DevAppServerMain.DevAppServerOption(main,(String)null, "admin_console_version", false) {
+            public void apply() {
+                this.main.admin_console_version = this.getValue();
                 System.setProperty("ADMIN_CONSOLE_VERSION", this.main.admin_console_version);
             }
-        }, new DevAppServerOption(main, null, "APP_NAME", false)
-        {
-            public void apply()
-            {
-                System.setProperty("APP_NAME", getValue());
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "APP_NAME", false) {
+            public void apply() {
+                System.setProperty("APP_NAME", this.getValue());
             }
-        }, new DevAppServerOption(main, null, "NGINX_ADDRESS", false)
-        {
-            public void apply()
-            {
-                System.setProperty("NGINX_ADDR", getValue());
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "NGINX_ADDRESS", false) {
+            public void apply() {
+                System.setProperty("NGINX_ADDR", this.getValue());
             }
-        }, new DevAppServerOption(main, null, "TQ_PROXY", false)
-        {
-            public void apply()
-            {
-                System.setProperty("TQ_PROXY", getValue());
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "TQ_PROXY", false) {
+            public void apply() {
+                System.setProperty("TQ_PROXY", this.getValue());
             }
-        }, new DevAppServerOption(main, null, "pidfile", false)
-        {
-            public void apply()
-            {
-                System.setProperty("PIDFILE", getValue());
+        }, new DevAppServerMain.DevAppServerOption(main, (String)null, "pidfile", false) {
+            public void apply() {
+                System.setProperty("PIDFILE", this.getValue());
             }
-        }});
+        });
     }
 
     private static void processInstancePorts(List<String> optionValues) {
-      for (String optionValue : optionValues) {
-        String[] keyAndValue = optionValue.split("=", 2);
-        if (keyAndValue.length != 2) {
-            reportBadInstancePortValue(optionValue);
+        for (String optionValue : optionValues) {
+            String[] keyAndValue = optionValue.split("=", 2);
+            if (keyAndValue.length != 2) {
+                reportBadInstancePortValue(optionValue);
             }
 
-        try {
-            Integer.parseInt(keyAndValue[1]);
+            try {
+                Integer.parseInt(keyAndValue[1]);
             } catch (NumberFormatException nfe) {
                 reportBadInstancePortValue(optionValue);
-                }
+            }
 
-        System.setProperty(
+            System.setProperty(
                 SYSTEM_PROPERTY_STATIC_MODULE_PORT_NUM_PREFIX + keyAndValue[0].trim() + ".port",
                 keyAndValue[1].trim());
         }
+
     }
 
     private static void reportBadInstancePortValue(String optionValue) {
         throw new IllegalArgumentException("Invalid instance_port value " + optionValue);
     }
 
-    private static List<Option> buildOptions( DevAppServerMain main )
-    {
-        List options = getBuiltInOptions(main);
-        for (SDKRuntimePlugin runtimePlugin : SDKPluginManager.findAllRuntimePlugins())
-        {
+    private static List<Option> buildOptions(DevAppServerMain main) {
+        List<Option> options = getBuiltInOptions(main);
+        for (SDKRuntimePlugin runtimePlugin : SDKPluginManager.findAllRuntimePlugins()) {
             options = runtimePlugin.customizeDevAppServerOptions(options);
         }
+
         return options;
     }
 
-    public static void main( String[] args ) throws Exception
-    {
+    public static void main(String[] args) throws Exception {
         recordTimeZone();
         Logging.initializeLogging();
-        if (System.getProperty("os.name").equalsIgnoreCase("Mac OS X"))
-        {
+        if (System.getProperty("os.name").equalsIgnoreCase("Mac OS X")) {
             Toolkit.getDefaultToolkit();
         }
+
         new DevAppServerMain(args);
     }
 
-    private static void recordTimeZone()
-    {
+    private static void recordTimeZone() {
         originalTimeZone = System.getProperty("user.timezone");
     }
 
-    public DevAppServerMain( String[] args ) throws Exception
-    {
+    public DevAppServerMain(String[] args) throws Exception {
         Parser parser = new Parser();
-        Parser.ParseResult result = parser.parseArgs(this.ACTION, this.PARSERS, args);
+        ParseResult result = parser.parseArgs(this.ACTION, this.PARSERS, args);
         result.applyArgs();
     }
 
-    public static void printHelp( PrintStream out )
-    {
+    public static void printHelp(PrintStream out) {
         out.println("Usage: <dev-appserver> [options] <app directory>");
         out.println("");
         out.println("Options:");
-        for (Option option : buildOptions(null))
-        {
-            for (String helpString : option.getHelpLines())
-            {
+        for (Option option : buildOptions(null)) {
+            for (String helpString : option.getHelpLines()) {
                 out.println(helpString);
             }
         }
+
         out.println(" --jvm_flag=FLAG            Pass FLAG as a JVM argument. May be repeated to");
         out.println("                              supply multiple flags.");
     }
 
-    public static void validateWarPath( File war )
-    {
-        if (!war.exists())
-        {
+    public static void validateWarPath(File war) {
+        if (!war.exists()) {
             System.out.println("Unable to find the webapp directory " + war);
             printHelp(System.err);
             System.exit(1);
-        }
-        else if (!war.isDirectory())
-        {
+        } else if (!war.isDirectory()) {
             System.out.println("dev_appserver only accepts webapp directories, not war files.");
             printHelp(System.err);
             System.exit(1);
         }
+
     }
 
-    private void validateArgsForWarGeneration( List<String> args )
-    {
+    private void validateArgsForWarGeneration(List<String> args) {
         ifNotWarGenConditionExit(this.externalResourceDir != null, "--external_resource_dir must also be specified.");
 
         File appYamlFile = new File(this.externalResourceDir, "app.yaml");
@@ -343,72 +284,63 @@ public class DevAppServerMain
     }
 
     @VisibleForTesting
-    static Map<String, String> parsePropertiesList( List<String> properties )
-    {
-        Map parsedProperties = new HashMap();
-        if (properties != null)
-        {
-            for (String property : properties)
-            {
+    static Map<String, String> parsePropertiesList(List<String> properties) {
+        Map<String, String> parsedProperties = new HashMap();
+        if (properties != null) {
+            for (String property : properties) {
                 String[] propertyKeyValue = property.split("=", 2);
-                if (propertyKeyValue.length == 2)
+                if (propertyKeyValue.length == 2) {
                     parsedProperties.put(propertyKeyValue[0], propertyKeyValue[1]);
-                else if (propertyKeyValue[0].startsWith("no"))
+                } else if (propertyKeyValue[0].startsWith("no")) {
                     parsedProperties.put(propertyKeyValue[0].substring(2), "false");
-                else
-                {
+                } else {
                     parsedProperties.put(propertyKeyValue[0], "true");
                 }
             }
         }
+
         return parsedProperties;
     }
 
-    private static void ifNotWarGenConditionExit( boolean condition, String suffix )
-    {
-        if (!condition)
-        {
+    private static void ifNotWarGenConditionExit( boolean condition, String suffix ) {
+        if (!condition) {
             System.err.println("When generating a war directory, " + suffix);
             System.exit(1);
         }
     }
 
-    class StartAction extends Action
-    {
-        StartAction()
-        {
+    class StartAction extends Action {
+        StartAction() {
             super();
         }
 
-        public void apply()
-        {
-            List args = getArgs();
-            try
-            {
-                File externalResourceDir = getExternalResourceDir();
-                if (args.size() != 1)
-                {
+        public void apply() {
+            List args = this.getArgs();
+
+            try {
+                File externalResourceDir = this.getExternalResourceDir();
+                if (args.size() != 1) {
                     DevAppServerMain.printHelp(System.err);
                     System.exit(1);
                 }
-                File appDir = new File((String)args.get(0)).getCanonicalFile();
-                DevAppServerMain.validateWarPath(appDir);
 
+                File appDir = (new File((String)args.get(0))).getCanonicalFile();
+                DevAppServerMain.validateWarPath(appDir);
                 SDKRuntimePlugin runtimePlugin = SDKPluginManager.findRuntimePlugin(appDir);
-                if (runtimePlugin != null)
-                {
-                    SDKRuntimePlugin.ApplicationDirectories appDirs = runtimePlugin.generateApplicationDirectories(appDir);
+                if (runtimePlugin != null) {
+                    ApplicationDirectories appDirs = runtimePlugin.generateApplicationDirectories(appDir);
                     appDir = appDirs.getWarDir();
                     externalResourceDir = appDirs.getExternalResourceDir();
                 }
 
                 UpdateCheck updateCheck = new UpdateCheck(DevAppServerMain.this.versionCheckServer, appDir, true);
-                if ((updateCheck.allowedToCheckForUpdates()) && (!DevAppServerMain.this.disableUpdateCheck))
-                {
+                if (updateCheck.allowedToCheckForUpdates() && !DevAppServerMain.this.disableUpdateCheck) {
                     updateCheck.maybePrintNagScreen(System.err);
                 }
+
                 updateCheck.checkJavaVersion(System.err);
 
+                // AppScale: Write a pidfile for Monit.
                 String pidfile = System.getProperty("PIDFILE");
                 if (pidfile != null) {
                     String pidString = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
@@ -416,183 +348,160 @@ public class DevAppServerMain
                     Files.write(file, pidString.getBytes());
                 }
 
-                DevAppServer server = new DevAppServerFactory().createDevAppServer(appDir, externalResourceDir, DevAppServerMain.this.address, DevAppServerMain.this.port, noJavaAgent);
-
+                DevAppServer server = (new DevAppServerFactory()).createDevAppServer(appDir, externalResourceDir, DevAppServerMain.this.address, DevAppServerMain.this.port, DevAppServerMain.this.noJavaAgent);
                 Map properties = System.getProperties();
+                this.setTimeZone(properties);
+                this.setGeneratedDirectory(properties);
+                this.setDefaultGcsBucketName(properties);
 
-                Map stringProperties = properties;
-                setTimeZone(stringProperties);
-                setGeneratedDirectory(stringProperties);
-                setDefaultGcsBucketName(stringProperties);
+                // AppScale: Fetch and cache deployment secret.
                 setSecret();
-                if (DevAppServerMain.this.disableRestrictedCheck)
-                {
-                    stringProperties.put("appengine.disableRestrictedCheck", "");
+
+                if (DevAppServerMain.this.disableRestrictedCheck) {
+                    properties.put("appengine.disableRestrictedCheck", "");
                 }
-                setRdbmsPropertiesFile(stringProperties, appDir, externalResourceDir);
-                stringProperties.putAll(DevAppServerMain.parsePropertiesList(DevAppServerMain.this.propertyOptions));
-                server.setServiceProperties(stringProperties);
+
+                this.setRdbmsPropertiesFile(properties, appDir, externalResourceDir);
+                properties.putAll(DevAppServerMain.parsePropertiesList(DevAppServerMain.this.propertyOptions));
+                server.setServiceProperties(properties);
+
                 server.start();
-                try
-                {
-                    while (true)
-                    {
+                try {
+                    while (true) {
                         Thread.sleep(3600000L);
                     }
                 }
-                catch (InterruptedException e)
-                {
+                catch (InterruptedException e) {
                     System.out.println("Shutting down.");
                     System.exit(0);
                 }
             }
-            catch (Exception ex)
-            {
+            catch (Exception ex) {
                 ex.printStackTrace();
                 System.exit(1);
             }
+
         }
 
         // Set the AppScale secret.
-        private void setSecret()
-        {
+        private void setSecret() {
             BufferedReader bufferReader = null;
-            try
-            {
+            try {
                 bufferReader = new BufferedReader(new FileReader(SECRET_LOCATION));
                 String value = bufferReader.readLine();
                 System.setProperty("COOKIE_SECRET", value);
             }
-            catch(IOException e)
-            {
+            catch(IOException e) {
                System.out.println("IOException getting port from secret key file.");
                e.printStackTrace(); 
             }        
-            finally
-            {
-               try
-               {
+            finally {
+               try {
                    if (bufferReader != null) bufferReader.close();
                } 
-               catch (IOException ex)
-               {
+               catch (IOException ex) {
                    ex.printStackTrace();
                }
             }
         }
 
-        private void setTimeZone( Map<String, String> serviceProperties )
-        {
+        private void setTimeZone(Map<String, String> serviceProperties) {
             String timeZone = (String)serviceProperties.get("appengine.user.timezone");
-            if (timeZone != null)
+            if (timeZone != null) {
                 TimeZone.setDefault(TimeZone.getTimeZone(timeZone));
-            else
-            {
+            } else {
                 timeZone = DevAppServerMain.originalTimeZone;
             }
+
             serviceProperties.put("appengine.user.timezone.impl", timeZone);
         }
 
-        private void setGeneratedDirectory( Map<String, String> stringProperties )
-        {
-            if (DevAppServerMain.this.generatedDirectory != null)
-            {
+        private void setGeneratedDirectory(Map<String, String> stringProperties) {
+            if (DevAppServerMain.this.generatedDirectory != null) {
                 File dir = new File(DevAppServerMain.this.generatedDirectory);
                 String error = null;
-                if (dir.exists())
-                {
-                    if (!dir.isDirectory())
+                if (dir.exists()) {
+                    if (!dir.isDirectory()) {
                         error = DevAppServerMain.this.generatedDirectory + " is not a directory.";
-                    else if (!dir.canWrite()) error = DevAppServerMain.this.generatedDirectory + " is not writable.";
-                }
-                else if (!dir.mkdirs())
-                {
+                    } else if (!dir.canWrite()) {
+                        error = DevAppServerMain.this.generatedDirectory + " is not writable.";
+                    }
+                } else if (!dir.mkdirs()) {
                     error = "Could not make " + DevAppServerMain.this.generatedDirectory;
                 }
-                if (error != null)
-                {
+
+                if (error != null) {
                     System.err.println(error);
                     System.exit(1);
                 }
+
                 stringProperties.put("appengine.generated.dir", DevAppServerMain.this.generatedDirectory);
             }
+
         }
-        
+
         private void setDefaultGcsBucketName(Map<String, String> stringProperties) {
-          if (defaultGcsBucketName != null) {
-              stringProperties.put("appengine.default.gcs.bucket.name", defaultGcsBucketName);
-          }
+            if (DevAppServerMain.this.defaultGcsBucketName != null) {
+                stringProperties.put("appengine.default.gcs.bucket.name", DevAppServerMain.this.defaultGcsBucketName);
+            }
+
         }
 
-        private void setRdbmsPropertiesFile( Map<String, String> stringProperties, File appDir, File externalResourceDir )
-        {
-            if (stringProperties.get("rdbms.properties.file") != null)
-            {
-                return;
-            }
-            File file = findRdbmsPropertiesFile(externalResourceDir);
-            if (file == null)
-            {
-                file = findRdbmsPropertiesFile(appDir);
-            }
-            if (file != null)
-            {
-                String path = file.getPath();
-                System.out.println("Reading local rdbms properties from " + path);
-                stringProperties.put("rdbms.properties.file", path);
+        private void setRdbmsPropertiesFile(Map<String, String> stringProperties, File appDir, File externalResourceDir) {
+            if (stringProperties.get("rdbms.properties.file") == null) {
+                File file = this.findRdbmsPropertiesFile(externalResourceDir);
+                if (file == null) {
+                    file = this.findRdbmsPropertiesFile(appDir);
+                }
+
+                if (file != null) {
+                    String path = file.getPath();
+                    System.out.println("Reading local rdbms properties from " + path);
+                    stringProperties.put("rdbms.properties.file", path);
+                }
+
             }
         }
 
-        private File findRdbmsPropertiesFile( File dir )
-        {
+        private File findRdbmsPropertiesFile(File dir) {
             File candidate = new File(dir, ".local.rdbms.properties");
-            if ((candidate.isFile()) && (candidate.canRead()))
-            {
-                return candidate;
-            }
-            return null;
+            return candidate.isFile() && candidate.canRead() ? candidate : null;
         }
 
-        private File getExternalResourceDir()
-        {
-            if (DevAppServerMain.this.externalResourceDir == null)
-            {
+        private File getExternalResourceDir() {
+            if (DevAppServerMain.this.externalResourceDir == null) {
                 return null;
-            }
-            DevAppServerMain.this.externalResourceDir = DevAppServerMain.this.externalResourceDir.trim();
-            String error = null;
-            File dir = null;
-            if (DevAppServerMain.this.externalResourceDir.isEmpty())
-            {
-                error = "The empty string was specified for external_resource_dir";
-            }
-            else
-            {
-                dir = new File(DevAppServerMain.this.externalResourceDir);
-                if (dir.exists())
-                {
-                    if (!dir.isDirectory()) error = DevAppServerMain.this.externalResourceDir + " is not a directory.";
+            } else {
+                DevAppServerMain.this.externalResourceDir = DevAppServerMain.this.externalResourceDir.trim();
+                String error = null;
+                File dir = null;
+                if (DevAppServerMain.this.externalResourceDir.isEmpty()) {
+                    error = "The empty string was specified for external_resource_dir";
+                } else {
+                    dir = new File(DevAppServerMain.this.externalResourceDir);
+                    if (dir.exists()) {
+                        if (!dir.isDirectory()) {
+                            error = DevAppServerMain.this.externalResourceDir + " is not a directory.";
+                        }
+                    } else {
+                        error = "No such directory: " + DevAppServerMain.this.externalResourceDir;
+                    }
                 }
-                else
-                {
-                    error = "No such directory: " + DevAppServerMain.this.externalResourceDir;
+
+                if (error != null) {
+                    System.err.println(error);
+                    System.exit(1);
                 }
+
+                return dir;
             }
-            if (error != null)
-            {
-                System.err.println(error);
-                System.exit(1);
-            }
-            return dir;
         }
     }
 
-    private static abstract class DevAppServerOption extends Option
-    {
+    private abstract static class DevAppServerOption extends Option {
         protected DevAppServerMain main;
 
-        DevAppServerOption( DevAppServerMain main, String shortName, String longName, boolean isFlag )
-        {
+        DevAppServerOption(DevAppServerMain main, String shortName, String longName, boolean isFlag) {
             super(shortName, longName, isFlag);
             this.main = main;
         }

--- a/AppServer_Java/src/com/google/appengine/tools/development/SharedMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/SharedMain.java
@@ -1,0 +1,184 @@
+package com.google.appengine.tools.development;
+
+import com.google.appengine.repackaged.com.google.common.annotations.VisibleForTesting;
+import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
+import com.google.appengine.tools.util.Logging;
+import com.google.appengine.tools.util.Option;
+import java.awt.Toolkit;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TimeZone;
+
+public abstract class SharedMain {
+    private static String originalTimeZone;
+    private boolean disableRestrictedCheck = false;
+    private boolean noJavaAgent = false;
+    private String externalResourceDir = null;
+    private List<String> propertyOptions = null;
+
+    protected List<Option> getSharedOptions() {
+        return Arrays.asList(new Option("h", "help", true) {
+            public void apply() {
+                SharedMain.this.printHelp(System.err);
+                System.exit(0);
+            }
+
+            public List<String> getHelpLines() {
+                return ImmutableList.of(" --help, -h                 Show this help message and exit.");
+            }
+        }, new Option((String)null, "sdk_root", false) {
+            public void apply() {
+                System.setProperty("appengine.sdk.root", this.getValue());
+            }
+
+            public List<String> getHelpLines() {
+                return ImmutableList.of(" --sdk_root=DIR             Overrides where the SDK is located.");
+            }
+        }, new Option((String)null, "disable_restricted_check", true) {
+            public void apply() {
+                SharedMain.this.disableRestrictedCheck = true;
+            }
+        }, new Option((String)null, "external_resource_dir", false) {
+            public void apply() {
+                SharedMain.this.externalResourceDir = this.getValue();
+            }
+        }, new Option((String)null, "property", false) {
+            public void apply() {
+                SharedMain.this.propertyOptions = this.getValues();
+            }
+        }, new Option((String)null, "allow_remote_shutdown", true) {
+            public void apply() {
+                System.setProperty("appengine.allowRemoteShutdown", "true");
+            }
+        }, new Option((String)null, "no_java_agent", true) {
+            public void apply() {
+                SharedMain.this.noJavaAgent = true;
+            }
+        });
+    }
+
+    protected static void sharedInit() {
+        recordTimeZone();
+        Logging.initializeLogging();
+        if (System.getProperty("os.name").equalsIgnoreCase("Mac OS X")) {
+            Toolkit.getDefaultToolkit();
+        }
+
+    }
+
+    private static void recordTimeZone() {
+        originalTimeZone = System.getProperty("user.timezone");
+    }
+
+    protected abstract void printHelp(PrintStream var1);
+
+    protected void postServerActions(Map<String, String> stringProperties) {
+        this.setTimeZone(stringProperties);
+        if (this.disableRestrictedCheck) {
+            stringProperties.put("appengine.disableRestrictedCheck", "");
+        }
+
+    }
+
+    protected void addPropertyOptionToProperties(Map<String, String> properties) {
+        properties.putAll(parsePropertiesList(this.propertyOptions));
+    }
+
+    protected Map<String, String> getSystemProperties() {
+        Properties properties = System.getProperties();
+        Map<String, String> stringProperties = new HashMap();
+        Iterator i$ = properties.stringPropertyNames().iterator();
+
+        while(i$.hasNext()) {
+            String property = (String)i$.next();
+            stringProperties.put(property, properties.getProperty(property));
+        }
+
+        return stringProperties;
+    }
+
+    private void setTimeZone(Map<String, String> serviceProperties) {
+        String timeZone = (String)serviceProperties.get("appengine.user.timezone");
+        if (timeZone != null) {
+            TimeZone.setDefault(TimeZone.getTimeZone(timeZone));
+        } else {
+            timeZone = originalTimeZone;
+        }
+
+        serviceProperties.put("appengine.user.timezone.impl", timeZone);
+    }
+
+    protected File getExternalResourceDir() {
+        if (this.externalResourceDir == null) {
+            return null;
+        } else {
+            this.externalResourceDir = this.externalResourceDir.trim();
+            String error = null;
+            File dir = null;
+            if (this.externalResourceDir.isEmpty()) {
+                error = "The empty string was specified for external_resource_dir";
+            } else {
+                dir = new File(this.externalResourceDir);
+                if (dir.exists()) {
+                    if (!dir.isDirectory()) {
+                        error = this.externalResourceDir + " is not a directory.";
+                    }
+                } else {
+                    error = "No such directory: " + this.externalResourceDir;
+                }
+            }
+
+            if (error != null) {
+                System.err.println(error);
+                System.exit(1);
+            }
+
+            return dir;
+        }
+    }
+
+    public void validateWarPath(File war) {
+        if (!war.exists()) {
+            System.out.println("Unable to find the webapp directory " + war);
+            this.printHelp(System.err);
+            System.exit(1);
+        } else if (!war.isDirectory()) {
+            System.out.println("dev_appserver only accepts webapp directories, not war files.");
+            this.printHelp(System.err);
+            System.exit(1);
+        }
+
+    }
+
+    @VisibleForTesting
+    static Map<String, String> parsePropertiesList(List<String> properties) {
+        Map<String, String> parsedProperties = new HashMap();
+        if (properties != null) {
+            Iterator i$ = properties.iterator();
+
+            while(i$.hasNext()) {
+                String property = (String)i$.next();
+                String[] propertyKeyValue = property.split("=", 2);
+                if (propertyKeyValue.length == 2) {
+                    parsedProperties.put(propertyKeyValue[0], propertyKeyValue[1]);
+                } else if (propertyKeyValue[0].startsWith("no")) {
+                    parsedProperties.put(propertyKeyValue[0].substring(2), "false");
+                } else {
+                    parsedProperties.put(propertyKeyValue[0], "true");
+                }
+            }
+        }
+
+        return parsedProperties;
+    }
+
+    protected boolean getNoJavaAgent() {
+        return this.noJavaAgent;
+    }
+}

--- a/AppServer_Java/src/com/google/appengine/tools/development/SharedMain.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/SharedMain.java
@@ -1,6 +1,7 @@
 package com.google.appengine.tools.development;
 
 import com.google.appengine.repackaged.com.google.common.annotations.VisibleForTesting;
+import com.google.appengine.repackaged.com.google.common.base.Joiner;
 import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
 import com.google.appengine.tools.util.Logging;
 import com.google.appengine.tools.util.Option;
@@ -19,6 +20,8 @@ public abstract class SharedMain {
     private static String originalTimeZone;
     private boolean disableRestrictedCheck = false;
     private boolean noJavaAgent = false;
+    private String pathToPythonApiServer = null;
+    private List<String> apisUsingPythonStubs = null;
     private String externalResourceDir = null;
     private List<String> propertyOptions = null;
 
@@ -55,6 +58,19 @@ public abstract class SharedMain {
         }, new Option((String)null, "allow_remote_shutdown", true) {
             public void apply() {
                 System.setProperty("appengine.allowRemoteShutdown", "true");
+            }
+        }, new Option((String)null, "api_using_python_stub", false) {
+            public void apply() {
+                SharedMain.this.apisUsingPythonStubs = this.getValues();
+                if (!SharedMain.this.apisUsingPythonStubs.isEmpty()) {
+                    System.setProperty("appengine.apisUsingPythonStubs", Joiner.on(',').join((Iterable)SharedMain.this.apisUsingPythonStubs));
+                }
+
+            }
+        }, new Option((String)null, "path_to_python_api_server", false) {
+            public void apply() {
+                SharedMain.this.pathToPythonApiServer = this.getValue();
+                System.setProperty("appengine.pathToPythonApiServer", SharedMain.this.pathToPythonApiServer);
             }
         }, new Option((String)null, "no_java_agent", true) {
             public void apply() {


### PR DESCRIPTION
- Brings ApiProxyLocalImpl, DevAppServerMain, and DevAppServerImpl up to date with the 1.8.4 SDK
- Adds changes from the 1.9.54 SDK which allow starting a Python server for making API calls
- Adds a flag to use an external API server instead of starting one (eg. `--external_api_port=19998 --api_using_python_stub=app_identity_service`)

In my opinion, it's easiest to review this PR by commit because there are a lot of whitespace changes introduced by commits whose only purpose is to reduce the diffs against the SDK.