### PR TITLE
Register instances with ZooKeeper

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/constants.py
+++ b/AdminServer/appscale/admin/instance_manager/constants.py
@@ -28,6 +28,10 @@ DASHBOARD_LOG_SIZE = 10 * 1024 * 1024
 # The default amount of memory in MB to allow an instance.
 DEFAULT_MAX_APPSERVER_MEMORY = 400
 
+# The Java class that runs AppServer instances.
+JAVA_APPSERVER_CLASS = ('com.google.appengine.tools.development.'
+                        'DevAppServerMain')
+
 # Default logrotate configuration directory.
 LOGROTATE_CONFIG_DIR = os.path.join('/', 'etc', 'logrotate.d')
 
@@ -51,6 +55,10 @@ MODIFIED_JARS = [
 
 # A prefix added to instance entries to distinguish them from services.
 MONIT_INSTANCE_PREFIX = 'app___'
+
+# The script used for starting Python AppServer instances.
+PYTHON_APPSERVER = os.path.join(APPSCALE_HOME, 'AppServer',
+                                'dev_appserver.py')
 
 # A mapping of instance classes to memory limits in MB.
 INSTANCE_CLASSES = {'F1': 128,

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4909,6 +4909,9 @@ HOSTS
 
   # Updates @app_info_map with registered instances. This must be called under
   # APPS_LOCK.
+  #
+  # Args:
+  #   version_key: A string specifying the version key to update.
   def update_registered_instances(version_key)
     begin
       zk_instances = ZKInterface.get_children(

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4921,11 +4921,9 @@ HOSTS
       return
     end
 
-    unless zk_instances.empty?
-      @app_info_map[version_key] = {} unless @app_info_map.key?(version_key)
-      unless @app_info_map[version_key].key?('appservers')
-        @app_info_map[version_key]['appservers'] = []
-      end
+    @app_info_map[version_key] = {} unless @app_info_map.key?(version_key)
+    unless @app_info_map[version_key].key?('appservers')
+      @app_info_map[version_key]['appservers'] = []
     end
     known_instances = @app_info_map[version_key]['appservers']
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1883,7 +1883,7 @@ class Djinn
       # Load balancers and shadow need to check/update nginx/haproxy.
       if my_node.is_load_balancer?
         APPS_LOCK.synchronize {
-          check_haproxy
+          regenerate_routing_config
         }
       end
       @state = "Done starting up AppScale, now in heartbeat mode"
@@ -2530,78 +2530,6 @@ class Djinn
     }
 
     return uuid
-  end
-
-  # Instructs Nginx and HAProxy to begin routing traffic for the named
-  # version to a new AppServer.
-  #
-  # This method should be called at the AppController running the login role,
-  # as it is the node that receives application traffic from the outside.
-  #
-  # Args:
-  #   version_key: A String that identifies the version that runs the new
-  #     AppServer.
-  #   ip: A String that identifies the private IP address where the new
-  #     AppServer runs.
-  #   port: A Fixnum that identifies the port where the new AppServer runs at
-  #     ip.
-  #   secret: A String that is used to authenticate the caller.
-  #
-  # Returns:
-  #   "OK" if the addition was successful. In case of failures, the following
-  #   Strings may be returned:
-  #   - BAD_SECRET_MSG: If the caller cannot be authenticated.
-  #   - NO_HAPROXY_PRESENT: If this node does not run HAProxy (and thus cannot
-  #     add AppServers to HAProxy config files).
-  #   - NOT_READY: If this node runs HAProxy, but hasn't allocated ports for
-  #     it and nginx yet. Callers should retry at a later time.
-  def add_routing_for_appserver(version_key, ip, port, secret)
-    return BAD_SECRET_MSG unless valid_secret?(secret)
-
-    unless my_node.is_shadow?
-       # We need to send the call to the shadow.
-       Djinn.log_debug("Sending routing call for #{version_key} to shadow.")
-       acc = AppControllerClient.new(get_shadow.private_ip, @@secret)
-       begin
-         return acc.add_routing_for_appserver(version_key, ip, port)
-       rescue FailedNodeException
-         Djinn.log_warn("Failed to forward routing call to shadow (#{get_shadow}).")
-         return NOT_READY
-       end
-    end
-
-    project_id, service_id, version_id = version_key.split(
-      VERSION_PATH_SEPARATOR)
-    begin
-      version_details = ZKInterface.get_version_details(
-        project_id, service_id, version_id)
-    rescue VersionNotFound => error
-      return "false: #{error.message}"
-    end
-
-    APPS_LOCK.synchronize {
-      if @app_info_map[version_key].nil? ||
-          @app_info_map[version_key]['appservers'].nil?
-        return NOT_READY
-      elsif @app_info_map[version_key]['appservers'].include?("#{ip}:#{port}")
-        Djinn.log_warn(
-          "Already registered AppServer for #{version_key} at #{ip}:#{port}.")
-        return INVALID_REQUEST
-      end
-
-      Djinn.log_debug("Add routing for #{version_key} at #{ip}:#{port}.")
-
-      # Find and remove an entry for this AppServer node and app.
-      match = @app_info_map[version_key]['appservers'].index("#{ip}:-1")
-      if match
-        @app_info_map[version_key]['appservers'].delete_at(match)
-      else
-        Djinn.log_warn("Received a no matching request for: #{ip}:#{port}.")
-      end
-      @app_info_map[version_key]['appservers'] << "#{ip}:#{port}"
-    }
-
-    'OK'
   end
 
   # Instruct HAProxy to begin routing traffic to the BlobServers.
@@ -4645,23 +4573,6 @@ HOSTS
     }
   end
 
-
-  # LoadBalancers need to do some extra work to detect when AppServers failed
-  # or were terminated.
-  def check_haproxy
-    @versions_loaded.each { |version_key|
-      if my_node.is_shadow?
-         _, failed = get_application_appservers(version_key)
-        failed.each { |appserver|
-          Djinn.log_warn(
-            "Detected failed AppServer for #{version_key}: #{appserver}.")
-          @app_info_map[version_key]['appservers'].delete(appserver)
-        }
-      end
-    }
-    regenerate_routing_config
-  end
-
   # All nodes will compare the list of AppServers they should be running,
   # with the list of AppServers actually running, and make the necessary
   # adjustments. Effectively only login node and compute nodes will run
@@ -4982,6 +4893,49 @@ HOSTS
   end
 
 
+  # Updates @app_info_map with registered instances. This must be called under
+  # APPS_LOCK.
+  def update_registered_instances(version_key)
+    begin
+      zk_instances = ZKInterface.get_children(
+        "/appscale/instances_by_version/#{version_key}")
+    rescue FailedZooKeeperOperationException
+      Djinn.log_warn('Unable to update registered instances.')
+      return
+    end
+
+    unless zk_instances.empty?
+      @app_info_map[version_key] = {} unless @app_info_map.key?(version_key)
+      unless @app_info_map[version_key].key?('appservers')
+        @app_info_map[version_key]['appservers'] = []
+      end
+    end
+    known_instances = @app_info_map[version_key]['appservers']
+
+    # Replace instance assignments with any new registered instances.
+    zk_instances.each { |instance_key|
+      next if known_instances.include?(instance_key)
+
+      # Find and remove an entry for this AppServer node and app.
+      ip = instance_key.split(':')[0]
+      match = known_instances.index("#{ip}:-1")
+      if match
+        known_instances.delete_at(match)
+        known_instances << instance_key
+      else
+        Djinn.log_warn("Ignoring unassigned instance: #{instance_key}.")
+      end
+    }
+
+    # Account for instances that have been stopped.
+    known_instances.delete_if { |instance_key|
+      pending = instance_key.split(':')[-1] == '-1'
+      registered = zk_instances.include?(instance_key)
+      !pending && !registered
+    }
+  end
+
+
   # Scale AppServers up/down for each application depending on the current
   # queued requests and load of the application.
   #
@@ -4993,6 +4947,7 @@ HOSTS
     ZKInterface.get_versions.each { |version_key|
       next unless @versions_loaded.include?(version_key)
 
+      update_registered_instances(version_key)
       initialize_scaling_info_for_version(version_key)
 
       # Get the desired changes in the number of AppServers.
@@ -6019,53 +5974,6 @@ HOSTS
         "req_tot=#{total_requests}, qcur=#{requests_in_queue}, scur=#{sessions}")
     end
     return total_requests, requests_in_queue, sessions, time
-  end
-
-  # Gets united lists of running and failed AppServers
-  # for a specific application version accross all LB nodes.
-  #
-  # Args:
-  #   version_key: A string specifying the version key.
-  # Returns:
-  #   An Array of running AppServers (ip:port).
-  #   An Array of failed (marked as DOWN) AppServers (ip:port).
-  #
-  def get_application_appservers(version_key)
-    all_running, all_failed = [], []
-    pxname = "gae_#{version_key}"
-    lb_nodes = @nodes.select{|node| node.is_load_balancer?}
-    lb_nodes.each { |node|
-      begin
-        ip = node.private_ip
-        running, failed = HermesClient.get_backend_servers(ip, @@secret, pxname)
-        all_running += running
-        all_failed += failed
-      rescue AppScaleException => error
-        Djinn.log_warn("Couldn't get proxy stats from Hermes: #{error.message}")
-      end
-    }
-    all_running.uniq!
-    all_failed.uniq!
-
-    if lb_nodes.length > 1
-      # Report total HAProxy stats if there are multiple LB nodes
-      if all_running.length > HelperFunctions::NUM_ENTRIES_TO_PRINT
-        Djinn.log_debug("Deployment: found #{all_running.length} running " \
-                        "AppServers for #{pxname}.")
-      else
-        Djinn.log_debug("Deployment: found these running " \
-                        "AppServers for #{pxname}: #{all_running}.")
-      end
-      if all_failed.length > HelperFunctions::NUM_ENTRIES_TO_PRINT
-        Djinn.log_debug("Deployment: found #{all_failed.length} failed " \
-                        "AppServers for #{pxname}.")
-      else
-        Djinn.log_debug("Deployment: found these failed " \
-                        "AppServers for #{pxname}: #{all_failed}.")
-      end
-    end
-
-    return all_running, all_failed
   end
 
   # Gets an application cron info.

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4917,7 +4917,7 @@ HOSTS
       zk_instances = ZKInterface.get_children(
         "/appscale/instances_by_version/#{version_key}")
     rescue FailedZooKeeperOperationException
-      Djinn.log_warn('Unable to update registered instances.')
+      Djinn.log_warn('Unable to fetch list of registered instances.')
       return
     end
 

--- a/AppController/djinnServer.rb
+++ b/AppController/djinnServer.rb
@@ -81,8 +81,6 @@ class DjinnServer < SOAP::RPC::HTTPServer
     add_method(@djinn, "backup_appscale", "backup_in_info", "secret")
     add_method(@djinn, "start_roles_on_nodes", "ips_hash", "secret")
     add_method(@djinn, "gather_logs", "secret")
-    add_method(@djinn, "add_routing_for_appserver", "version_key", "ip",
-               "port", "secret")
     add_method(@djinn, "add_routing_for_blob_server", "secret")
     add_method(@djinn, "run_groomer", "secret")
     add_method(@djinn, "get_property", "property_regex", "secret")

--- a/AppController/lib/app_controller_client.rb
+++ b/AppController/lib/app_controller_client.rb
@@ -72,8 +72,6 @@ class AppControllerClient
     @conn.add_method('get_node_stats_json', 'secret')
     @conn.add_method('get_instance_info', 'secret')
     @conn.add_method('get_request_info', 'version_key', 'secret')
-    @conn.add_method('add_routing_for_appserver', 'version_key', 'ip', 'port',
-                     'secret')
     @conn.add_method('update_cron', 'project_id', 'secret')
   end
 
@@ -216,13 +214,6 @@ class AppControllerClient
   def get_node_stats_json
     make_call(10, RETRY_ON_FAIL, 'get_node_stats_json') {
       @conn.get_node_stats_json(@secret)
-    }
-  end
-
-  # Adds routing for appserver.
-  def add_routing_for_appserver(version_key, ip, port)
-    make_call(10, RETRY_ON_FAIL, 'add_routing_for_appserver') {
-      @conn.add_routing_for_appserver(version_key, ip, port, @secret)
     }
   end
 

--- a/AppController/lib/hermes_client.rb
+++ b/AppController/lib/hermes_client.rb
@@ -102,44 +102,4 @@ module HermesClient
       "scur=#{current_sessions}")
     return total_requests_seen, total_req_in_queue, current_sessions
   end
