### PR TITLE
Account properly for pending AppServer.

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4577,6 +4577,12 @@ HOSTS
       return
     end
 
+    # Temporary arrays for AppServers housekeeping.
+    to_start = []
+    no_appservers = []
+    running_instances = []
+    to_end = []
+
     APPS_LOCK.synchronize {
       # Registered instances are no longer pending.
       @app_info_map.each { |version_key, info|
@@ -4600,10 +4606,6 @@ HOSTS
         @pending_appservers.delete(instance_key)
       }
 
-      to_start = []
-      no_appservers = []
-      running_instances = []
-      to_end = []
       @app_info_map.each { |version_key, info|
         # The remainder of this loop is for Compute nodes only, so we
         # need to do work only if we have AppServers.

--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -226,7 +226,7 @@ BOO
       }
     end
 
-    Djinn.log_debug("Found these appservers processes running: #{appservers}.")
+    Djinn.log_debug("Found these AppServers processes running: #{appservers}.")
     appservers
   end
 


### PR DESCRIPTION
In check_running_appservers we were removing too many appservers from
the @pending_appservers since we were not accounting for the IP address
of the host but only the port.
 
This fixes the below issue (as seen on a compute node) when AppServers were terminated prematurely before having a chance to get registered properly:
D, [2018-01-05T19:21:33.584626 #24343] DEBUG -- : Found these appservers processes running: ["test_default_v1_1513649612399:20007", "test_default_v1_1513649612399:20003", "test_default_v1_1513649612399:20002", "test_default_v1_1513649612399:20001", "test_default_v1_1513649612399:20000"].
D, [2018-01-05T19:21:33.584702 #24343] DEBUG -- : AppServers to start: ["test_default_v1", "test_default_v1", "test_default_v1"].
D, [2018-01-05T19:21:33.584722 #24343] DEBUG -- : AppServers to terminate: ["test_default_v1:20003", "test_default_v1:20002", "test_default_v1:20000"].
