### PR TITLE
Fix AppControllerClient update_cron method

### DIFF
--- a/AdminServer/appscale/admin/appengine_api.py
+++ b/AdminServer/appscale/admin/appengine_api.py
@@ -109,7 +109,7 @@ class UpdateCronHandler(BaseHandler):
     try:
       self.acc.update_cron(project_id)
     except AppControllerException as error:
-      message = 'Error while stopping version: {}'.format(error)
+      message = 'Error while updating cron: {}'.format(error)
       raise CustomHTTPError(HTTPCodes.INTERNAL_ERROR, message=message)
 
     logger.info('Updated cron jobs for {}'.format(project_id))

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4449,11 +4449,10 @@ HOSTS
         response = Net::HTTP.start(uri.hostname, uri.port) do |http|
           http.request(request)
         end
-        if response.code != '200'
-          HelperFunctions.log_and_crash(
-            "AdminServer failed to update dashboard cron: #{response.body}")
-        end
-        break
+        break if response.code == '200'
+        Djinn.log_warn(
+          "Error updating dashboard cron: #{response.body}. Trying again.")
+        sleep(SMALL_WAIT)
       rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT => error
         Djinn.log_warn(
           "Error updating dashboard cron: #{error.message}. Trying again.")

--- a/AppController/lib/app_controller_client.rb
+++ b/AppController/lib/app_controller_client.rb
@@ -228,8 +228,8 @@ class AppControllerClient
 
   # Gets the statistics of this node
   def update_cron(project_id)
-    make_call(10, RETRY_ON_FAIL, 'update_project') {
-      @conn.get_node_stats_json(project_id, @secret)
+    make_call(10, RETRY_ON_FAIL, 'update_cron') {
+      @conn.update_cron(project_id, @secret)
     }
   end
 


### PR DESCRIPTION
This bug crashed AppScale during an up when the shadow was not the first load balancer IP address.