### PR TITLE
Don't allow editing entities with datastore viewer

### DIFF
--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -599,52 +599,5 @@ class DatastoreEditRequestHandler(DatastoreViewerPage):
       project_id: A string specifying the project ID.
       entity_key_string: A string specifying the entity key.
     """
-    self.ensure_user_has_admin(project_id)
-
-    ds_access = DatastoreDistributed(project_id, DATASTORE_LOCATION,
-                                     require_indexes=False, trusted=True)
-
-    if self.request.get('action:delete'):
-      if entity_key_string:
-        _delete_entities(ds_access, [datastore.Key(entity_key_string)])
-        redirect_url = self.request.get(
-          'next', '/datastore_viewer/{}'.format(project_id))
-        self.redirect(str(redirect_url))
-      else:
-        self.response.set_status(400)
-      return
-
-    if entity_key_string:
-      entity = _get_entity_by_key(ds_access, datastore.Key(entity_key_string))
-    else:
-      kind = self.request.get('kind')
-      namespace = self.request.get('namespace', None)
-      entity = datastore.Entity(kind, _namespace=namespace)
-
-    for arg_name in self.request.arguments():
-      # Arguments are in <property_type>|<property_name>=<value> format.
-      if '|' not in arg_name:
-        continue
-      data_type_name, property_name = arg_name.split('|')
-      form_value = self.request.get(arg_name)
-      data_type = DataType.get_by_name(data_type_name)
-      if (entity and
-          property_name in entity and
-          data_type.format(entity[property_name]) == form_value):
-        # If the property is unchanged then don't update it. This will prevent
-        # empty form values from causing the property to be deleted if the
-        # property was already empty.
-        continue
-
-      if form_value:
-        # TODO: Handle parse exceptions.
-        entity[property_name] = data_type.parse(form_value)
-      elif property_name in entity:
-        # TODO: Treating empty input as deletion is a not a good
-        # interface.
-        del entity[property_name]
-
-    _put_entity(ds_access, entity)
-    redirect_url = self.request.get(
-      'next', '/datastore_viewer/{}'.format(project_id))
-    self.redirect(str(redirect_url))
+    raise NotImplementedError(
+      'Editing entities with the datastore viewer is not supported')

--- a/AppDashboard/templates/datastore/edit.html
+++ b/AppDashboard/templates/datastore/edit.html
@@ -1,8 +1,8 @@
 <div id="datastore-viewer">
   <div class="page-header">
-    <h1>Datastore Editor - {% if key %}Edit Entity{% else %}New Entity{% endif %}</h1>
+    <h1>Datastore Editor - {% if key %}View Entity{% else %}New Entity{% endif %}</h1>
     <h3>{{ project_id }} >
-      {% if key %}Edit &quot;{{ kind }}&quot; Entity{% else %}New &quot;{{ kind }}&quot; Entity{% endif %}</h3>
+      {% if key %}View &quot;{{ kind }}&quot; Entity{% else %}New &quot;{{ kind }}&quot; Entity{% endif %}</h3>
   </div>
 
   <form action="{{ request.path }}" method="post">
@@ -72,14 +72,6 @@
         <div>{{ field.2|safe }}</div>
       </div>
     {% endfor %}
-    <div class="ae-settings-block">
-      <div>
-        <input class="ae-button ae-button-submit" type="submit" value="Save Changes"/>
-        {% if key %}
-          <input id="delete_button" class="ae-button" type="submit" name="action:delete" value="Delete"/>
-        {% endif %}
-      </div>
-    </div>
   </form>
 </div>
 <script>{% include "datastore/edit.js" %}</script>

--- a/AppDashboard/templates/datastore/viewer.html
+++ b/AppDashboard/templates/datastore/viewer.html
@@ -56,7 +56,6 @@
               </td>
               <td>
                 <input type="submit" class="ae-button" value="List Entities"/>
-                <input type="button" id="create_button" class="ae-button" value="Create New Entity"/>
                 {% if not show_namespace %}
                   <a href="{{ select_namespace_url }}">Select a different namespace</a>
                 {% endif %}

--- a/AppServer/google/appengine/tools/devappserver2/admin/datastore_viewer.py
+++ b/AppServer/google/appengine/tools/devappserver2/admin/datastore_viewer.py
@@ -184,7 +184,7 @@ class DataType(object):
   def input_field(self, name, value, sample_values, back_uri):
     string_value = self.format(value) if value else ''
     return (
-        '<input class="%s" name="%s" type="text" size="%d" value="%s" %s/>' % (
+        '<input disabled class="%s" name="%s" type="text" size="%d" value="%s" %s/>' % (
             cgi.escape(self.name()),
             cgi.escape(name),
             self.input_field_size(),


### PR DESCRIPTION
The editing feature needs additional testing to ensure certain inputs do not have unintended side effects.