### PR TITLE
Do not reuse SourceManager future if it failed

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/source_manager.py
+++ b/AdminServer/appscale/admin/instance_manager/source_manager.py
@@ -118,11 +118,12 @@ class SourceManager(object):
       location: A string specifying the location of the source archive.
       runtime: A string specifying the revision's runtime.
     """
-    if revision_key not in self.source_futures:
-      self.source_futures[revision_key] = self.prepare_source(
-        revision_key, location, runtime)
+    future = self.source_futures.get(revision_key)
+    if future is None or (future.done() and future.exception() is not None):
+      future = self.prepare_source(revision_key, location, runtime)
+      self.source_futures[revision_key] = future
 
-    yield self.source_futures[revision_key]
+    yield future
 
   def clean_old_revisions(self, active_revisions):
     """ Cleans up the source code for old revisions.


### PR DESCRIPTION
Previously, a failure to fetch the source would prevent the archive from ever being fetched since the the manager would just yield the failed future on subsequent requests.