### PR TITLE
Consider the version's previous ports as available

### DIFF
--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -385,6 +385,10 @@ def assign_ports(old_version, new_version, zk_client):
 
   taken_locations = assigned_locations(zk_client)
 
+  # Consider the version's old ports as available.
+  taken_locations.remove(old_http_port)
+  taken_locations.remove(old_https_port)
+
   # If ports were requested, make sure they are available.
   if new_http_port is not None and new_http_port in taken_locations:
     raise CustomHTTPError(HTTPCodes.BAD_REQUEST,

--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -386,8 +386,8 @@ def assign_ports(old_version, new_version, zk_client):
   taken_locations = assigned_locations(zk_client)
 
   # Consider the version's old ports as available.
-  taken_locations.remove(old_http_port)
-  taken_locations.remove(old_https_port)
+  taken_locations.discard(old_http_port)
+  taken_locations.discard(old_https_port)
 
   # If ports were requested, make sure they are available.
   if new_http_port is not None and new_http_port in taken_locations:


### PR DESCRIPTION
Without this, it's not possible to relocate just one port (eg. 8080/4380 -> 8080/443).