### PR TITLE
Rsync appcontroller client

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3571,6 +3571,21 @@ class Djinn
     @options['restore_from_tar'] || @options['restore_from_ebs']
   end
 
+  def build_appcontroller_client
+    Djinn.log_info('Building uncommitted appcontroller client changes')
+    unless system('pip install --upgrade --no-deps ' \
+                  "#{APPSCALE_HOME}/AppControllerClient > /dev/null 2>&1")
+      Djinn.log_error('Unable to build appcontroller client (install failed).')
+      return
+    end
+    unless system('pip install ' \
+                  "#{APPSCALE_HOME}/AppControllerClient > /dev/null 2>&1")
+      Djinn.log_error('Unable to build appcontroller client (install dependencies failed).')
+      return
+    end
+    Djinn.log_info('Finished building appcontroller client.')
+  end
+
   def build_taskqueue
     Djinn.log_info('Building uncommitted taskqueue changes')
     extras = TaskQueue::OPTIONAL_FEATURES.join(',')
@@ -3672,6 +3687,7 @@ class Djinn
   # Run a build on modified directories so that changes will take effect.
   def build_uncommitted_changes
     status = `git -C #{APPSCALE_HOME} status`
+    build_appcontroller_client if status.include?('AppControllerClient')
     build_admin_server if status.include?('AdminServer')
     build_taskqueue if status.include?('AppTaskQueue')
     build_datastore if status.include?('AppDB')

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3811,7 +3811,8 @@ class Djinn
 
     ["#{APPSCALE_HOME}/AdminServer", "#{APPSCALE_HOME}/AppDB",
      "#{APPSCALE_HOME}/AppManager", "#{APPSCALE_HOME}/AppTaskQueue",
-     "#{APPSCALE_HOME}/AppController", "#{APPSCALE_HOME}/common",
+     "#{APPSCALE_HOME}/AppController", "#{APPSCALE_HOME}/AppControllerClient",
+     "#{APPSCALE_HOME}/common", "#{APPSCALE_HOME}/Hermes",
      "#{APPSCALE_HOME}/InfrastructureManager", "#{APPSCALE_HOME}/AppDashboard",
      "#{APPSCALE_HOME}/scripts", "#{APPSCALE_HOME}/AppServer",
      "#{APPSCALE_HOME}/AppServer_Java", "#{APPSCALE_HOME}/XMPPReceiver",


### PR DESCRIPTION
RSync uncommitted changes in AppControllerClient and rebuild it when djinn is started.
https://ocd.appscale.com:8080/job/Daily%20Build/4481/

In this branch which is based on master I just cherry-picked 2 commits from https://github.com/jeanleonov/appscale/tree/rsync-fix .

