### PR TITLE
Register running instances with ZooKeeper

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/constants.py
+++ b/AdminServer/appscale/admin/instance_manager/constants.py
@@ -28,6 +28,10 @@ DASHBOARD_LOG_SIZE = 10 * 1024 * 1024
 # The default amount of memory in MB to allow an instance.
 DEFAULT_MAX_APPSERVER_MEMORY = 400
 
+# The Java class that runs AppServer instances.
+JAVA_APPSERVER_CLASS = ('com.google.appengine.tools.development.'
+                        'DevAppServerMain')
+
 # Default logrotate configuration directory.
 LOGROTATE_CONFIG_DIR = os.path.join('/', 'etc', 'logrotate.d')
 
@@ -51,6 +55,10 @@ MODIFIED_JARS = [
 
 # A prefix added to instance entries to distinguish them from services.
 MONIT_INSTANCE_PREFIX = 'app___'
+
+# The script used for starting Python AppServer instances.
+PYTHON_APPSERVER = os.path.join(APPSCALE_HOME, 'AppServer',
+                                'dev_appserver.py')
 
 # A mapping of instance classes to memory limits in MB.
 INSTANCE_CLASSES = {'F1': 128,

--- a/AppController/djinnServer.rb
+++ b/AppController/djinnServer.rb
@@ -81,8 +81,6 @@ class DjinnServer < SOAP::RPC::HTTPServer
     add_method(@djinn, "backup_appscale", "backup_in_info", "secret")
     add_method(@djinn, "start_roles_on_nodes", "ips_hash", "secret")
     add_method(@djinn, "gather_logs", "secret")
-    add_method(@djinn, "add_routing_for_appserver", "version_key", "ip",
-               "port", "secret")
     add_method(@djinn, "add_routing_for_blob_server", "secret")
     add_method(@djinn, "run_groomer", "secret")
     add_method(@djinn, "get_property", "property_regex", "secret")

--- a/AppController/lib/app_controller_client.rb
+++ b/AppController/lib/app_controller_client.rb
@@ -72,8 +72,6 @@ class AppControllerClient
     @conn.add_method('get_node_stats_json', 'secret')
     @conn.add_method('get_instance_info', 'secret')
     @conn.add_method('get_request_info', 'version_key', 'secret')
-    @conn.add_method('add_routing_for_appserver', 'version_key', 'ip', 'port',
-                     'secret')
     @conn.add_method('update_cron', 'project_id', 'secret')
   end
 
@@ -216,13 +214,6 @@ class AppControllerClient
   def get_node_stats_json
     make_call(10, RETRY_ON_FAIL, 'get_node_stats_json') {
       @conn.get_node_stats_json(@secret)
-    }
-  end
-
-  # Adds routing for appserver.
-  def add_routing_for_appserver(version_key, ip, port)
-    make_call(10, RETRY_ON_FAIL, 'add_routing_for_appserver') {
-      @conn.add_routing_for_appserver(version_key, ip, port, @secret)
     }
   end
 

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -61,8 +61,6 @@ class TestDjinn < Test::Unit::TestCase
     assert_equal(BAD_SECRET_MSG, djinn.job_start(@secret))
     assert_equal(BAD_SECRET_MSG, djinn.get_online_users_list(@secret))
     assert_equal(BAD_SECRET_MSG, djinn.start_roles_on_nodes({}, @secret))
-    assert_equal(BAD_SECRET_MSG, djinn.add_routing_for_appserver(@app, 'baz',
-      'baz', @secret))
     assert_equal(BAD_SECRET_MSG, djinn.run_groomer(@secret))
     assert_equal(BAD_SECRET_MSG, djinn.get_property('baz', @secret))
     assert_equal(BAD_SECRET_MSG, djinn.set_property('baz', 'qux', @secret))

--- a/AppControllerClient/appscale/appcontroller_client/__init__.py
+++ b/AppControllerClient/appscale/appcontroller_client/__init__.py
@@ -314,19 +314,6 @@ class AppControllerClient():
     return self.call(self.MAX_RETRIES, self.server.run_groomer, self.secret)
 
 
-  def add_routing_for_appserver(self, version_key, appserver_ip, port):
-    """ Tells the AppController to begin routing traffic to an AppServer.
-
-    Args:
-      version_key: A string that contains the version key.
-      appserver_ip: A string that contains the IP address of the instance
-        running the AppServer.
-      port: A string that contains the port that the AppServer listens on.
-    """
-    return self.call(self.MAX_RETRIES, self.server.add_routing_for_appserver,
-                     version_key, appserver_ip, port, self.secret)
-
-
   def add_routing_for_blob_server(self):
     """ Tells the AppController to begin routing traffic to the
         BlobServer(s).

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -4,11 +4,13 @@ import logging
 import math
 import os
 import re
+import signal
 import threading
 import time
 import urllib
 import urllib2
 
+import psutil
 import tornado.web
 from concurrent.futures import ThreadPoolExecutor
 from kazoo.client import KazooClient
@@ -26,10 +28,12 @@ from appscale.admin.instance_manager.constants import (
   DASHBOARD_PROJECT_ID,
   DEFAULT_MAX_APPSERVER_MEMORY,
   INSTANCE_CLASSES,
+  JAVA_APPSERVER_CLASS,
   LOGROTATE_CONFIG_DIR,
   MAX_BACKGROUND_WORKERS,
   MAX_INSTANCE_RESPONSE_TIME,
-  MONIT_INSTANCE_PREFIX
+  MONIT_INSTANCE_PREFIX,
+  PYTHON_APPSERVER
 )
 from appscale.admin.instance_manager.projects_manager import (
   GlobalProjectsManager)
@@ -46,6 +50,7 @@ from appscale.common import (
   misc
 )
 from appscale.common.constants import HTTPCodes
+from appscale.common.constants import MonitStates
 from appscale.common.constants import VERSION_PATH_SEPARATOR
 from appscale.common.deployment_config import ConfigInaccessible
 from appscale.common.deployment_config import DeploymentConfig
@@ -673,6 +678,76 @@ def create_java_start_cmd(app_name, port, load_balancer_host, max_heap,
   return ' '.join(cmd)
 
 
+def clean_up_instances(monit_entries):
+  """ Terminates instances that aren't accounted for.
+
+  Args:
+    monit_entries: A list of dictionaries containing instance details.
+  """
+  monitored = {(entry['revision'], entry['port']) for entry in monit_entries}
+  to_stop = []
+  for process in psutil.process_iter():
+    cmd = process.cmdline()
+    if len(cmd) < 2:
+      continue
+
+    if JAVA_APPSERVER_CLASS in cmd:
+      revision = cmd[-1].split(os.sep)[-2]
+      port_arg = next(arg for arg in cmd if arg.startswith('--port='))
+      port = int(port_arg.split('=')[-1])
+    elif cmd[1] == PYTHON_APPSERVER:
+      source_arg = next(arg for arg in cmd
+                        if arg.startswith(constants.APPS_PATH))
+      revision = source_arg.split(os.sep)[-2]
+      port = int(cmd[cmd.index('--port') + 1])
+    else:
+      continue
+
+    if (revision, port) not in monitored:
+      to_stop.append(process)
+
+  if not to_stop:
+    return
+
+  logging.info('Killing {} unmonitored instances'.format(len(to_stop)))
+  for process in to_stop:
+    group = os.getpgid(process.pid)
+    os.killpg(group, signal.SIGKILL)
+
+
+def recover_state(zk_client):
+  """ Establishes current state from Monit entries.
+
+  Args:
+    zk_client: A KazooClient.
+  """
+  logging.info('Getting current state')
+  monit_entries = monit_operator.get_entries_sync()
+  instance_entries = {entry: state for entry, state in monit_entries.items()
+                      if entry.startswith(MONIT_INSTANCE_PREFIX)}
+
+  # Remove all unmonitored entries.
+  removed = []
+  for entry, state in instance_entries.items():
+    if state == MonitStates.UNMONITORED:
+      monit_operator.remove_configuration(entry)
+      removed.append(entry)
+
+  for entry in removed:
+    del instance_entries[entry]
+
+  if removed:
+    monit_operator.reload_sync()
+
+  instance_details = []
+  for entry, state in instance_entries.items():
+    revision, port = entry[len(MONIT_INSTANCE_PREFIX):].rsplit('-', 1)
+    instance_details.append(
+      {'revision': revision, 'port': int(port), 'state': state})
+
+  clean_up_instances(instance_details)
+
+
 class VersionHandler(tornado.web.RequestHandler):
   """ Handles requests to start and stop instances for a project. """
   @gen.coroutine
@@ -738,6 +813,8 @@ if __name__ == "__main__":
   options.define('syslog_server', appscale_info.get_headnode_ip())
   options.define('db_proxy', appscale_info.get_db_proxy())
   options.define('tq_proxy', appscale_info.get_tq_proxy())
+
+  recover_state(zk_client)
 
   app = tornado.web.Application([
     ('/versions/([a-z0-9-_]+)', VersionHandler),

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -115,6 +115,7 @@ class BadConfigurationException(Exception):
   def __str__(self):
     return repr(self.value)
 
+
 class NoRedirection(urllib2.HTTPErrorProcessor):
   """ A url opener that does not automatically redirect. """
   def http_response(self, request, response):
@@ -157,6 +158,7 @@ def add_routing(version_key, port):
 
   logging.info(
     'Successfully established routing for {}:{}'.format(version_key, port))
+
 
 @gen.coroutine
 def start_app(version_key, config):
@@ -283,6 +285,7 @@ def start_app(version_key, config):
     logging.error("Error while setting up log rotation for application: {}".
       format(project_id))
 
+
 def setup_logrotate(app_name, log_size):
   """ Creates a logrotate script for the logs that the given application
       will create.
@@ -319,6 +322,7 @@ def setup_logrotate(app_name, log_size):
 
   return True
 
+
 def unmonitor(process_name, retries=5):
   """ Unmonitors a process.
 
@@ -344,6 +348,7 @@ def unmonitor(process_name, retries=5):
 
     raise
 
+
 @gen.coroutine
 def clean_old_sources():
   """ Removes source code for obsolete revisions. """
@@ -362,6 +367,7 @@ def clean_old_sources():
         active_revisions.add(revision_key)
 
   source_manager.clean_old_revisions(active_revisions=active_revisions)
+
 
 @gen.coroutine
 def unmonitor_and_terminate(watch):
@@ -386,6 +392,7 @@ def unmonitor_and_terminate(watch):
 
   IOLoop.current().spawn_callback(stop_instance, watch,
                                   MAX_INSTANCE_RESPONSE_TIME)
+
 
 @gen.coroutine
 def stop_app_instance(version_key, port):
@@ -422,6 +429,7 @@ def stop_app_instance(version_key, port):
   yield monit_operator.reload()
   yield clean_old_sources()
 
+
 @gen.coroutine
 def stop_app(version_key):
   """ Stops all process instances of a version on this machine.
@@ -453,6 +461,7 @@ def stop_app(version_key):
   yield monit_operator.reload()
   yield clean_old_sources()
 
+
 def remove_logrotate(app_name):
   """ Removes logrotate script for the given application.
 
@@ -472,6 +481,7 @@ def remove_logrotate(app_name):
     return False
 
   return True
+
 
 ############################################
 # Private Functions (but public for testing)
@@ -505,6 +515,7 @@ def wait_on_app(port):
     format(url, START_APP_TIMEOUT))
   return False
 
+
 def create_python_app_env(public_ip, app_name):
   """ Returns the environment variables the python application server uses.
 
@@ -521,6 +532,7 @@ def create_python_app_env(public_ip, app_name):
   env_vars['APPSCALE_HOME'] = constants.APPSCALE_HOME
   env_vars['PYTHON_LIB'] = "{0}/AppServer/".format(constants.APPSCALE_HOME)
   return env_vars
+
 
 def create_java_app_env(app_name):
   """ Returns the environment variables Java application servers uses.
@@ -542,6 +554,7 @@ def create_java_app_env(app_name):
     env_vars['GCS_HOST'] = '{scheme}://{host}:{port}'.format(**gcs_config)
 
   return env_vars
+
 
 def create_python27_start_cmd(app_name, login_ip, port, pidfile, revision_key):
   """ Creates the start command to run the python application server.
@@ -584,6 +597,7 @@ def create_python27_start_cmd(app_name, login_ip, port, pidfile, revision_key):
 
   return ' '.join(cmd)
 
+
 def locate_dir(path, dir_name):
   """ Locates a directory inside the given path.
 
@@ -613,6 +627,7 @@ def locate_dir(path, dir_name):
     return sorted_paths[0]
   else:
     return None
+
 
 def create_java_start_cmd(app_name, port, load_balancer_host, max_heap,
                           pidfile, revision_key):

--- a/common/appscale/common/monit_interface.py
+++ b/common/appscale/common/monit_interface.py
@@ -1,4 +1,6 @@
+import errno
 import logging
+import os
 import subprocess
 import time
 import urllib
@@ -7,10 +9,12 @@ from xml.etree import ElementTree
 
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient
+from tornado.httpclient import HTTPClient
 from tornado.httpclient import HTTPError
 from tornado.ioloop import IOLoop
 
 from appscale.common.async_retrying import retry_coroutine
+from appscale.common.monit_app_configuration import MONIT_CONFIG_DIR
 from appscale.common.retrying import retry
 from . import constants
 from . import misc
@@ -189,11 +193,15 @@ class MonitOperator(object):
   # The number of seconds to wait between each reload operation.
   RELOAD_COOLDOWN = 1
 
+  # Monit's endpoint for fetching the status of each service.
+  STATUS_URL = '{}/_status?format=xml'.format(LOCATION)
+
   def __init__(self):
     """ Creates a new MonitOperator. There should only be one. """
     self.reload_future = None
-    self.client = AsyncHTTPClient()
     self.last_reload = time.time()
+    self._async_client = AsyncHTTPClient()
+    self._client = HTTPClient()
 
   @gen.coroutine
   def reload(self):
@@ -203,6 +211,10 @@ class MonitOperator(object):
 
     yield self.reload_future
 
+  def reload_sync(self):
+    """ Reloads Monit. """
+    subprocess.check_call(['monit', 'reload'])
+
   @retry_coroutine(retrying_timeout=RETRYING_TIMEOUT)
   def get_entries(self):
     """ Retrieves the status for each Monit entry.
@@ -210,10 +222,19 @@ class MonitOperator(object):
     Returns:
       A dictionary mapping Monit entries to their state.
     """
-    status_url = '{}/_status?format=xml'.format(self.LOCATION)
-    response = yield self.client.fetch(status_url)
+    response = yield self._async_client.fetch(self.STATUS_URL)
     monit_entries = parse_entries(response.body)
     raise gen.Return(monit_entries)
+
+  def get_entries_sync(self):
+    """ Retrieves the status for each Monit entry.
+
+    Returns:
+      A dictionary mapping Monit entries to their state.
+    """
+    response = self._client.fetch(self.STATUS_URL)
+    monit_entries = parse_entries(response.body)
+    return monit_entries
 
   @retry_coroutine(
     retrying_timeout=RETRYING_TIMEOUT,
@@ -228,7 +249,7 @@ class MonitOperator(object):
     process_url = '{}/{}'.format(self.LOCATION, process_name)
     payload = urllib.urlencode({'action': command})
     try:
-      yield self.client.fetch(process_url, method='POST', body=payload)
+      yield self._async_client.fetch(process_url, method='POST', body=payload)
     except HTTPError as error:
       if error.code == 404:
         raise ProcessNotFound('{} is not monitored'.format(process_name))
@@ -290,6 +311,21 @@ class MonitOperator(object):
         yield self.send_command(process_name, 'start')
 
       yield gen.sleep(1)
+
+  def remove_configuration(self, entry):
+    """ Removes the configuration file for an entry.
+
+    Args:
+      entry: A string specifying a Monit entry.
+    """
+    monit_config_file = '{}/appscale-{}.cfg'.format(MONIT_CONFIG_DIR, entry)
+    try:
+      os.remove(monit_config_file)
+    except OSError as error:
+      if error.errno != errno.ENOENT:
+        raise
+
+      logging.error('Error deleting {}'.format(monit_config_file))
 
   @retry_coroutine(
     retrying_timeout=RETRYING_TIMEOUT,


### PR DESCRIPTION
This replaces the HTTP callback that the AppManager server used to perform to register an AppServer instance.