### PR TITLE
Use datastore server registry to toggle read-only mode

### DIFF
--- a/AppController/lib/datastore_server.rb
+++ b/AppController/lib/datastore_server.rb
@@ -82,15 +82,4 @@ module DatastoreServer
   def self.get_executable_name
     `which appscale-datastore`.chomp
   end
-
-  # Tell each of the datastore servers on this node to disable writes.
-  def self.set_read_only_mode(read_only)
-    ports = get_server_ports
-    ports.each { |port|
-      http = Net::HTTP.new('localhost', port)
-      request = Net::HTTP::Post.new('/read-only')
-      request.body = { 'readOnly' => read_only }.to_json
-      http.request(request)
-    }
-  end
 end

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -443,7 +443,7 @@ class ZKInterface
     return JSON.load(cron_config_json)
   end
 
-  def self.get_datastore_servers()
+  def self.get_datastore_servers
     return get_children('/appscale/datastore/servers').map { |server|
       server = server.split(':')
       server[1] = server[1].to_i

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -443,6 +443,14 @@ class ZKInterface
     return JSON.load(cron_config_json)
   end
 
+  def self.get_datastore_servers()
+    return get_children('/appscale/datastore/servers').map { |server|
+      server = server.split(':')
+      server[1] = server[1].to_i
+      server
+    }
+  end
+
   # Defines deployment-wide defaults for runtime parameters.
   def self.set_runtime_params(parameters)
     runtime_params_node = '/appscale/config/runtime_parameters'

--- a/AppController/lib/zkinterface.rb
+++ b/AppController/lib/zkinterface.rb
@@ -50,6 +50,9 @@ class ZKInterface
   # ports that each AppServer binds to).
   APPSERVER_STATE_PATH = "#{APPCONTROLLER_PATH}/appservers".freeze
 
+  # The ZooKeeper node where datastore servers register themselves.
+  DATASTORE_REGISTRY_PATH = '/appscale/datastore/servers'
+
   # The location in ZooKeeper that contains a list of the IP addresses that
   # are currently running within AppScale.
   IP_LIST = "#{APPCONTROLLER_PATH}/ips".freeze
@@ -444,7 +447,7 @@ class ZKInterface
   end
 
   def self.get_datastore_servers
-    return get_children('/appscale/datastore/servers').map { |server|
+    return get_children(DATASTORE_REGISTRY_PATH).map { |server|
       server = server.split(':')
       server[1] = server[1].to_i
       server


### PR DESCRIPTION
This anticipates moving datastore servers away from set locations.