### PR TITLE
RM-589 handle failure on fetching local stats

### DIFF
--- a/Hermes/appscale/hermes/stats/producers/cluster_stats.py
+++ b/Hermes/appscale/hermes/stats/producers/cluster_stats.py
@@ -58,12 +58,12 @@ class ClusterStatsSource(object):
     stats_per_node = {
       ip: snapshot_or_err
       for ip, snapshot_or_err in stats_or_error_per_node.iteritems()
-      if not isinstance(snapshot_or_err, str)
+      if not isinstance(snapshot_or_err, (str, unicode))
     }
     failures = {
       ip: snapshot_or_err
       for ip, snapshot_or_err in stats_or_error_per_node.iteritems()
-      if isinstance(snapshot_or_err, str)
+      if isinstance(snapshot_or_err, (str, unicode))
     }
     logging.info("Fetched {stats} from {nodes} nodes in {elapsed:.1f}s."
                  .format(stats=self.stats_model.__name__,
@@ -74,7 +74,12 @@ class ClusterStatsSource(object):
   @gen.coroutine
   def _stats_from_node_async(self, node_ip, max_age, include_lists):
     if node_ip == appscale_info.get_private_ip():
-      snapshot = self.local_stats_source.get_current()
+      try:
+        snapshot = self.local_stats_source.get_current()
+      except Exception as err:
+        snapshot = unicode(err)
+        logging.exception(
+          u"Failed to prepare local stats: {err}".format(err=err))
     else:
       snapshot = yield self._fetch_remote_stats_async(
         node_ip, max_age, include_lists)
@@ -104,16 +109,16 @@ class ClusterStatsSource(object):
     if response.code >= 400:
       if response.body:
         logging.error(
-          "Failed to get stats from {url} ({code} {reason}, BODY: {body})"
+          u"Failed to get stats from {url} ({code} {reason}, BODY: {body})"
           .format(url=url, code=response.code, reason=response.reason,
                   body=response.body)
         )
       else:
         logging.error(
-          "Failed to get stats from {url} ({code} {reason})"
+          u"Failed to get stats from {url} ({code} {reason})"
           .format(url=url, code=response.code, reason=response.reason)
         )
-      raise gen.Return("{} {}".format(response.code, response.reason))
+      raise gen.Return(u"{} {}".format(response.code, response.reason))
 
     try:
       snapshot = json.loads(response.body)

--- a/Hermes/appscale/hermes/stats/producers/tests/test_cluster_stats.py
+++ b/Hermes/appscale/hermes/stats/producers/tests/test_cluster_stats.py
@@ -84,8 +84,8 @@ class TestClusterNodeStatsProducer(testing.AsyncTestCase):
   @patch.object(cluster_stats.httpclient.AsyncHTTPClient, 'fetch')
   @patch.object(node_stats.NodeStatsSource, 'get_current')
   @testing.gen_test
-  def test_failure_of_node(self, mock_get_current, mock_fetch,
-                           mock_ips_getter, mock_get_private_ip, mock_options):
+  def test_remote_failure(self, mock_get_current, mock_fetch,
+                          mock_ips_getter, mock_get_private_ip, mock_options):
     # Mock appscale_info functions for getting IPs
     mock_get_private_ip.return_value = '192.168.33.10'
     mock_ips_getter.return_value = ['192.168.33.10', '192.168.33.11']
@@ -126,6 +126,27 @@ class TestClusterNodeStatsProducer(testing.AsyncTestCase):
     self.assertEqual(local_stats.utc_timestamp, 1494248091.0)
     self.assertEqual(failures, {'192.168.33.11': '500 Timeout error'})
 
+  @patch.object(cluster_stats.appscale_info, 'get_private_ip')
+  @patch.object(cluster_stats.ClusterNodesStatsSource, 'ips_getter')
+  @patch.object(node_stats.NodeStatsSource, 'get_current')
+  @testing.gen_test
+  def test_local_failure(self, mock_get_current, mock_ips_getter,
+                         mock_get_private_ip):
+    # Mock appscale_info functions for getting IPs
+    mock_get_private_ip.return_value = '192.168.33.10'
+    mock_ips_getter.return_value = ['192.168.33.10']
+    # Mock local source
+    mock_get_current.side_effect = ValueError(u"Something strange \u2234")
+    # Initialize cluster stats source
+    cluster_stats_source = cluster_stats.ClusterNodesStatsSource()
+
+    # ^^^ ALL INPUTS ARE SPECIFIED (or mocked) ^^^
+    # Call method under test
+    stats, failures = yield cluster_stats_source.get_current_async()
+
+    # ASSERTING EXPECTATIONS
+    self.assertEqual(stats, {})
+    self.assertEqual(failures, {'192.168.33.10': u"Something strange \u2234"})
 
   @patch.object(cluster_stats, 'options')
   @patch.object(cluster_stats.appscale_info, 'get_private_ip')


### PR DESCRIPTION
https://redmine.appscale.com/issues/589
This bug was found when haproxy process failed on one deployment at master node.
When `/cluster/stats/proxies` endpoint was queried master node attempted to get local stats and failed to get haproxy stats - it failed badly and returned 500 error.
Instead, it should report this failure as following: 
```{
"failures": {"<local_ip>": "Connection refused: ..."}
"stats": {"<active_lb_ip>": { ...<normal_stats>... }}
}```