### PR TITLE
Wait for all load balancers to route instances

### DIFF
--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -93,6 +93,20 @@ def wait_for_port_to_open(http_port, operation_id, deadline):
 
     yield gen.sleep(1)
 
+  for load_balancer in appscale_info.get_load_balancer_ips():
+    while True:
+      if time.time() > deadline:
+        # The version is reachable from the login IP, but it's not reachable
+        # from every registered load balancer. It makes more sense to mark the
+        # operation as a success than a failure because the lagging load
+        # balancers should eventually reflect the registered instances.
+        break
+
+      if utils.port_is_open(load_balancer, http_port):
+        break
+
+      yield gen.sleep(1)
+
 
 @gen.coroutine
 def wait_for_deploy(operation_id, acc):

--- a/AdminServer/appscale/admin/constants.py
+++ b/AdminServer/appscale/admin/constants.py
@@ -88,7 +88,7 @@ DEFAULT_VERSION = 'v1'
 DEFAULT_SERVICE = 'default'
 
 # The number of seconds to wait before giving up on an operation.
-MAX_OPERATION_TIME = 100
+MAX_OPERATION_TIME = 120
 
 # Supported runtimes.
 VALID_RUNTIMES = {PYTHON27, JAVA, GO, PHP}


### PR DESCRIPTION
There are times when it takes a significant amount of time for a load balancer machine to reflect the latest instance registration list. This delay can cause push workers to fail if they try to make a request through a load balancer before it is updated.

This change makes that situation less likely at the cost of longer deploy operations.