### PR TITLE
Retry creating system users when AppScale starts

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4515,7 +4515,7 @@ HOSTS
     rescue InternalError, FailedNodeException
       Djinn.log_warn('Failed to create a new user')
       retries += 1
-      if retries < 5
+      if retries < RETRIES
         sleep(SMALL_WAIT)
         retry
       else
@@ -5939,7 +5939,7 @@ HOSTS
     rescue InternalError
       Djinn.log_warn('Failed to create a new user')
       retries += 1
-      if retries < 5
+      if retries < RETRIES
         sleep(SMALL_WAIT)
         retry
       else

--- a/AppController/lib/custom_exceptions.rb
+++ b/AppController/lib/custom_exceptions.rb
@@ -15,6 +15,10 @@ end
 class InvalidSource < StandardError
 end
 
+# Indicates that a service was unable to complete a correctly-formed request.
+class InternalError < StandardError
+end
+
 # A class of exceptions that can be thrown if the AppController believes that
 # the node it is talking to has failed.
 class FailedNodeException < AppScaleException

--- a/AppController/lib/user_app_client.rb
+++ b/AppController/lib/user_app_client.rb
@@ -88,10 +88,9 @@ class UserAppClient
     if result == 'true'
       puts "\nYour user account has been created successfully."
     elsif result == 'false'
-      HelperFunctions.log_and_crash("\nWe were unable to create your user " \
-        'account. Please contact your cloud administrator for further details.')
+      raise InternalError.new('Unable to create user')
     else
-      puts "\n[unexpected] Commit new user returned: [#{result}]"
+      raise InternalError.new(result)
     end
     result
   end


### PR DESCRIPTION
If the UAServer is down, the AppController will retry the operation a few times instead of crashing immediately.