-
-  # Gets running and failed backend servers for a specific proxy.
-  #
-  # Args:
-  #   lb_ip: IP address of load balancer node.
-  #   secret: Deployment secret.
-  #   proxy_name: Name of proxy to return.
-  # Returns:
-  #   An Array of running AppServers (ip:port).
-  #   An Array of failed (marked as DOWN) AppServers (ip:port).
-  #
-  def self.get_backend_servers(lb_ip, secret, proxy_name)
-    proxy = HermesClient.get_proxy_stats(lb_ip, secret, proxy_name, true)
-    
-    # TODO: do investigation about best way to detect failed servers.
-    running = proxy['servers'] \
-      .select{|server| not server['status'].start_with?('DOWN')} \
-      .map{|server| "#{server['private_ip']}:#{server['port']}"}
-
-    failed = proxy['servers'] \
-      .select{|server| server['status'].start_with?('DOWN')} \
-      .map{|server| "#{server['private_ip']}:#{server['port']}"}
-
-    if running.length > HelperFunctions::NUM_ENTRIES_TO_PRINT
-      Djinn.log_debug("Haproxy at #{lb_ip}: found #{running.length} running " \
-                      "AppServers for #{proxy_name}.")
-    else
-      Djinn.log_debug("Haproxy at #{lb_ip}: found these running " \
-                      "AppServers for #{proxy_name}: #{running}.")
-    end
-    if failed.length > HelperFunctions::NUM_ENTRIES_TO_PRINT
-      Djinn.log_debug("Haproxy at #{lb_ip}: found #{failed.length} failed " \
-                      "AppServers for #{proxy_name}.")
-    else
-      Djinn.log_debug("Haproxy at #{lb_ip}: found these failed " \
-                      "AppServers for #{proxy_name}: #{failed}.")
-    end
-    return running, failed
-  end
-
 end

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -61,8 +61,6 @@ class TestDjinn < Test::Unit::TestCase
     assert_equal(BAD_SECRET_MSG, djinn.job_start(@secret))
     assert_equal(BAD_SECRET_MSG, djinn.get_online_users_list(@secret))
     assert_equal(BAD_SECRET_MSG, djinn.start_roles_on_nodes({}, @secret))
