### PR TITLE
Run apps without application element in app.yaml

### DIFF
--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -668,6 +668,7 @@ def create_python27_start_cmd(app_name, login_ip, port, pidfile, revision_key,
   cmd = [
     "/usr/bin/python2",
     constants.APPSCALE_HOME + "/AppServer/dev_appserver.py",
+    "--application", app_name,
     "--port " + str(port),
     "--admin_port " + str(port + 10000),
     "--login_server " + login_ip,

--- a/AppServer/google/appengine/api/appinfo.py
+++ b/AppServer/google/appengine/api/appinfo.py
@@ -1501,7 +1501,7 @@ class AppInfoExternal(validation.Validated):
   ATTRIBUTES = {
 
 
-      APPLICATION: APPLICATION_RE_STRING,
+      APPLICATION: validation.Optional(APPLICATION_RE_STRING),
       MODULE: validation.Optional(MODULE_ID_RE_STRING),
       VERSION: validation.Optional(MODULE_VERSION_ID_RE_STRING),
       RUNTIME: RUNTIME_RE_STRING,

--- a/AppServer/google/appengine/tools/devappserver2/devappserver2.py
+++ b/AppServer/google/appengine/tools/devappserver2/devappserver2.py
@@ -187,6 +187,10 @@ def create_command_line_parser():
 
   common_group = parser.add_argument_group('Common')
   common_group.add_argument(
+      '-A', '--application', action='store', dest='app_id',
+      help='Set the application, overriding the application value from the '
+      'app.yaml file.')
+  common_group.add_argument(
       '--host', default='localhost',
       help='host name to which application modules should bind')
   common_group.add_argument(
@@ -547,7 +551,7 @@ class DevelopmentServer(object):
         _LOG_LEVEL_TO_PYTHON_CONSTANT[options.dev_appserver_log_level])
 
     configuration = application_configuration.ApplicationConfiguration(
-        options.yaml_files)
+        options.yaml_files, options.app_id)
 
     if options.skip_sdk_update_check:
       logging.info('Skipping SDK update check.')


### PR DESCRIPTION
This uses the application flag introduced in the 1.9.8 SDK to override the application element in the app.yaml.