### PR TITLE
Use external App Identity service for Java apps

### DIFF
--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -332,7 +332,8 @@ def start_app(version_key, config):
       login_server,
       max_heap,
       pidfile,
-      revision_key
+      revision_key,
+      api_server_port
     )
 
     env_vars.update(create_java_app_env(project_id))
@@ -725,7 +726,7 @@ def locate_dir(path, dir_name):
     return None
 
 def create_java_start_cmd(app_name, port, load_balancer_host, max_heap,
-                          pidfile, revision_key):
+                          pidfile, revision_key, api_server_port):
   """ Creates the start command to run the java application server.
 
   Args:
@@ -735,6 +736,7 @@ def create_java_start_cmd(app_name, port, load_balancer_host, max_heap,
     max_heap: An integer specifying the max heap size in MB.
     pidfile: A string specifying the pidfile location.
     revision_key: A string specifying the revision key.
+    api_server_port: An integer specifying the port of the external API server.
   Returns:
     A string of the start command.
   """
@@ -762,6 +764,8 @@ def create_java_start_cmd(app_name, port, load_balancer_host, max_heap,
     "--NGINX_ADDRESS=" + load_balancer_host,
     "--TQ_PROXY=" + options.tq_proxy,
     "--pidfile={}".format(pidfile),
+    "--external_api_port={}".format(api_server_port),
+    "--api_using_python_stub=app_identity_service",
     os.path.dirname(web_inf_directory)
   ]
 

--- a/AppServer_Java/src/com/google/appengine/tools/development/JettyContainerService.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/JettyContainerService.java
@@ -12,6 +12,7 @@ import com.google.appengine.tools.development.IsolatedAppClassLoader;
 import com.google.appengine.tools.development.LocalHttpRequestEnvironment;
 import com.google.appengine.tools.development.SerializableObjectsOnlyHashSessionManager;
 import com.google.appengine.tools.development.ServiceProvider;
+import com.google.appengine.tools.resources.ResourceLoader;
 import com.google.apphosting.api.ApiProxy;
 import com.google.apphosting.utils.config.AppEngineConfigException;
 import com.google.apphosting.utils.config.AppEngineWebXml;
@@ -368,7 +369,12 @@ public class JettyContainerService extends AbstractContainerService {
             Semaphore semaphore = new Semaphore(100);
             LocalHttpRequestEnvironment env = new LocalHttpRequestEnvironment(this.appEngineWebXml.getAppId(), WebModule.getModuleName(this.appEngineWebXml), this.appEngineWebXml.getMajorVersionId(), JettyContainerService.this.instance, Integer.valueOf(JettyContainerService.this.getPort()), request, JettyContainerService.SOFT_DEADLINE_DELAY_MS, JettyContainerService.this.modulesFilterHelper);
             env.getAttributes().put("com.google.appengine.tools.development.api_call_semaphore", semaphore);
-            env.getAttributes().put("com.google.appengine.runtime.default_version_hostname", "localhost:" + JettyContainerService.this.devAppServer.getPort());
+
+            // AppScale: Override default version hostname.
+            String nginxPort = ResourceLoader.getNginxPort();
+            String defaultVersionHostname = System.getProperty("NGINX_ADDR") + ":" + nginxPort;
+            env.getAttributes().put("com.google.appengine.runtime.default_version_hostname", defaultVersionHostname);
+
             ApiProxy.setEnvironmentForCurrentThread(env);
             JettyContainerService.RecordingResponseWrapper wrappedResponse = JettyContainerService.this.new RecordingResponseWrapper(response);
             boolean var43 = false;


### PR DESCRIPTION
This also sets the default version hostname, which is analagous to `app_identity.get_default_version_hostname()` in Python.