-    assert_equal(BAD_SECRET_MSG, djinn.add_routing_for_appserver(@app, 'baz',
-      'baz', @secret))
     assert_equal(BAD_SECRET_MSG, djinn.run_groomer(@secret))
     assert_equal(BAD_SECRET_MSG, djinn.get_property('baz', @secret))
     assert_equal(BAD_SECRET_MSG, djinn.set_property('baz', 'qux', @secret))

--- a/AppControllerClient/appscale/appcontroller_client/__init__.py
+++ b/AppControllerClient/appscale/appcontroller_client/__init__.py
@@ -314,19 +314,6 @@ class AppControllerClient():
     return self.call(self.MAX_RETRIES, self.server.run_groomer, self.secret)
 
 
-  def add_routing_for_appserver(self, version_key, appserver_ip, port):
-    """ Tells the AppController to begin routing traffic to an AppServer.
-
-    Args:
-      version_key: A string that contains the version key.
-      appserver_ip: A string that contains the IP address of the instance
-        running the AppServer.
-      port: A string that contains the port that the AppServer listens on.
-    """
-    return self.call(self.MAX_RETRIES, self.server.add_routing_for_appserver,
-                     version_key, appserver_ip, port, self.secret)
-
-
   def add_routing_for_blob_server(self):
     """ Tells the AppController to begin routing traffic to the
         BlobServer(s).

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -129,6 +129,7 @@ class BadConfigurationException(Exception):
   def __str__(self):
     return repr(self.value)
 
+
 class NoRedirection(urllib2.HTTPErrorProcessor):
   """ A url opener that does not automatically redirect. """
   def http_response(self, request, response):
@@ -375,6 +376,7 @@ def start_app(version_key, config):
     logging.error("Error while setting up log rotation for application: {}".
       format(project_id))
 
+
 def setup_logrotate(app_name, log_size):
   """ Creates a logrotate script for the logs that the given application
       will create.
