### PR TITLE
Use HTTP API to stop Monit services

### DIFF
--- a/AdminServer/appscale/admin/stop_services.py
+++ b/AdminServer/appscale/admin/stop_services.py
@@ -1,0 +1,35 @@
+""" Tries to stop all Monit services until they are stopped. """
+import socket
+import subprocess
+import time
+
+from appscale.common.monit_interface import MonitOperator, MonitStates
+
+
+def main():
+  """ Tries to stop all Monit services until they are stopped. """
+  monit_operator = MonitOperator()
+  hostname = socket.gethostname()
+
+  print('Waiting for monit to stop services')
+  while True:
+    monit_entries = monit_operator.get_entries_sync()
+    all_stopped = True
+    for service in sorted(monit_entries.keys()):
+      state = monit_entries[service]
+      if 'cron' in service or service == hostname:
+        continue
+
+      if state in (MonitStates.STOPPED, MonitStates.UNMONITORED):
+        continue
+
+      all_stopped = False
+      if state == MonitStates.PENDING:
+        continue
+
+      subprocess.Popen(['monit', 'stop', service])
+      time.sleep(.3)
+      break
+
+    if all_stopped:
+      break

--- a/AdminServer/setup.py
+++ b/AdminServer/setup.py
@@ -37,6 +37,7 @@ setup(
             'appscale.admin.instance_manager'],
   entry_points={'console_scripts': [
     'appscale-admin=appscale.admin:main',
-    'appscale-stop-instance=appscale.admin.instance_manager.stop_instance:main'
+    'appscale-stop-instance=appscale.admin.instance_manager.stop_instance:main',
+    'appscale-stop-services=appscale.admin.stop_services:main'
   ]}
 )

--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -18,25 +18,7 @@ module TerminateHelper
     `rm -f /etc/haproxy/sites-enabled/*.cfg`
     `service nginx reload`
 
-    puts "Waiting for monit to stop services ..."
-    loop do
-      monit_output = `monit summary`
-      all_stopped = true
-      monit_output.each_line do |line|
-        # Leave cron-related entries alone.
-        next if line.include?('cron')
-        next if line.start_with?('System')
-        next unless line.include?('Running')
-
-        all_stopped = false
-        next if line.include?('stop pending')
-        entry = line.split[1][1..-2]
-        `monit stop #{entry} 2>&1`
-        sleep(0.5)
-        break
-      end
-      break if all_stopped
-    end
+    `appscale-stop-services`
 
     `rm -f /etc/monit/conf.d/appscale*.cfg`
     `rm -f /etc/monit/conf.d/controller-17443.cfg`


### PR DESCRIPTION
Monit 5.18 changed its default output to a table, so it's no longer reasonable to loop through lines in the output of `monit summary`.

As a bonus, this branch also cuts the stop time in half by stopping ZooKeeper last.