### PR TITLE
Allow group locks to persist when commits fail

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
+++ b/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
@@ -20,6 +20,7 @@ from cassandra.query import BatchStatement
 from cassandra.query import ConsistencyLevel
 from cassandra.query import SimpleStatement
 from cassandra.query import ValueSequence
+from .constants import CURRENT_VERSION
 from .large_batch import (FailedBatch,
                           LargeBatch)
 from .retry_policies import (BASIC_RETRIES,
@@ -52,9 +53,6 @@ CASSANDRA_MONIT_WATCH_NAME = "cassandra"
 
 # The number of times to retry connecting to Cassandra.
 INITIAL_CONNECT_RETRIES = 20
-
-# The data layout version that the datastore expects.
-EXPECTED_DATA_VERSION = 1.0
 
 # The metadata key for the data layout version.
 VERSION_INFO_KEY = 'version'
@@ -781,7 +779,7 @@ class DatastoreProxy(AppDBInterface):
     except cassandra.InvalidRequest:
       return False
 
-    return version is not None and float(version) == EXPECTED_DATA_VERSION
+    return version is not None and float(version) == CURRENT_VERSION
 
   def group_updates(self, groups):
     """ Fetch the latest transaction IDs for each group.

--- a/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
+++ b/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
@@ -96,6 +96,7 @@ class ThriftColumn(object):
 class IndexStates(object):
   """ Possible states for datastore indexes. """
   CLEAN = 'clean'
+  DIRTY = 'dirty'
   SCRUB_IN_PROGRESS = 'scrub_in_progress'
 
 

--- a/AppDB/appscale/datastore/cassandra_env/constants.py
+++ b/AppDB/appscale/datastore/cassandra_env/constants.py
@@ -1,0 +1,4 @@
+""" Datastore constants specific to the Cassandra implementation. """
+
+# The current data layout version.
+CURRENT_VERSION = 2.0

--- a/AppDB/appscale/datastore/cassandra_env/schema.py
+++ b/AppDB/appscale/datastore/cassandra_env/schema.py
@@ -321,7 +321,7 @@ def prime_cassandra(replication):
   # Indicate that the database has been successfully primed.
   parameters = {'key': bytearray(cassandra_interface.PRIMED_KEY),
                 'column': cassandra_interface.PRIMED_KEY,
-                'value': bytearray('true')}
+                'value': bytearray(str(CURRENT_VERSION))}
   session.execute(metadata_insert, parameters)
   logging.info('Cassandra is primed.')
 
@@ -338,6 +338,7 @@ def primed():
     return False
 
   try:
-    return db_access.get_metadata(cassandra_interface.PRIMED_KEY) == 'true'
+    primed_version = db_access.get_metadata(cassandra_interface.PRIMED_KEY)
+    return primed_version == str(CURRENT_VERSION)
   finally:
     db_access.close()

--- a/AppDB/appscale/datastore/cassandra_env/schema.py
+++ b/AppDB/appscale/datastore/cassandra_env/schema.py
@@ -17,10 +17,8 @@ from .cassandra_interface import IndexStates
 from .cassandra_interface import INITIAL_CONNECT_RETRIES
 from .cassandra_interface import KEYSPACE
 from .cassandra_interface import ThriftColumn
+from .constants import CURRENT_VERSION
 from .. import dbconstants
-
-# The current data layout version.
-CURRENT_VERSION = 2.0
 
 # A policy that does not retry statements.
 NO_RETRIES = FallthroughRetryPolicy()
@@ -189,7 +187,7 @@ def current_datastore_version(session):
   Returns:
     A float specifying the existing datastore version or None.
   """
-  key = cassandra_interface.INDEX_STATE_KEY
+  key = cassandra_interface.VERSION_INFO_KEY
   statement = """
     SELECT {value} FROM "{table}"
     WHERE {key} = %s

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -542,13 +542,6 @@ class DatastoreDistributed():
       composite_indexes: A list or tuple of CompositeIndex objects.
     """
     self.logger.debug('Inserting {} entities'.format(len(entities)))
-    entity_keys = []
-    for entity in entities:
-      prefix = self.get_table_prefix(entity)
-      entity_keys.append(get_entity_key(prefix, entity.key().path()))
-
-    current_values = self.datastore_batch.batch_get_entity(
-      dbconstants.APP_ENTITY_TABLE, entity_keys, APP_ENTITY_SCHEMA)
 
     by_group = {}
     for entity in entities:
@@ -569,6 +562,12 @@ class DatastoreDistributed():
         lock.acquire()
       except entity_lock.LockTimeout:
         raise TimeoutError('Unable to acquire entity group lock')
+
+      entity_keys = [
+        get_entity_key(self.get_table_prefix(entity), entity.key().path())
+        for entity in entity_list]
+      current_values = self.datastore_batch.batch_get_entity(
+        dbconstants.APP_ENTITY_TABLE, entity_keys, APP_ENTITY_SCHEMA)
 
       batch = []
       entity_changes = []

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -560,6 +560,7 @@ class DatastoreDistributed():
       group_key = entity_pb.Reference(encoded_group_key)
 
       txid = self.transaction_manager.create_transaction_id(app, xg=False)
+      self.transaction_manager.set_groups(app, txid, [group_key])
       lock = entity_lock.EntityLock(self.zookeeper.handle, [group_key], txid)
       try:
         with lock:
@@ -896,6 +897,7 @@ class DatastoreDistributed():
         group_key = entity_pb.Reference(encoded_group_key)
 
         txid = self.transaction_manager.create_transaction_id(app_id, xg=False)
+        self.transaction_manager.set_groups(app_id, txid, [group_key])
         lock = entity_lock.EntityLock(self.zookeeper.handle, [group_key], txid)
         try:
           with lock:
@@ -3217,6 +3219,7 @@ class DatastoreDistributed():
                          for index in self.datastore_batch.get_indices(app)]
 
     decoded_groups = (entity_pb.Reference(group) for group in tx_groups)
