### PR TITLE
Don't clear cron jobs during an up

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2304,7 +2304,6 @@ class Djinn
 
     Nginx.clear_sites_enabled()
     HAProxy.clear_sites_enabled()
-    CronHelper.clear_app_crontabs()
   end
 
   def wait_for_nodes_to_finish_loading(nodes)


### PR DESCRIPTION
We don't yet have a way to automatically recreate cron entries when they are removed, so we need to keep them across down,up cycles for now.