@@ -411,6 +413,7 @@ def setup_logrotate(app_name, log_size):
 
   return True
 
+
 def unmonitor(process_name, retries=5):
   """ Unmonitors a process.
 
@@ -436,6 +439,7 @@ def unmonitor(process_name, retries=5):
 
     raise
 
+
 @gen.coroutine
 def clean_old_sources():
   """ Removes source code for obsolete revisions. """
@@ -454,6 +458,7 @@ def clean_old_sources():
         active_revisions.add(revision_key)
 
   source_manager.clean_old_revisions(active_revisions=active_revisions)
+
 
 @gen.coroutine
 def unmonitor_and_terminate(watch):
@@ -478,6 +483,7 @@ def unmonitor_and_terminate(watch):
 
   IOLoop.current().spawn_callback(stop_instance, watch,
                                   MAX_INSTANCE_RESPONSE_TIME)
+
 
 @gen.coroutine
 def stop_app_instance(version_key, port):
@@ -521,6 +527,7 @@ def stop_app_instance(version_key, port):
   yield monit_operator.reload()
   yield clean_old_sources()
 
+
 @gen.coroutine
 def stop_app(version_key):
   """ Stops all process instances of a version on this machine.
@@ -559,6 +566,7 @@ def stop_app(version_key):
   yield monit_operator.reload()
   yield clean_old_sources()
 
