### PR TITLE
Reduce Cassandra memory if running other services

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3190,11 +3190,20 @@ class Djinn
         }
         needed_nodes = needed_for_quorum(db_nodes,
                                          Integer(@options['replication']))
+
+        # If this machine is running other services, decrease Cassandra's max
+        # heap size.
+        heap_reduction = 0
+        heap_reduction += 0.2 if my_node.is_compute?
+        if my_node.is_taskqueue_master? || my_node.is_taskqueue_slave?
+          heap_reduction += 0.1
+        end
+
         if my_node.is_db_master?
-          start_db_master(false, needed_nodes, db_nodes)
+          start_db_master(false, needed_nodes, db_nodes, heap_reduction)
           prime_database
         else
-          start_db_slave(false, needed_nodes, db_nodes)
+          start_db_slave(false, needed_nodes, db_nodes, heap_reduction)
         end
       }
     else

--- a/AppDB/appscale/datastore/cassandra_env/templates/cassandra-env.sh
+++ b/AppDB/appscale/datastore/cassandra_env/templates/cassandra-env.sh
@@ -70,6 +70,16 @@ calculate_heap_sizes()
     else
         max_heap_size_in_mb="$quarter_system_memory_in_mb"
     fi
+
+    # AppScale: Adjust max heap size to make room for other services. Padding
+    # should be defined as a decimal. For example, ".2" would set max heap to
+    # 80% of what it normally would be.
+    if [ -n "${HEAP_REDUCTION}" ]
+    then
+        max_heap_size_in_mb=$(awk \
+          "BEGIN { print int(${max_heap_size_in_mb}*(1-${HEAP_REDUCTION})) }")
+    fi
+
     MAX_HEAP_SIZE="${max_heap_size_in_mb}M"
 
     # Young gen: min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)


### PR DESCRIPTION
When a database machine is running AppServer instances and other services, it's helpful to have a little extra room. This is most important for single-node deployments.