+    self.transaction_manager.set_groups(app, txn, decoded_groups)
     lock = entity_lock.EntityLock(self.zookeeper.handle, decoded_groups, txn)
 
     with lock:

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -16,7 +16,7 @@ from kazoo.client import KazooState
 from .dbconstants import APP_ENTITY_SCHEMA
 from .dbconstants import ID_KEY_LENGTH
 from .dbconstants import MAX_TX_DURATION
-from .dbconstants import TimeoutError
+from .dbconstants import Timeout
 from .cassandra_env import cassandra_interface
 from .cassandra_env.entity_id_allocator import EntityIDAllocator
 from .cassandra_env.entity_id_allocator import ScatteredAllocator
@@ -561,7 +561,7 @@ class DatastoreDistributed():
       try:
         lock.acquire()
       except entity_lock.LockTimeout:
-        raise TimeoutError('Unable to acquire entity group lock')
+        raise Timeout('Unable to acquire entity group lock')
 
       entity_keys = [
         get_entity_key(self.get_table_prefix(entity), entity.key().path())
@@ -907,7 +907,7 @@ class DatastoreDistributed():
         try:
           lock.acquire()
         except entity_lock.LockTimeout:
-          raise TimeoutError('Unable to acquire entity group lock')
+          raise Timeout('Unable to acquire entity group lock')
 
         self.delete_entities(
           group_key,
@@ -3234,7 +3234,7 @@ class DatastoreDistributed():
     try:
       lock.acquire()
     except entity_lock.LockTimeout:
-      raise TimeoutError('Unable to acquire entity group locks')
+      raise Timeout('Unable to acquire entity group locks')
 
     group_txids = self.datastore_batch.group_updates(metadata['reads'])
     for group_txid in group_txids:
@@ -3313,8 +3313,7 @@ class DatastoreDistributed():
 
     try:
       self.apply_txn_changes(app_id, txn_id)
-    except (dbconstants.TxTimeoutException,
-            dbconstants.TimeoutError) as timeout:
+    except (dbconstants.TxTimeoutException, dbconstants.Timeout) as timeout:
       return commitres_pb.Encode(), datastore_pb.Error.TIMEOUT, str(timeout)
     except dbconstants.AppScaleDBConnectionError:
       self.logger.exception('DB connection error during commit')

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -17,7 +17,6 @@ from .dbconstants import APP_ENTITY_SCHEMA
 from .dbconstants import ID_KEY_LENGTH
 from .dbconstants import MAX_TX_DURATION
 from .dbconstants import Timeout
-from .cassandra_env import cassandra_interface
 from .cassandra_env.entity_id_allocator import EntityIDAllocator
 from .cassandra_env.entity_id_allocator import ScatteredAllocator
 from .cassandra_env.utils import deletions_for_entity
@@ -36,7 +35,6 @@ from .utils import reference_property_to_reference
 from .utils import UnprocessedQueryCursor
 from .zkappscale import entity_lock
 from .zkappscale import zktransaction
-from .zkappscale.transaction_manager import TransactionManager
 
 sys.path.append(APPSCALE_PYTHON_APPSERVER)
 from google.appengine.api import api_base_pb

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -16,6 +16,7 @@ from kazoo.client import KazooState
 from .dbconstants import APP_ENTITY_SCHEMA
 from .dbconstants import ID_KEY_LENGTH
 from .dbconstants import MAX_TX_DURATION
+from .dbconstants import TimeoutError
 from .cassandra_env import cassandra_interface
 from .cassandra_env.entity_id_allocator import EntityIDAllocator
 from .cassandra_env.entity_id_allocator import ScatteredAllocator
@@ -561,32 +562,38 @@ class DatastoreDistributed():
 
       txid = self.transaction_manager.create_transaction_id(app, xg=False)
       self.transaction_manager.set_groups(app, txid, [group_key])
+
+      # Allow the lock to stick around if there is an issue applying the batch.
       lock = entity_lock.EntityLock(self.zookeeper.handle, [group_key], txid)
       try:
-        with lock:
-          batch = []
-          entity_changes = []
-          for entity in entity_list:
-            prefix = self.get_table_prefix(entity)
-            entity_key = get_entity_key(prefix, entity.key().path())
+        lock.acquire()
+      except entity_lock.LockTimeout:
+        raise TimeoutError('Unable to acquire entity group lock')
 
-            current_value = None
-            if current_values[entity_key]:
-              current_value = entity_pb.EntityProto(
-                current_values[entity_key][APP_ENTITY_SCHEMA[0]])
+      batch = []
+      entity_changes = []
+      for entity in entity_list:
+        prefix = self.get_table_prefix(entity)
+        entity_key = get_entity_key(prefix, entity.key().path())
 
-            batch.extend(mutations_for_entity(entity, txid, current_value,
-                                              composite_indexes))
+        current_value = None
+        if current_values[entity_key]:
+          current_value = entity_pb.EntityProto(
+            current_values[entity_key][APP_ENTITY_SCHEMA[0]])
 
-            batch.append({'table': 'group_updates',
-                          'key': bytearray(encoded_group_key),
-                          'last_update': txid})
+        batch.extend(mutations_for_entity(entity, txid, current_value,
+                                          composite_indexes))
 
-            entity_changes.append(
-              {'key': entity.key(), 'old': current_value, 'new': entity})
-          self.datastore_batch.batch_mutate(app, batch, entity_changes, txid)
-      finally:
-        self.transaction_manager.delete_transaction_id(app, txid)
+        batch.append({'table': 'group_updates',
+                      'key': bytearray(encoded_group_key),
+                      'last_update': txid})
+
+        entity_changes.append(
+          {'key': entity.key(), 'old': current_value, 'new': entity})
+      self.datastore_batch.batch_mutate(app, batch, entity_changes, txid)
+
+      lock.release()
+      self.transaction_manager.delete_transaction_id(app, txid)
 
   def delete_entities(self, group, txid, keys, composite_indexes=()):
     """ Deletes the entities and the indexes associated with them.
@@ -658,10 +665,7 @@ class DatastoreDistributed():
       self.datastore_batch.put_entities_tx(
         app_id, put_request.transaction().handle(), entities)
     else:
-      try:
-        self.put_entities(app_id, entities, put_request.composite_index_list())
-      except entity_lock.LockTimeout as timeout_error:
-        raise dbconstants.AppScaleDBConnectionError(str(timeout_error))
+      self.put_entities(app_id, entities, put_request.composite_index_list())
       self.logger.debug('Updated {} entities'.format(len(entities)))
 
     put_response.key_list().extend([e.key() for e in entities])
@@ -898,20 +902,25 @@ class DatastoreDistributed():
 
         txid = self.transaction_manager.create_transaction_id(app_id, xg=False)
         self.transaction_manager.set_groups(app_id, txid, [group_key])
+
+        # Allow the lock to stick around if there is an issue applying the batch.
         lock = entity_lock.EntityLock(self.zookeeper.handle, [group_key], txid)
         try:
-          with lock:
-            self.delete_entities(
-              group_key,
-              txid,
-              key_list,
-              composite_indexes=filtered_indexes
-            )
-          self.logger.debug('Removed {} entities'.format(len(key_list)))
-        except entity_lock.LockTimeout as timeout_error:
-          raise dbconstants.AppScaleDBConnectionError(str(timeout_error))
-        finally:
-          self.transaction_manager.delete_transaction_id(app_id, txid)
+          lock.acquire()
+        except entity_lock.LockTimeout:
+          raise TimeoutError('Unable to acquire entity group lock')
+
+        self.delete_entities(
+          group_key,
+          txid,
+          key_list,
+          composite_indexes=filtered_indexes
+        )
+
+        lock.release()
+        self.logger.debug('Removed {} entities'.format(len(key_list)))
+
+        self.transaction_manager.delete_transaction_id(app_id, txid)
 
   def generate_filter_info(self, filters):
     """Transform a list of filters into a more usable form.
@@ -3220,60 +3229,70 @@ class DatastoreDistributed():
 
     decoded_groups = (entity_pb.Reference(group) for group in tx_groups)
     self.transaction_manager.set_groups(app, txn, decoded_groups)
+
+    # Allow the lock to stick around if there is an issue applying the batch.
     lock = entity_lock.EntityLock(self.zookeeper.handle, decoded_groups, txn)
+    try:
+      lock.acquire()
+    except entity_lock.LockTimeout:
+      raise TimeoutError('Unable to acquire entity group locks')
 
-    with lock:
-      group_txids = self.datastore_batch.group_updates(metadata['reads'])
-      for group_txid in group_txids:
-        if group_txid in metadata['in_progress'] or group_txid > txn:
-          raise dbconstants.ConcurrentModificationException(
-            'A group was modified after this transaction was started.')
+    group_txids = self.datastore_batch.group_updates(metadata['reads'])
+    for group_txid in group_txids:
+      if group_txid in metadata['in_progress'] or group_txid > txn:
+        lock.release()
+        self.transaction_manager.delete_transaction_id(app, txn)
+        raise dbconstants.ConcurrentModificationException(
+          'A group was modified after this transaction was started.')
 
-      # Fetch current values so we can remove old indices.
-      entity_table_keys = [encode_entity_table_key(key)
-                           for key, _ in metadata['puts'].iteritems()]
-      entity_table_keys.extend([encode_entity_table_key(key)
-                                for key in metadata['deletes']])
-      current_values = self.datastore_batch.batch_get_entity(
-        dbconstants.APP_ENTITY_TABLE, entity_table_keys, APP_ENTITY_SCHEMA)
+    # Fetch current values so we can remove old indices.
+    entity_table_keys = [encode_entity_table_key(key)
+                         for key, _ in metadata['puts'].iteritems()]
+    entity_table_keys.extend([encode_entity_table_key(key)
+                              for key in metadata['deletes']])
+    current_values = self.datastore_batch.batch_get_entity(
+      dbconstants.APP_ENTITY_TABLE, entity_table_keys, APP_ENTITY_SCHEMA)
 
-      batch = []
-      entity_changes = []
-      for encoded_key, encoded_entity in metadata['puts'].iteritems():
-        key = entity_pb.Reference(encoded_key)
-        entity_table_key = encode_entity_table_key(key)
-        current_value = None
-        if current_values[entity_table_key]:
-          current_value = entity_pb.EntityProto(
-            current_values[entity_table_key][APP_ENTITY_SCHEMA[0]])
-
-        entity = entity_pb.EntityProto(encoded_entity)
-        mutations = mutations_for_entity(entity, txn, current_value,
-                                         composite_indices)
-        batch.extend(mutations)
-
-        entity_changes.append({'key': key, 'old': current_value,
-                               'new': entity})
-
-      for key in metadata['deletes']:
-        entity_table_key = encode_entity_table_key(key)
-        if not current_values[entity_table_key]:
-          continue
-
+    batch = []
+    entity_changes = []
+    for encoded_key, encoded_entity in metadata['puts'].iteritems():
+      key = entity_pb.Reference(encoded_key)
+      entity_table_key = encode_entity_table_key(key)
+      current_value = None
+      if current_values[entity_table_key]:
         current_value = entity_pb.EntityProto(
           current_values[entity_table_key][APP_ENTITY_SCHEMA[0]])
 
-        deletions = deletions_for_entity(current_value, composite_indices)
-        batch.extend(deletions)
+      entity = entity_pb.EntityProto(encoded_entity)
+      mutations = mutations_for_entity(entity, txn, current_value,
+                                       composite_indices)
+      batch.extend(mutations)
 
-        entity_changes.append({'key': key, 'old': current_value, 'new': None})
+      entity_changes.append({'key': key, 'old': current_value,
+                             'new': entity})
 
-      for group in groups_mutated:
-        batch.append(
-          {'table': 'group_updates', 'key': bytearray(group),
-           'last_update': txn})
+    for key in metadata['deletes']:
+      entity_table_key = encode_entity_table_key(key)
+      if not current_values[entity_table_key]:
+        continue
 
-      self.datastore_batch.batch_mutate(app, batch, entity_changes, txn)
+      current_value = entity_pb.EntityProto(
+        current_values[entity_table_key][APP_ENTITY_SCHEMA[0]])
+
+      deletions = deletions_for_entity(current_value, composite_indices)
+      batch.extend(deletions)
+
+      entity_changes.append({'key': key, 'old': current_value, 'new': None})
+
+    for group in groups_mutated:
+      batch.append(
+        {'table': 'group_updates', 'key': bytearray(group),
+         'last_update': txn})
+
+    self.datastore_batch.batch_mutate(app, batch, entity_changes, txn)
+
+    lock.release()
+    self.transaction_manager.delete_transaction_id(app, txn)
 
     # Process transactional tasks.
     if metadata['tasks']:
@@ -3295,7 +3314,8 @@ class DatastoreDistributed():
 
     try:
       self.apply_txn_changes(app_id, txn_id)
-    except dbconstants.TxTimeoutException as timeout:
+    except (dbconstants.TxTimeoutException,
+            dbconstants.TimeoutError) as timeout:
       return commitres_pb.Encode(), datastore_pb.Error.TIMEOUT, str(timeout)
     except dbconstants.AppScaleDBConnectionError:
       self.logger.exception('DB connection error during commit')
@@ -3304,17 +3324,10 @@ class DatastoreDistributed():
     except dbconstants.ConcurrentModificationException as error:
       return (commitres_pb.Encode(), datastore_pb.Error.CONCURRENT_TRANSACTION,
               str(error))
-    except dbconstants.TooManyGroupsException as error:
+    except (dbconstants.TooManyGroupsException,
+            dbconstants.BadRequest) as error:
       return (commitres_pb.Encode(), datastore_pb.Error.BAD_REQUEST,
               str(error))
-    except entity_lock.LockTimeout as error:
-      return (commitres_pb.Encode(), datastore_pb.Error.TIMEOUT,
-              str(error))
-
-    try:
-      self.transaction_manager.delete_transaction_id(app_id, txn_id)
-    except dbconstants.BadRequest as error:
-      return '', datastore_pb.Error.BAD_REQUEST, str(error)
 
     return commitres_pb.Encode(), 0, ""
 

--- a/AppDB/appscale/datastore/dbconstants.py
+++ b/AppDB/appscale/datastore/dbconstants.py
@@ -197,7 +197,7 @@ class InternalError(Exception):
   """ Indicates that the datastore was unable to perform an operation. """
   pass
 
-class TimeoutError(Exception):
+class Timeout(Exception):
   """ Indicates that the datastore timed out while performing an operation. """
   pass
 

--- a/AppDB/appscale/datastore/dbconstants.py
+++ b/AppDB/appscale/datastore/dbconstants.py
@@ -197,6 +197,10 @@ class InternalError(Exception):
   """ Indicates that the datastore was unable to perform an operation. """
   pass
 
+class TimeoutError(Exception):
+  """ Indicates that the datastore timed out while performing an operation. """
+  pass
+
 class TooManyGroupsException(Exception):
   """ Indicates that there are too many groups involved in a transaction. """
   pass

--- a/AppDB/appscale/datastore/groomer.py
+++ b/AppDB/appscale/datastore/groomer.py
@@ -396,14 +396,11 @@ class DatastoreGroomer(threading.Thread):
       start_key = ''
     end_key = dbconstants.TERMINATING_STRING
 
-    # Indicate that an index scrub has started after the journal was removed.
+    # Indicate that an index scrub has started.
     if direction == datastore_pb.Query_Order.ASCENDING and not start_key:
-      index_state = self.db_access.get_metadata(
-        cassandra_interface.INDEX_STATE_KEY)
-      if index_state is None:
-        self.db_access.set_metadata(
-          cassandra_interface.INDEX_STATE_KEY,
-          cassandra_interface.IndexStates.SCRUB_IN_PROGRESS)
+      self.db_access.set_metadata(
+        cassandra_interface.INDEX_STATE_KEY,
+        cassandra_interface.IndexStates.SCRUB_IN_PROGRESS)
 
     while True:
       references = self.db_access.range_query(

--- a/AppDB/appscale/datastore/scripts/datastore.py
+++ b/AppDB/appscale/datastore/scripts/datastore.py
@@ -645,6 +645,8 @@ class MainHandler(tornado.web.RequestHandler):
       return (putresp_pb.Encode(), 0, "")
     except dbconstants.InternalError as error:
       return '', datastore_pb.Error.INTERNAL_ERROR, str(error)
+    except dbconstants.TimeoutError as error:
+      return '', datastore_pb.Error.TIMEOUT, str(error)
     except dbconstants.BadRequest as error:
       return '', datastore_pb.Error.BAD_REQUEST, str(error)
     except zktransaction.ZKBadRequest as zkie:
@@ -732,6 +734,8 @@ class MainHandler(tornado.web.RequestHandler):
       return (delresp_pb.Encode(), 0, "")
     except dbconstants.InternalError as error:
       return '', datastore_pb.Error.INTERNAL_ERROR, str(error)
+    except dbconstants.TimeoutError as error:
+      return '', datastore_pb.Error.TIMEOUT, str(error)
     except dbconstants.BadRequest as error:
       return '', datastore_pb.Error.BAD_REQUEST, str(error)
     except zktransaction.ZKBadRequest as zkie:

--- a/AppDB/appscale/datastore/scripts/datastore.py
+++ b/AppDB/appscale/datastore/scripts/datastore.py
@@ -645,7 +645,7 @@ class MainHandler(tornado.web.RequestHandler):
       return (putresp_pb.Encode(), 0, "")
     except dbconstants.InternalError as error:
       return '', datastore_pb.Error.INTERNAL_ERROR, str(error)
-    except dbconstants.TimeoutError as error:
+    except dbconstants.Timeout as error:
       return '', datastore_pb.Error.TIMEOUT, str(error)
     except dbconstants.BadRequest as error:
       return '', datastore_pb.Error.BAD_REQUEST, str(error)
@@ -734,7 +734,7 @@ class MainHandler(tornado.web.RequestHandler):
       return (delresp_pb.Encode(), 0, "")
     except dbconstants.InternalError as error:
       return '', datastore_pb.Error.INTERNAL_ERROR, str(error)
-    except dbconstants.TimeoutError as error:
+    except dbconstants.Timeout as error:
       return '', datastore_pb.Error.TIMEOUT, str(error)
     except dbconstants.BadRequest as error:
       return '', datastore_pb.Error.BAD_REQUEST, str(error)

--- a/AppDB/appscale/datastore/scripts/prime_cassandra.py
+++ b/AppDB/appscale/datastore/scripts/prime_cassandra.py
@@ -6,9 +6,6 @@ import logging
 from appscale.common.constants import LOG_FORMAT
 from ..cassandra_env import schema
 
-# The data layout version to set after removing the journal table.
-POST_JOURNAL_VERSION = 1.0
-
 
 def main():
   logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)

--- a/AppDB/appscale/datastore/zkappscale/entity_lock.py
+++ b/AppDB/appscale/datastore/zkappscale/entity_lock.py
@@ -211,8 +211,7 @@ class EntityLock(object):
       while True:
         try:
           node = self.client.create(
-            self.create_paths[index], self.data, ephemeral=True,
-            sequence=True)
+            self.create_paths[index], self.data, sequence=True)
           break
         except NoNodeError:
           self.client.ensure_path(self.paths[index])

--- a/AppDB/appscale/datastore/zkappscale/transaction_manager.py
+++ b/AppDB/appscale/datastore/zkappscale/transaction_manager.py
@@ -7,7 +7,6 @@ import time
 
 from kazoo.exceptions import KazooException
 from kazoo.exceptions import NodeExistsError
-from kazoo.exceptions import NotEmptyError
 from tornado.ioloop import IOLoop
 
 from appscale.common.async_retrying import retry_children_watch_coroutine

--- a/AppDB/appscale/datastore/zkappscale/transaction_manager.py
+++ b/AppDB/appscale/datastore/zkappscale/transaction_manager.py
@@ -1,6 +1,7 @@
 """ Generates and keeps track of transaction IDs. """
 from __future__ import division
 
+import json
 import logging
 import time
 
@@ -14,6 +15,7 @@ from .constants import CONTAINER_PREFIX
 from .constants import COUNTER_NODE_PREFIX
 from .constants import MAX_SEQUENCE_COUNTER
 from .constants import OFFSET_NODE
+from .entity_lock import zk_group_path
 from ..dbconstants import BadRequest
 from ..dbconstants import InternalError
 
@@ -103,20 +105,8 @@ class ProjectTransactionManager(object):
     Args:
       txid: An integer specifying a transaction ID.
     """
-    corrected_counter = txid - self._txid_manual_offset
-
-    # The number of counters a container can store (including 0).
-    container_size = MAX_SEQUENCE_COUNTER + 1
-
-    container_count = int(corrected_counter / container_size) + 1
-    container_suffix = '' if container_count == 1 else str(container_count)
-    container_name = CONTAINER_PREFIX + container_suffix
-    container_path = '/'.join([self._project_node, container_name])
-
-    counter_value = corrected_counter % container_size
-    node_name = COUNTER_NODE_PREFIX + str(counter_value).zfill(10)
-    full_path = '/'.join([container_path, node_name])
-    self._delete_counter(full_path)
+    path = self._txid_to_path(txid)
+    self._delete_counter(path)
 
   def get_open_transactions(self):
     """ Fetches a list of active transactions.
@@ -152,6 +142,23 @@ class ProjectTransactionManager(object):
 
     return txids
 
+  def set_groups(self, txid, groups):
+    """ Defines which groups will be involved in a transaction.
+
+    Args:
+      txid: An integer specifying a transaction ID.
+      groups: An iterable of entity group Reference objects.
+    """
+    txid_path = self._txid_to_path(txid)
+    groups_path = '/'.join([txid_path, 'groups'])
+    encoded_groups = [zk_group_path(group) for group in groups]
+    try:
+      self.zk_client.create(groups_path, value=json.dumps(encoded_groups))
+    except KazooException:
+      message = 'Unable to set lock list for transaction'
+      logger.exception(message)
+      raise InternalError(message)
+
   def _delete_counter(self, path):
     """ Removes a counter node.
 
@@ -159,11 +166,7 @@ class ProjectTransactionManager(object):
       path: A string specifying a ZooKeeper path.
     """
     try:
-      try:
-        self.zk_client.delete(path)
-      except NotEmptyError:
-        # Cross-group transaction nodes have a child node.
-        self.zk_client.delete(path, recursive=True)
+      self.zk_client.delete(path, recursive=True)
     except KazooException:
       # Let the transaction groomer clean it up.
       logger.exception('Unable to delete counter')
@@ -184,6 +187,28 @@ class ProjectTransactionManager(object):
     return tuple('/'.join([self._project_node, container])
                  for container in all_containers
                  if container not in self._inactive_containers)
+
+  def _txid_to_path(self, txid):
+    """ Determines the ZooKeeper path for a given transaction ID.
+
+    Args:
+      txid: An integer specifying a transaction ID.
+    Returns:
+      A strings specifying the transaction's ZooKeeper path.
+    """
+    corrected_counter = txid - self._txid_manual_offset
+
+    # The number of counters a container can store (including 0).
+    container_size = MAX_SEQUENCE_COUNTER + 1
+
+    container_count = int(corrected_counter / container_size) + 1
+    container_suffix = '' if container_count == 1 else str(container_count)
+    container_name = CONTAINER_PREFIX + container_suffix
+    container_path = '/'.join([self._project_node, container_name])
+
+    counter_value = corrected_counter % container_size
+    node_name = COUNTER_NODE_PREFIX + str(counter_value).zfill(10)
+    return '/'.join([container_path, node_name])
 
   def _update_auto_offset(self):
     """ Ensures there is a usable sequence container. """
@@ -307,6 +332,21 @@ class TransactionManager(object):
       raise BadRequest('The project {} was not found'.format(project_id))
 
     return project_tx_manager.get_open_transactions()
+
+  def set_groups(self, project_id, txid, groups):
+    """ Defines which groups will be involved in a transaction.
+
+    Args:
+      project_id: A string specifying a project ID.
+      txid: An integer specifying a transaction ID.
+      groups: An iterable of entity group Reference objects.
+    """
+    try:
+      project_tx_manager = self.projects[project_id]
+    except KeyError:
+      raise BadRequest('The project {} was not found'.format(project_id))
+
+    return project_tx_manager.set_groups(txid, groups)
 
   def _update_projects_sync(self, new_project_ids):
     """ Updates the available projects for starting transactions.

--- a/AppDB/test/unit/test_datastore_server.py
+++ b/AppDB/test/unit/test_datastore_server.py
@@ -371,7 +371,8 @@ class TestDatastoreServer(unittest.TestCase):
     db_batch.should_receive('batch_mutate')
     transaction_manager = flexmock(
       create_transaction_id=lambda project, xg: 1,
-      delete_transaction_id=lambda project, txid: None)
+      delete_transaction_id=lambda project, txid: None,
+      set_groups=lambda project, txid, groups: None)
     dd = DatastoreDistributed(db_batch, transaction_manager,
                               self.get_zookeeper())
     putreq_pb = datastore_pb.PutRequest()
@@ -410,7 +411,8 @@ class TestDatastoreServer(unittest.TestCase):
     db_batch.should_receive('batch_mutate')
     transaction_manager = flexmock(
       create_transaction_id=lambda project, xg: 1,
-      delete_transaction_id=lambda project, txid: None)
+      delete_transaction_id=lambda project, txid: None,
+      set_groups=lambda project, txid, groups: None)
     dd = DatastoreDistributed(db_batch, transaction_manager,
                               self.get_zookeeper())
 
@@ -718,7 +720,8 @@ class TestDatastoreServer(unittest.TestCase):
     db_batch.should_receive('valid_data_version').and_return(True)
     transaction_manager = flexmock(
       create_transaction_id=lambda project, xg: 1,
-      delete_transaction_id=lambda project, txid: None)
+      delete_transaction_id=lambda project, txid: None,
+      set_groups=lambda project_id, txid, groups: None)
     dd = DatastoreDistributed(db_batch, transaction_manager,
                               self.get_zookeeper())
     dd.dynamic_delete("appid", del_request)
@@ -1056,7 +1059,9 @@ class TestDatastoreServer(unittest.TestCase):
 
     db_batch.should_receive('get_indices').and_return([])
 
-    transaction_manager = flexmock()
+    transaction_manager = flexmock(
+      delete_transaction_id=lambda project_id, txid: None,
+      set_groups=lambda project_id, txid, groups: None)
     dd = DatastoreDistributed(db_batch, transaction_manager,
                               self.get_zookeeper())
     prefix = dd.get_table_prefix(entity)

--- a/scripts/datastore_upgrade.py
+++ b/scripts/datastore_upgrade.py
@@ -15,6 +15,7 @@ from appscale.datastore.dbconstants import APP_ENTITY_TABLE
 from appscale.datastore.dbconstants import ID_KEY_LENGTH
 from appscale.datastore.dbconstants import TOMBSTONE
 from appscale.datastore.cassandra_env import cassandra_interface
+from appscale.datastore.cassandra_env.constants import CURRENT_VERSION
 from appscale.datastore.zkappscale import zktransaction as zk
 from appscale.datastore.zkappscale.zktransaction import ZK_SERVER_CMD_LOCATIONS
 from appscale.datastore.zkappscale.zktransaction import ZKInternalException
@@ -427,7 +428,7 @@ def run_datastore_upgrade(db_access, zookeeper, log_postfix, total_entities):
 
   # Update the data version.
   db_access.set_metadata(cassandra_interface.VERSION_INFO_KEY,
-                         str(cassandra_interface.EXPECTED_DATA_VERSION))
+                         str(CURRENT_VERSION))
   logging.info('Stored the data version successfully.')
 
   db_access.delete_table(dbconstants.JOURNAL_TABLE)


### PR DESCRIPTION
This prevents other clients from writing to a group before a large batch is fully applied. During each commit, there is now an additional ZooKeeper write to the transaction ID node that associates a list of entity groups with the transaction.

This pull request also fixes an issue where reads during puts (to determine index deletions) were not performed inside of a group lock. The fix may slightly decrease performance.

Finally, this pull request fixes an issue where transaction IDs were not cleaned up after a ConcurrentModificationError (when one of the groups that were read for a transaction was updated after the transaction started).