### PR TITLE
Fix dashboard app list

### DIFF
--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -577,11 +577,6 @@ class AppDeletePage(AppDashboard):
     if self.dstore.is_user_cloud_admin() or \
             appname in self.dstore.get_owned_apps():
       message = self.helper.delete_app(appname)
-      try:
-        taskqueue.add(url='/status/refresh')
-        taskqueue.add(url='/status/refresh', countdown=self.REFRESH_WAIT_TIME)
-      except Exception as err:
-        logging.exception(err)
     else:
       message = "You do not have permission to delete the application: " \
                 "{0}".format(appname)

--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -586,9 +586,18 @@ class AppDeletePage(AppDashboard):
       message = "You do not have permission to delete the application: " \
                 "{0}".format(appname)
 
+    # Get the list of project ids the user has access to.
+    is_cloud_admin = self.helper.is_user_cloud_admin()
+    all_versions = self.helper.get_version_info()
+    if is_cloud_admin:
+      apps_user_owns = list({version.split('_')[0]
+                             for version in all_versions})
+    else:
+      apps_user_owns = self.helper.get_owned_apps()
     self.render_app_page(page='apps', values={
       'flash_message': message,
       'page_content': self.TEMPLATE,
+      'apps_user_owns': apps_user_owns,
     })
 
   def get(self):

--- a/AppDashboard/templates/apps/delete.html
+++ b/AppDashboard/templates/apps/delete.html
@@ -11,11 +11,11 @@
     {% set apps=apps_user_owns %}
         <!-- Build page from here: -->
         <div class="row-fluid">
-            <div class="well">
+          <div class="well">
+          {% if flash_message %}
+            <ul id="noticeExplanation"><li class="flash notice">{{ flash_message }}</li></ul>
+          {% endif %}
           {% if apps|length > 0 %}
-              {% if flash_message %}
-              <ul id="noticeExplanation"><li class="flash notice">{{ flash_message }}</li></ul>
-              {% endif %}
                <form action="/apps/delete" method="post"><div style="margin:0;padding:0;display:inline">
               <p>
                 <select id="appname" name="appname">


### PR DESCRIPTION
The dashboard will report no application after an attempt to delete/undeploy a currently running application. This PR fixes this behavior, making sure it shows the current list of running applications after any delete attempt. Also sometime an error wouldn't be displayed if there is not running application: this fixes that too, ensuring the error message takes priority.