### PR TITLE
Replace gen.Return() with bare return statements

### DIFF
--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -381,7 +381,7 @@ class ProjectHandler(BaseVersionHandler):
       if time.time() > deadline:
         logger.error('Delete operation took too long (project_id: {}).'
                      .format(project_id))
-        raise gen.Return()
+        return
       to_remove = []
       for http_port in ports:
         # If the port is open, continue to process other ports.

--- a/AppDB/appscale/datastore/cassandra_env/large_batch.py
+++ b/AppDB/appscale/datastore/cassandra_env/large_batch.py
@@ -256,7 +256,7 @@ class BatchResolver(object):
     except BatchNotFound:
       # Make sure another process doesn't try to commit the transaction.
       yield self._insert(txid_hash, new_op_id)
-      raise gen.Return()
+      return
 
     old_op_id = batch_status.op_id
     yield self._update_op_id(txid_hash, batch_status.applied, old_op_id,

--- a/AppDB/appscale/datastore/scripts/datastore.py
+++ b/AppDB/appscale/datastore/scripts/datastore.py
@@ -160,7 +160,7 @@ class MainHandler(tornado.web.RequestHandler):
       app_id = app_data[0]
       os.environ['APPLICATION_ID'] = app_id
     else:
-      raise gen.Return()
+      return
 
     # If the application identifier has the HRD string prepened, remove it.
     app_id = clean_app_id(app_id)

--- a/AppDB/appscale/datastore/scripts/transaction_groomer.py
+++ b/AppDB/appscale/datastore/scripts/transaction_groomer.py
@@ -266,7 +266,7 @@ class ProjectGroomer(object):
     try:
       yield self._stop_event.wait(timeout=time_to_wait)
     except gen.TimeoutError:
-      raise gen.Return()
+      return
 
   @gen.coroutine
   def _remove_locks(self, txid, tx_path):
@@ -281,7 +281,7 @@ class ProjectGroomer(object):
       groups_data = yield self._tornado_zk.get(groups_path)
     except NoNodeError:
       # If the group list does not exist, the locks have not been acquired.
-      raise gen.Return()
+      return
 
     group_paths = json.loads(groups_data[0])
     for group_path in group_paths:
@@ -330,7 +330,7 @@ class ProjectGroomer(object):
     try:
       tx_data = yield self._tornado_zk.get(tx_path)
     except NoNodeError:
-      raise gen.Return()
+      return
 
     tx_time = float(tx_data[0])
 
@@ -339,7 +339,7 @@ class ProjectGroomer(object):
     container_count = int(container[len(CONTAINER_PREFIX):] or 1)
     if tx_node_id < 0:
       yield self._remove_path(tx_path)
-      raise gen.Return()
+      return
 
     container_size = MAX_SEQUENCE_COUNTER + 1
     automatic_offset = (container_count - 1) * container_size
@@ -347,7 +347,7 @@ class ProjectGroomer(object):
 
     if txid < 1:
       yield self._remove_path(tx_path)
-      raise gen.Return()
+      return
 
     # If the transaction is still valid, return the time it was created.
     if tx_time + MAX_TX_DURATION >= time.time():

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -223,7 +223,7 @@ def stop_api_server(project_id):
   """
   global api_servers
   if project_id not in api_servers:
-    raise gen.Return()
+    return
 
   port = api_servers[project_id]
   watch = '{}{}-{}'.format(API_SERVER_PREFIX, project_id, port)
@@ -466,7 +466,7 @@ def unmonitor_and_terminate(watch):
     unmonitor(watch)
   except ProcessNotFound:
     # If Monit does not know about a process, assume it is already stopped.
-    raise gen.Return()
+    return
 
   # Now that the AppServer is stopped, remove its monit config file so that
   # monit doesn't pick it up and restart it.

--- a/AppTaskQueue/appscale/taskqueue/appscale_taskqueue.py
+++ b/AppTaskQueue/appscale/taskqueue/appscale_taskqueue.py
@@ -206,7 +206,7 @@ class StatsHandler(RequestHandler):
     except ValueError:
       self.set_status(400, "cursor and last_milliseconds "
                            "arguments should be integers")
-      raise gen.Return()
+      return
 
     with (yield stats_lock.acquire()):
       cumulative_counters = service_stats.get_cumulative_counters()

--- a/common/appscale/common/async_retrying.py
+++ b/common/appscale/common/async_retrying.py
@@ -216,7 +216,7 @@ class _PersistentWatch(object):
               logging.info("Giving up retrying because newer update came up")
               if not node_lock.waiters:
                 del self._locks[node]
-              raise gen.Return()
+              return
 
           # End of retrying iteration
 

--- a/common/appscale/common/monit_interface.py
+++ b/common/appscale/common/monit_interface.py
@@ -284,7 +284,7 @@ class MonitOperator(object):
                                       IOLoop.current())
 
       if status == constants.MonitStates.RUNNING:
-        raise gen.Return()
+        return
 
       if status == constants.MonitStates.UNMONITORED:
         yield self.send_command(process_name, 'start')


### PR DESCRIPTION
According to http://www.tornadoweb.org/en/stable/gen.html#tornado.gen.Return, this is preferred when returning early from a coroutine.

A bare return has the benefit of not being caught by an `except Exception` block in the same coroutine.