### PR TITLE
RM-565 - Script to automate version bump.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+#
+# Makefile currently only performs some release
+# activities, version bump and release notes generation
+#
+
+.PHONY: bump-major bump-minor bump-patch release-notes help all
+
+all: help
+
+help:
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-10s\033[0m- %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+bump-major: ## Bump the major version number for AppScale
+	util/bump_version.sh major
+
+bump-minor: ## Bump the minor version number for AppScale
+	util/bump_version.sh minor
+
+bump-patch: ## Bump the patch version number for AppScale
+	util/bump_version.sh patch
+
+release-notes: ## Generate release notes for a new release
+	util/gen_release_notes.sh
+

--- a/util/bump_version.sh
+++ b/util/bump_version.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# Simple script to allow version bumping of AppScale.
+#
+# major -> 3.4.0 -> 4.0.0
+# minor -> 3.4.3 -> 3.5.0
+# patch -> 3.4.3 -> 3.4.4
+#
+if [ ! -e VERSION ]; then
+	echo "Unable to locate the VERSION file, is your working directory the top level of the repo?"
+	exit 1
+fi
+
+version=$(tail -1 VERSION | cut -d' ' -f3)
+
+case $1 in
+	"major")
+	bump_field="\$1"
+	fmt_str="%s.0.0"
+	;;
+	"minor")
+	bump_field="\$2"
+	fmt_str="%s.%s.0"
+	;;
+	"patch")
+	bump_field="\$3"
+	fmt_str="%s.%s.%s"
+	;;
+	*)
+	echo "usage: $0 [major|minor|patch]"
+	exit 1
+esac
+
+# awk doesn't mind that not all fields will get formatted...
+new_version=$(echo $version | awk -F. "{${bump_field}++;printf \"${fmt_str}\", \$1, \$2, \$3}")
+
+echo "Bumping version from: ${version} to ${new_version}, changes not automatically committed"
+
+# Do the version change
+sed -i "s/${version}/${new_version}/g" VERSION

--- a/util/gen_release_notes.sh
+++ b/util/gen_release_notes.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#
+# Helper script to gather all git log messages from the last tag
+# and construct a preliminary RELEASE file for the release.
+#
+# Assumes the new release from the VERSION file.
+#
+
+if [ ! -e RELEASE ]; then
+	echo "Unable to locate RELEASE file, is your working dir the top level of the repo"
+	exit 1
+fi
+
+echo "Generating RELEASE file (changelog)"
+
+# header
+head -7 RELEASE > t_release
+
+echo "New Release version: $(tail -1 VERSION) - released $(date +'%B %Y')"
+# release line
+echo "$(tail -1 VERSION), released $(date +'%B %Y')" >> t_release
+echo "Highlights of features/bugs in this release:" >> t_release
+
+echo -n "Gathering git logs"
+# Git logs from last tag (eg 3.4.0)
+git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:"- %s" >> t_release
+echo "" >> t_release
+echo "" >> t_release
+echo "...done"
+
+echo "Known Issues:" >> t_release
+echo "" >> t_release
+
+echo -n "Appending old release notes"
+tail -n+7 RELEASE >> t_release
+echo "...done"
+
+echo -n "Constructing new RELEASE file"
+cp t_release RELEASE
+rm -f t_release
+echo "...done"
+
+echo "Be sure to read through the RELEASE file before commiting the changes"


### PR DESCRIPTION
Also resolves RM-566 - Script to generate RELEASE file after version bump.

 - Adds Makefile to top level directory, with targets:
   - bump-major
   - bump-minor
   - bump-patch
   - release-notes
 - added util directory for scripts that are not part of the distro
 - added util/bump_version.sh script to bump VERSION file
 - added util/gen_release_notes.sh script to help generate release notes.