+
 def remove_logrotate(app_name):
   """ Removes logrotate script for the given application.
 
@@ -578,6 +586,7 @@ def remove_logrotate(app_name):
     return False
 
   return True
+
 
 ############################################
 # Private Functions (but public for testing)
@@ -611,6 +620,7 @@ def wait_on_app(port):
     format(url, START_APP_TIMEOUT))
   return False
 
+
 def create_python_app_env(public_ip, app_name):
   """ Returns the environment variables the python application server uses.
 
@@ -627,6 +637,7 @@ def create_python_app_env(public_ip, app_name):
   env_vars['APPSCALE_HOME'] = constants.APPSCALE_HOME
   env_vars['PYTHON_LIB'] = "{0}/AppServer/".format(constants.APPSCALE_HOME)
   return env_vars
+
 
 def create_java_app_env(app_name):
   """ Returns the environment variables Java application servers uses.
@@ -648,6 +659,7 @@ def create_java_app_env(app_name):
     env_vars['GCS_HOST'] = '{scheme}://{host}:{port}'.format(**gcs_config)
 
   return env_vars
+
 
 def create_python27_start_cmd(app_name, login_ip, port, pidfile, revision_key,
                               api_server_port):
@@ -693,6 +705,7 @@ def create_python27_start_cmd(app_name, login_ip, port, pidfile, revision_key,
 
   return ' '.join(cmd)
 
+
 def locate_dir(path, dir_name):
   """ Locates a directory inside the given path.
 
@@ -722,6 +735,7 @@ def locate_dir(path, dir_name):
     return sorted_paths[0]
   else:
     return None
+
 
 def create_java_start_cmd(app_name, port, load_balancer_host, max_heap,
                           pidfile, revision_key):

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -865,11 +865,11 @@ def declare_instance_nodes(running_instances, zk_client):
   for version_key in zk_client.get_children(VERSION_REGISTRATION_NODE):
     version_node = '/'.join([VERSION_REGISTRATION_NODE, version_key])
     for instance_entry in zk_client.get_children(version_node):
-      machine_ip, port = instance_entry.split(':')
-      port = int(port)
+      machine_ip = instance_entry.split(':')[0]
       if machine_ip != options.private_ip:
         continue
 
+      port = int(instance_entry.split(':')[-1])
       instance_node = '/'.join([version_node, instance_entry])
       revision = zk_client.get(instance_node)[0]
       revision_key = VERSION_PATH_SEPARATOR.join([version_key, revision])

--- a/common/appscale/common/monit_interface.py
+++ b/common/appscale/common/monit_interface.py
@@ -211,7 +211,8 @@ class MonitOperator(object):
 
     yield self.reload_future
 
-  def reload_sync(self):
+  @staticmethod
+  def reload_sync():
     """ Reloads Monit. """
     subprocess.check_call(['monit', 'reload'])
 
