### PR TITLE
Allow Go instances to use external API server

### DIFF
--- a/AppServer/google/appengine/tools/devappserver2/module.py
+++ b/AppServer/google/appengine/tools/devappserver2/module.py
@@ -263,7 +263,7 @@ class Module(object):
 
     # AppScale: Pack both API ports into the same field.
     if (self._external_api_port is not None and
-        self._module_configuration.runtime == 'python27'):
+        self._module_configuration.runtime in ('python27', 'go')):
       port_bytes = struct.pack('HH', self._api_port, self._external_api_port)
       runtime_config.api_port = struct.unpack('I', port_bytes)[0]
     else:

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -530,20 +530,23 @@ installapiclient()
 installgosdk()
 {
     if [ ${UNAME_MACHINE} = "x86_64" ]; then
-        GO_SDK_PACKAGE="go_appengine_sdk_linux_amd64-1.9.48.zip"
-        GO_SDK_PACKAGE_MD5="b5c1a3eab1ba69993c3a35661ec3043d"
+        GO_SDK_PACKAGE="appscale-go-runtime-1.9.48.zip"
+        GO_SDK_PACKAGE_MD5="3af8c4f6b3a147f99590862d2815025b"
+
+        GO_RUNTIME_DIR="/opt/go_appengine"
+        cachepackage ${GO_SDK_PACKAGE} ${GO_SDK_PACKAGE_MD5}
+
+        echo "Extracting Go SDK"
+        # Remove existing SDK directory in case it's old.
+        rm -rf ${GO_RUNTIME_DIR}
+        mkdir -p ${GO_RUNTIME_DIR}/gopath
+        unzip -q ${PACKAGE_CACHE}/${GO_SDK_PACKAGE} -d ${GO_RUNTIME_DIR}
     else
-        GO_SDK_PACKAGE="go_appengine_sdk_linux_386-1.9.48.zip"
-        GO_SDK_PACKAGE_MD5="b6aad6a3cb2506dfe1067e06fb93f9fb"
+        echo "Warning: There is no binary appscale-go-runtime package"
+        echo "available for ${UNAME_MACHINE}. If you need support for Go"
+        echo "applications, compile github.com/AppScale/appscale-go-runtime"
+        echo "and install in ${GO_RUNTIME_DIR}/goroot."
     fi
-
-    EXTRAS_DIR="/opt"
-    cachepackage ${GO_SDK_PACKAGE} ${GO_SDK_PACKAGE_MD5}
-
-    echo "Extracting Go SDK"
-    # Remove existing SDK directory in case it's old.
-    rm -rf ${EXTRAS_DIR}/go_appengine
-    unzip -q ${PACKAGE_CACHE}/${GO_SDK_PACKAGE} -d ${EXTRAS_DIR}
 }
 
 installpycapnp()


### PR DESCRIPTION
This is only for App Identity calls.