### PR TITLE
RM-624 Start AppManager on compute nodes only

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3289,19 +3289,13 @@ class Djinn
       }
     end
 
-    if !my_node.is_open?
-      threads << Thread.new {
-        start_app_manager_server
-      }
-    else
-      stop_app_manager_server
-    end
-
     if my_node.is_compute?
       threads << Thread.new {
+        start_app_manager_server
         start_blobstore_server
       }
     else
+      stop_app_manager_server
       stop_blobstore_server
     end
 


### PR DESCRIPTION
AppManager is needed only on compute nodes. So let's run it only on compute nodes=)