@@ -312,7 +313,8 @@ class MonitOperator(object):
 
       yield gen.sleep(1)
 
-  def remove_configuration(self, entry):
+  @staticmethod
+  def remove_configuration(entry):
     """ Removes the configuration file for an entry.
 
     Args:

--- a/common/appscale/common/monit_interface.py
+++ b/common/appscale/common/monit_interface.py
@@ -1,4 +1,6 @@
+import errno
 import logging
+import os
 import subprocess
 import time
 import urllib
@@ -7,10 +9,12 @@ from xml.etree import ElementTree
 
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient
+from tornado.httpclient import HTTPClient
 from tornado.httpclient import HTTPError
 from tornado.ioloop import IOLoop
 
 from appscale.common.async_retrying import retry_coroutine
+from appscale.common.monit_app_configuration import MONIT_CONFIG_DIR
 from appscale.common.retrying import retry
 from . import constants
 from . import misc
@@ -189,11 +193,15 @@ class MonitOperator(object):
   # The number of seconds to wait between each reload operation.
   RELOAD_COOLDOWN = 1
 
+  # Monit's endpoint for fetching the status of each service.
+  STATUS_URL = '{}/_status?format=xml'.format(LOCATION)
+
   def __init__(self):
     """ Creates a new MonitOperator. There should only be one. """
     self.reload_future = None
-    self.client = AsyncHTTPClient()
     self.last_reload = time.time()
+    self._async_client = AsyncHTTPClient()
+    self._client = HTTPClient()
 
   @gen.coroutine
   def reload(self):
@@ -203,6 +211,10 @@ class MonitOperator(object):
 
     yield self.reload_future
 
+  def reload_sync(self):
+    """ Reloads Monit. """
+    subprocess.check_call(['monit', 'reload'])
+
   @retry_coroutine(retrying_timeout=RETRYING_TIMEOUT)
   def get_entries(self):
     """ Retrieves the status for each Monit entry.
@@ -210,10 +222,19 @@ class MonitOperator(object):
     Returns:
       A dictionary mapping Monit entries to their state.
     """
-    status_url = '{}/_status?format=xml'.format(self.LOCATION)
-    response = yield self.client.fetch(status_url)
+    response = yield self._async_client.fetch(self.STATUS_URL)
     monit_entries = parse_entries(response.body)
     raise gen.Return(monit_entries)
+
+  def get_entries_sync(self):
+    """ Retrieves the status for each Monit entry.
+
+    Returns:
+      A dictionary mapping Monit entries to their state.
+    """
+    response = self._client.fetch(self.STATUS_URL)
+    monit_entries = parse_entries(response.body)
+    return monit_entries
 
   @retry_coroutine(
     retrying_timeout=RETRYING_TIMEOUT,
@@ -228,7 +249,7 @@ class MonitOperator(object):
     process_url = '{}/{}'.format(self.LOCATION, process_name)
     payload = urllib.urlencode({'action': command})
     try:
-      yield self.client.fetch(process_url, method='POST', body=payload)
+      yield self._async_client.fetch(process_url, method='POST', body=payload)
     except HTTPError as error:
       if error.code == 404:
         raise ProcessNotFound('{} is not monitored'.format(process_name))
@@ -290,6 +311,21 @@ class MonitOperator(object):
         yield self.send_command(process_name, 'start')
 
       yield gen.sleep(1)
+
+  def remove_configuration(self, entry):
+    """ Removes the configuration file for an entry.
+
+    Args:
+      entry: A string specifying a Monit entry.
+    """
+    monit_config_file = '{}/appscale-{}.cfg'.format(MONIT_CONFIG_DIR, entry)
+    try:
+      os.remove(monit_config_file)
+    except OSError as error:
+      if error.errno != errno.ENOENT:
+        raise
+
+      logging.error('Error deleting {}'.format(monit_config_file))
 
   @retry_coroutine(
     retrying_timeout=RETRYING_TIMEOUT,


### PR DESCRIPTION
This replaces the HTTP callback that the AppManager server used to perform to register an AppServer instance.

While similar to https://github.com/AppScale/appscale/pull/2640, it addresses the code review comments and moves the instance health check from the router to the AppManager.