### PR TITLE
Ensure haproxy configuration is up-to-date

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1358,7 +1358,6 @@ class Djinn
         end
         Djinn.log_info("Reload haproxy with new connect timeout.")
         HAProxy.initialize_config(val)
-        HAProxy.regenerate_config
       end
 
       @options[key] = val

--- a/AppController/lib/haproxy.rb
+++ b/AppController/lib/haproxy.rb
@@ -180,17 +180,13 @@ module HAProxy
       config << "\n  timeout server #{ALB_SERVER_TIMEOUT}\n"
     end
 
-    # Let's reload and overwrite only if something changed.
+    # Let's overwrite configuration for 'name' only if anything changed.
     current = ''
     current = File.read(config_path) if File.exists?(config_path)
-    if current != config
-      File.open(config_path, 'w+') { |dest_file| dest_file.write(config) }
-      HAProxy.regenerate_config
-    else
-      Djinn.log_debug("No need to restart haproxy: configuration didn't change.")
-    end
+    File.open(config_path, 'w+') { |f| f.write(config) } if current != config
 
-    true
+    # This will reload haproxy if anything changed.
+    HAProxy.regenerate_config
   end
 
   # Generates a load balancer configuration file. Since HAProxy doesn't provide


### PR DESCRIPTION
We do use a similar schema to what nginx/apache is using on debian's
based systems, with a 'enable.d' directory to allow for custom
configuration to haproxy to be added. This PR ensure that when those
custom configurations are changed, the main configuration is rebuilt.