### PR TITLE
Fix the version delete API method

### DIFF
--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -1008,7 +1008,7 @@ class VersionHandler(BaseVersionHandler):
     IOLoop.current().spawn_callback(wait_for_delete,
                                     del_operation.id, ports_to_close)
 
-    self.write(json_encode(del_operation))
+    self.write(json_encode(del_operation.rest_repr()))
 
   @gen.coroutine
   def patch(self, project_id, service_id, version_id):

--- a/AdminServer/appscale/admin/operation.py
+++ b/AdminServer/appscale/admin/operation.py
@@ -129,16 +129,16 @@ class CreateVersionOperation(Operation):
 class DeleteVersionOperation(Operation):
   """ A container that keeps track of DeleteVersion operations. """
 
-  def __init__(self, project_id, service_id, version):
+  def __init__(self, project_id, service_id, version_id):
     """ Creates a new CreateVersionOperation.
 
     Args:
       project_id: A string specifying a project ID.
       service_id: A string specifying a service ID.
-      version: A dictionary containing verision details.
+      version_id: A string specifying a version ID.
     """
     super(DeleteVersionOperation, self).__init__(
-      project_id, service_id, version)
+      project_id, service_id, {'id': version_id})
     self.method = Methods.DELETE_VERSION
 
   def finish(self):


### PR DESCRIPTION
This gives clients back a proper operation object after a successful delete instead of a 500.

Resolves #2724 