### PR TITLE
Handle key inequality filter within property value

### DIFF
--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -24,6 +24,7 @@ from .cassandra_env.utils import mutations_for_entity
 from .utils import clean_app_id
 from .utils import encode_entity_table_key
 from .utils import encode_index_pb
+from .utils import encode_path_from_filter
 from .utils import get_composite_index_keys
 from .utils import get_entity_key
 from .utils import get_entity_kind
@@ -1895,6 +1896,7 @@ class DatastoreDistributed():
     # This query has a value it bases the query on for a property name
     # The difference between operators is what the end and start key are.
     if len(filter_ops) == 1:
+      key_comparison = False
       oper = filter_ops[0][0]
       value = str(filter_ops[0][1])
 
@@ -1906,6 +1908,20 @@ class DatastoreDistributed():
         else:  # Keep range within property value.
           start_value = ''.join([value, self._SEPARATOR])
         end_value = ''.join([start_value, self._TERM_STRING])
+
+        # Single prop indexes can handle key inequality within a given value.
+        key_comparison = (query.filter_size() == 2 and
+                          query.filter(1).property(0).name() == '__key__')
+        if key_comparison:
+          encoded_path = encode_path_from_filter(query.filter(1))
+          ops = datastore_pb.Query_Filter
+          key_op = query.filter(1).op()
+          if key_op in (ops.LESS_THAN, ops.LESS_THAN_OR_EQUAL):
+            end_value = ''.join([value, self._SEPARATOR, encoded_path])
+            end_inclusive = key_op == ops.LESS_THAN_OR_EQUAL
+          elif key_op in (ops.GREATER_THAN, ops.GREATER_THAN_OR_EQUAL):
+            start_value = ''.join([value, self._SEPARATOR, encoded_path])
+            start_inclusive = key_op == ops.GREATER_THAN_OR_EQUAL
       elif oper == datastore_pb.Query_Filter.LESS_THAN:
         start_value = ""
         end_value = value
@@ -1940,7 +1956,8 @@ class DatastoreDistributed():
       if not startrow:
         params = [prefix, kind, property_name, start_value]
         startrow = get_index_key_from_params(params)
-        start_inclusive = self._DISABLE_INCLUSIVITY
+        if not key_comparison:
+          start_inclusive = self._DISABLE_INCLUSIVITY
       if not endrow:
         params = [prefix, kind, property_name, end_value]
         endrow = get_index_key_from_params(params)
@@ -2191,7 +2208,8 @@ class DatastoreDistributed():
           0, 
           startrow,
           force_start_key_exclusive=force_exclusive,
-          ancestor=ancestor)
+          ancestor=ancestor,
+          query=query)
 
       # We do reference counting and consider any reference which matches the
       # number of properties to be a match. Any others are discarded but it 

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -1901,19 +1901,11 @@ class DatastoreDistributed():
       if direction == datastore_pb.Query_Order.DESCENDING: 
         value = helper_functions.reverse_lex(value)
       if oper == datastore_pb.Query_Filter.EQUAL:
-        if value == "" and ancestor:
-          start_value = self._SEPARATOR + ancestor_filter
-          end_value = self._SEPARATOR + ancestor_filter + self._TERM_STRING
-        elif value == "":
-          start_value = value + self._SEPARATOR
-          end_value = self.MIN_INDEX_VALUE + self._TERM_STRING
-        elif ancestor:
-          start_value = value + self._SEPARATOR + ancestor_filter
-          end_value = value + self._SEPARATOR + ancestor_filter + \
-            self._TERM_STRING
-        else:
-          start_value = value  + self._SEPARATOR
-          end_value = value + self._SEPARATOR + self._TERM_STRING
+        if ancestor:  # Keep range within ancestor key.
+          start_value = ''.join([value, self._SEPARATOR, ancestor_filter])
+        else:  # Keep range within property value.
+          start_value = ''.join([value, self._SEPARATOR])
+        end_value = ''.join([start_value, self._TERM_STRING])
       elif oper == datastore_pb.Query_Filter.LESS_THAN:
         start_value = ""
         end_value = value

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -1909,7 +1909,8 @@ class DatastoreDistributed():
           start_value = ''.join([value, self._SEPARATOR])
         end_value = ''.join([start_value, self._TERM_STRING])
 
-        # Single prop indexes can handle key inequality within a given value.
+        # Single prop indexes can handle key inequality within a given value
+        # (eg. color='blue', __key__<Key('Bike', 5)).
         key_comparison = (query.filter_size() == 2 and
                           query.filter(1).property(0).name() == '__key__')
         if key_comparison:

--- a/AppDB/appscale/datastore/utils.py
+++ b/AppDB/appscale/datastore/utils.py
@@ -641,3 +641,19 @@ def get_write_time(txid):
   offset = datetime.datetime(2022, 2, 1) - epoch
   usec_offset = offset.total_seconds() * 1000000
   return int(usec_offset + txid)
+
+
+def encode_path_from_filter(filter):
+  """ Encode a reference path from a query filter.
+
+  Args:
+    filter: A datastore_pb.Query_Filter.
+  Returns:
+    A string containing an encoded reference path.
+  """
+  path = entity_pb.Path()
+  ref_value = filter.property(0).value().referencevalue()
+  for element in ref_value.pathelement_list():
+    path.add_element().MergeFrom(element)
+
+  return str(encode_index_pb(path))

--- a/AppDB/appscale/datastore/utils.py
+++ b/AppDB/appscale/datastore/utils.py
@@ -643,16 +643,16 @@ def get_write_time(txid):
   return int(usec_offset + txid)
 
 
-def encode_path_from_filter(filter):
+def encode_path_from_filter(query_filter):
   """ Encode a reference path from a query filter.
 
   Args:
-    filter: A datastore_pb.Query_Filter.
+    query_filter: A datastore_pb.Query_Filter.
   Returns:
     A string containing an encoded reference path.
   """
   path = entity_pb.Path()
-  ref_value = filter.property(0).value().referencevalue()
+  ref_value = query_filter.property(0).value().referencevalue()
   for element in ref_value.pathelement_list():
     path.add_element().MergeFrom(element)
 


### PR DESCRIPTION
This fixes queries that look like 'prop=val,key!=example_key'.