### PR TITLE
Use ranges to keep track of merge join queries

### DIFF
--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -22,6 +22,7 @@ from .cassandra_env.entity_id_allocator import ScatteredAllocator
 from .cassandra_env.utils import deletions_for_entity
 from .cassandra_env.utils import mutations_for_entity
 from .utils import clean_app_id
+from .utils import decode_path
 from .utils import encode_entity_table_key
 from .utils import encode_index_pb
 from .utils import encode_path_from_filter
@@ -2605,7 +2606,7 @@ class DatastoreDistributed():
 
       # This is a projection query.
       if query.property_name_size() > 0:
-        potential_entities = self.__extract_entities_from_composite_indexes(
+        potential_entities = self._extract_entities_from_composite_indexes(
           query, references)
       else:
         potential_entities = self.__fetch_entities(references)
@@ -2843,7 +2844,7 @@ class DatastoreDistributed():
 
     return cleaned_results
 
-  def __extract_entities_from_composite_indexes(self, query, index_result):
+  def _extract_entities_from_composite_indexes(self, query, index_result):
     """ Takes index values and creates partial entities out of them.
  
     This is required for projection queries where the query specifies certain
@@ -2909,36 +2910,21 @@ class DatastoreDistributed():
         self.__decode_index_str(value, prop_value)
 
       key_string = tokens[-1]
-      elements = key_string.split(dbconstants.KIND_SEPARATOR)
+      path = decode_path(key_string)
 
       # Set the entity group.
-      element = elements[0]
-      kind, identifier = element.split(dbconstants.ID_SEPARATOR)
       ent_group = entity.mutable_entity_group()
       new_element = ent_group.add_element()
-      new_element.set_type(kind)
-      if len(identifier) == ID_KEY_LENGTH and identifier.isdigit():
-        new_element.set_id(int(identifier))
-      else:
-        new_element.set_name(identifier) 
- 
+      new_element.MergeFrom(path.element(0))
+
       # Set the key path.
       key = entity.mutable_key()
       key.set_app(clean_app_id(app_id))
-      path = key.mutable_path()
       if namespace:
         key.set_name_space(namespace)
-      for element in elements:
-        if not element:
-          continue
-        kind, identifier = element.split(dbconstants.ID_SEPARATOR)
-        new_element = path.add_element()  
-        new_element.set_type(kind)
-        if len(identifier) == ID_KEY_LENGTH and identifier.isdigit():
-          new_element.set_id(int(identifier))
-        else:
-          new_element.set_name(identifier) 
- 
+
+      key.mutable_path().MergeFrom(path)
+
       # Filter entities if this is a distinct query. 
       if query.group_by_property_name_size() == 0:
         entities.append(entity.Encode())

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -21,6 +21,7 @@ from .cassandra_env.entity_id_allocator import EntityIDAllocator
 from .cassandra_env.entity_id_allocator import ScatteredAllocator
 from .cassandra_env.utils import deletions_for_entity
 from .cassandra_env.utils import mutations_for_entity
+from .range_iterator import RangeIterator
 from .utils import clean_app_id
 from .utils import decode_path
 from .utils import encode_entity_table_key
@@ -64,10 +65,6 @@ class DatastoreDistributed():
   """
   # Max number of results for a query
   _MAXIMUM_RESULTS = 10000
-
-  # The number of entries looked at when doing a composite query
-  # It will keep looking at this size window when getting the result
-  _MAX_COMPOSITE_WINDOW = 10000
 
   # Maximum amount of filter and orderings allowed within a query
   _MAX_QUERY_COMPONENTS = 63
@@ -2125,6 +2122,61 @@ class DatastoreDistributed():
          
     return []
 
+  @staticmethod
+  def _common_refs_from_ranges(ranges, limit):
+    """ Find common entries across multiple index ranges.
+
+    Args:
+      ranges: A list of RangeIterator objects.
+      limit: An integer specifying the maximum number of references to find.
+    Returns:
+      A dictionary mapping entity references to index entries.
+    """
+    reference_hash = {}
+    min_common_path = ranges[0].get_cursor()
+    entries_exhausted = False
+    while True:
+      common_keys = []
+      entry = None
+      for range_ in ranges:
+        try:
+          entry = next(range_)
+        except StopIteration:
+          # If any ranges have been exhausted, there are no more matches.
+          entries_exhausted = True
+          break
+
+        # If this entry's path is ahead of the others, consider it the new
+        # minimum acceptable path and adjust the other ranges.
+        if entry.encoded_path > str(encode_index_pb(min_common_path)):
+          min_common_path = entry.path
+          break
+
+        common_keys.append({'index': entry.key, 'prop_name': range_.prop_name})
+
+      if entries_exhausted:
+        break
+
+      # If not all paths are common, adjust earlier ranges.
+      if len(common_keys) < len(ranges):
+        for range_ in ranges:
+          range_.set_cursor(min_common_path, inclusive=True)
+
+        continue
+
+      reference_hash[entry.entity_reference] = common_keys
+
+      # Ensure the chosen reference is excluded.
+      for range_ in ranges:
+        range_.set_cursor(min_common_path, inclusive=False)
+
+      # If there are enough references to satisfy the query, stop fetching
+      # entries.
+      if len(reference_hash) == limit:
+        break
+
+    return reference_hash
+
   def zigzag_merge_join(self, query, filter_info, order_info):
     """ Performs a composite query for queries which have multiple 
     equality filters. Uses a varient of the zigzag join merge algorithm.
@@ -2149,183 +2201,44 @@ class DatastoreDistributed():
     if not self.is_zigzag_merge_join(query, filter_info, order_info):
       return None
     kind = query.kind()  
-    prefix = self.get_table_prefix(query)
     limit = self.get_limit(query)
     app_id = clean_app_id(query.app())
 
     # We only use references from the ascending property table.
     direction = datastore_pb.Query_Order.ASCENDING
 
-    count = self._MAX_COMPOSITE_WINDOW
-    start_key = ""
-    result_list = []
-    force_exclusive = False
-    more_results = True
-    ancestor = None
+    ranges = [RangeIterator.from_filter(self.datastore_batch, app_id,
+                                        query.name_space(), kind, filter_)
+              for filter_ in query.filter_list()]
     if query.has_ancestor():
-      ancestor = query.ancestor()
+      for range_ in ranges:
+        range_.restrict_to_path(query.ancestor())
 
-    # We will apply the other equality filters after fetching the entities.
-    clean_filter_info = {}
-    for prop in filter_info:
-      filter_ops = filter_info[prop]
-      clean_filter_info[prop] = self.remove_extra_equality_filters(filter_ops)
-    filter_info = clean_filter_info
+    if query.has_compiled_cursor() and query.compiled_cursor().position_size():
+      cursor = appscale_stub_util.ListCursor(query)
+      cursor_path = cursor._GetLastResult().key().path()
+      for range_ in ranges:
+        range_.set_cursor(cursor_path, inclusive=False)
 
-    multiple_equality_filters = self.__get_multiple_equality_filters(
-      query.filter_list())
+    entities = []
+    while True:
+      reference_hash = self._common_refs_from_ranges(ranges, limit)
+      entities.extend(
+        self.__fetch_and_validate_entity_set(reference_hash, limit, app_id,
+                                             direction))
 
-    while more_results:
-      reference_hash = {}
-      temp_res = {}
-      # We use what we learned from the previous scans to skip over any keys 
-      # that we know will not be a match.
-      startrow = "" 
-      # TODO Do these in parallel and measure speedup.
-      # I've tried a thread wrapper before but due to the function having
-      # self attributes it's nontrivial.
-      for prop_name in filter_info.keys():
-        filter_ops = filter_info.get(prop_name, [])
-        if start_key:
-          # Grab the reference key which is after the last delimiter. 
-          value = str(filter_ops[0][1])
-          reference_key = start_key.split(self._SEPARATOR)[-1]
-          params = [prefix, kind, prop_name, value, reference_key]
-          startrow = get_index_key_from_params(params)
-        elif query.has_compiled_cursor() and \
-          query.compiled_cursor().position_size():
-          cursor = appscale_stub_util.ListCursor(query)
-          last_result = cursor._GetLastResult()
-          value = str(filter_ops[0][1])
-          reference_key = str(encode_index_pb(last_result.key().path()))
-          params = [prefix, kind, prop_name, value, reference_key]
-          startrow = get_index_key_from_params(params)
+      # If there are enough entities to satisfy the query, stop fetching.
+      if len(entities) >= limit:
+        break
 
-        # We use equality filters only so order ops should always be ASC. 
-        order_ops = []
-        for i in order_info:
-          if i[0] == prop_name:
-            order_ops = [i]
-            break
+      # If there weren't enough common references to fulfill the limit, the
+      # references are exhausted.
+      if len(reference_hash) < limit:
+        break
 
-        temp_res[prop_name] = self.__apply_filters(filter_ops, 
-          order_ops, 
-          prop_name, 
-          kind, 
-          prefix, 
-          count, 
-          0, 
-          startrow,
-          force_start_key_exclusive=force_exclusive,
-          ancestor=ancestor,
-          query=query)
-
-      # We do reference counting and consider any reference which matches the
-      # number of properties to be a match. Any others are discarded but it 
-      # possible they show up on subsequent scans. 
-      last_keys_of_scans = {}
-      first_keys_of_scans = {}
-      for prop_name in temp_res:
-        for indexes in temp_res[prop_name]:
-          for reference in indexes: 
-            reference_key = indexes[reference]['reference']
-            if reference_key not in reference_hash:
-              reference_hash[reference_key] = []
-
-            reference_hash[reference_key].append(
-              {'index': reference, 'prop_name': prop_name})
-          # Of the set of entity scans we use the earliest of the set as the
-          # starting point of scans to follow. This makes sure we do not miss 
-          # overlapping results because different properties had different 
-          # distributions of keys. The index value gives us the key to 
-          # the entity table (what the index points to).
-          index_key = indexes.keys()[0]
-          index_value = indexes[index_key]['reference']
-          first_keys_of_scans[prop_name] = index_value
-
-          index_key = indexes.keys()[-1]
-          index_value = indexes[index_key]['reference']
-          last_keys_of_scans[prop_name] = index_value
-
-      # We are looking for the earliest (alphabetically) of the set of last 
-      # keys. This tells us where to start our next scans. And from where 
-      # we can remove potential results.
-      start_key = ""
-      starting_prop_name = ""
-      for prop_name in first_keys_of_scans:
-        first_key = first_keys_of_scans[prop_name]
-        if not start_key or first_key < start_key: 
-          start_key = first_key
-          starting_prop_name = prop_name
- 
-      # Override the start key if one of the prop starting keys is outside the 
-      # end key of all the other props. This allows to jump over results which 
-      # would not have matched.
-      for prop_name in first_keys_of_scans:
-        first_key = first_keys_of_scans[prop_name]
-        jump_ahead = False
-        for last_prop in last_keys_of_scans:
-          if last_prop == prop_name:
-            continue
-
-          if first_key > last_keys_of_scans[last_prop]:
-            jump_ahead = True
-          else:
-            jump_ahead = False
-            break
-        if jump_ahead:
-          start_key = first_key
-          starting_prop_name = prop_name
-
-      # Purge keys which did not intersect from all equality filters and those
-      # which are past the earliest reference shared by all property names 
-      # (start_key variable). 
-      keys_to_delete = []
-      for key in reference_hash:
-        if len(reference_hash[key]) != len(filter_info.keys()):
-          keys_to_delete.append(key)
-      # You cannot loop on a dictionary and delete from it at the same time.
-      # Hence why the deletes happen here.
-      for key in keys_to_delete:
-        del reference_hash[key]
-
-      # If we have results, we only need to fetch enough to meet the limit.
-      to_fetch = limit - len(result_list)
-
-      entities = self.__fetch_and_validate_entity_set(reference_hash, to_fetch,
-        app_id, direction)
-
-      if len(multiple_equality_filters) > 0:
-        self.logger.debug('Detected multiple equality filters on a repeated'
-          'property. Removing results that do not match query.')
-        entities = self.__apply_multiple_equality_filters(
-          entities, multiple_equality_filters)
-
-      result_list.extend(entities)
-
-      # If the property we are setting the start key did not get the requested
-      # amount of entities then we can stop scanning, as there are no more 
-      # entities to scan from that property.
-      for prop_name in temp_res:
-        if len(temp_res[prop_name]) < count and prop_name == starting_prop_name:
-          more_results = False
-
-        # If any property no longer has any more items, this query is done.
-        if len(temp_res[prop_name]) == 0:
-          more_results = False 
-
-      # If we reached our limit of result entities, then we are done.
-      if len(result_list) >= limit:
-        more_results = False
-
-      # Do not include the first key in subsequent scans because we have 
-      # already accounted for the given entity.
-      if start_key in result_list:
-        force_exclusive = True
-
-    results = result_list[:limit]
+    results = entities[:limit]
     self.logger.debug('Returning {} results'.format(len(results)))
-    return result_list[:limit]
+    return results
 
   def does_composite_index_exist(self, query):
     """ Checks to see if the query has a composite index that can implement

--- a/AppDB/appscale/datastore/range_iterator.py
+++ b/AppDB/appscale/datastore/range_iterator.py
@@ -1,0 +1,225 @@
+""" Iterates through a range of index entries. """
+
+import sys
+from collections import namedtuple
+
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+from appscale.datastore.dbconstants import (
+  ASC_PROPERTY_TABLE, BadRequest, KEY_DELIMITER, PROPERTY_SCHEMA,
+  TERMINATING_STRING)
+from appscale.datastore.utils import decode_path, encode_index_pb
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.datastore.datastore_pb import Path, Query_Filter
+
+
+IndexEntry = namedtuple('IndexEntry',
+                        ['encoded_path', 'entity_reference', 'key', 'path'])
+
+
+Cursor = namedtuple('Cursor', ['key', 'inclusive'])
+
+
+class RangeIterator(object):
+  """ Iterates through a range of index entries.
+
+  This was designed for merge join queries. The range can only be narrowed.
+  """
+  CHUNK_SIZE = 1000
+
+  def __init__(self, db, project_id, namespace, kind, prop_name, value):
+    """ Creates a new IndexReader.
+
+    Args:
+      db: A database interface object.
+      project_id: A string specifying a project ID.
+      namespace: A string specifying a namespace.
+      kind: A string specifying an entity kind.
+      prop_name: A string specifying a property name.
+      value: An entity_pb.PropertyValue.
+    """
+    self.project_id = project_id
+    self.namespace = namespace
+    self.kind = kind
+    self.prop_name = prop_name
+
+    self._db = db
+    self._value = value
+
+    self._range = (self.prefix, ''.join([self.prefix, TERMINATING_STRING]))
+    self._cursor = Cursor(self.prefix, inclusive=True)
+
+    self._cache = []
+    self._index_exhausted = False
+
+  @property
+  def prefix(self):
+    """ The encoded reference without the path element. """
+    return KEY_DELIMITER.join(
+      [self.project_id, self.namespace, self.kind, self.prop_name,
+       str(encode_index_pb(self._value))])
+
+  def __iter__(self):
+    """ Returns a new iterator object. """
+    return self
+
+  def next(self):
+    """ Retrieves the next index entry in the range.
+
+    Returns:
+      An IndexEntry.
+    """
+    try:
+      # First check if the request can be fulfilled with the cache.
+      entry = self._next_from_cache()
+      self._cursor = Cursor(entry.key, inclusive=False)
+      return entry
+    except ValueError:
+      # If the cache and index have been exhausted, there are no more entries.
+      if self._index_exhausted:
+        raise StopIteration()
+
+    self._cache = self._db.range_query(
+      ASC_PROPERTY_TABLE, PROPERTY_SCHEMA, self._cursor.key, self._range[-1],
+      self.CHUNK_SIZE, start_inclusive=self._cursor.inclusive)
+
+    if len(self._cache) < self.CHUNK_SIZE:
+      self._index_exhausted = True
+
+    if not self._cache:
+      raise StopIteration()
+
+    entry = self.entry_from_result(self._cache[0])
+    self._cursor = Cursor(entry.key, inclusive=False)
+    return entry
+
+  @classmethod
+  def from_filter(cls, db, project_id, namespace, kind, pb_filter):
+    """ Creates a new RangeIterator from a filter.
+
+    Args:
+      db: A database interface object.
+      project_id: A string specifying a project ID.
+      namespace: A string specifying a namespace.
+      kind: A string specifying an entity kind.
+      pb_filter: A datastore_pb.Query_Filter object.
+    Raises:
+      BadRequest if the filter cannot be used to create the range.
+    """
+    # Make sure this filter can be used for a merge join.
+    if pb_filter.op() != Query_Filter.EQUAL:
+      raise BadRequest('Invalid filter for merge join '
+                       '(op must be equal): {}'.format(pb_filter))
+
+    if pb_filter.property_size() != 1:
+      raise BadRequest('Invalid filter for merge join '
+                       '(multiple properties): {}'.format(pb_filter))
+
+    property_ = pb_filter.property(0)
+    if property_.name() == '__key__':
+      raise BadRequest('Invalid property for merge join '
+                       '(must not be __key__): {}'.format(property_))
+
+    return cls(db, project_id, namespace, kind, property_.name(),
+               property_.value())
+
+  @staticmethod
+  def entry_from_result(result):
+    """ Creates an IndexEntry from a Cassandra result.
+
+    Args:
+      result: A dictionary mapping a Cassandra key to a reference value.
+    Returns:
+      An IndexEntry.
+    """
+    entry_key = result.keys()[0]
+    encoded_path = entry_key.rsplit(KEY_DELIMITER)[-1]
+    path = decode_path(encoded_path)
+    entity_ref = result.values()[0]['reference']
+    return IndexEntry(encoded_path, entity_ref, entry_key, path)
+
+  def get_cursor(self):
+    """ Fetches the range's current cursor position.
+
+    Returns:
+      An entity_pb.Path object.
+    """
+    # If the current cursor does not have a path, return an empty one.
+    if self._cursor.key == self.prefix:
+      return Path()
+
+    encoded_path = self._cursor.key.rsplit(KEY_DELIMITER)[-1]
+    return decode_path(encoded_path)
+
+  def set_cursor(self, path, inclusive):
+    """ Changes the range's cursor position.
+
+    Args:
+      path: An entity_pb.Path object.
+      inclusive: A boolean specifying that the next result can include the
+        given path.
+    Raises:
+      BadRequest if unable to set the cursor to the given path.
+    """
+    range_start, range_end = self._range
+    cursor = Cursor(
+      KEY_DELIMITER.join([range_start, str(encode_index_pb(path))]), inclusive)
+
+    if cursor.key < self._cursor.key:
+      raise BadRequest(
+        'Cursor cannot be moved backwards '
+        '({} < {})'.format(repr(cursor.key), repr(self._cursor.key)))
+
+    if cursor.key > range_end:
+      raise BadRequest('Cursor outside range: {}'.format(self._range))
+
+    self._cursor = cursor
+
+  def restrict_to_path(self, path):
+    """ Narrows the range to a specific entity path.
+
+    Args:
+      path: An entity_pb.Path object.
+    """
+    start_key = KEY_DELIMITER.join([self.prefix, str(encode_index_pb(path))])
+    end_key = ''.join([start_key, TERMINATING_STRING])
+    if start_key < self._range[0] or end_key > self._range[-1]:
+      raise BadRequest('Restriction must be within range')
+
+    if self._cursor.key > end_key:
+      raise BadRequest('Cursor already exceeds new range')
+
+    self._range = (start_key, end_key)
+    self._cursor.key = max(start_key, self._cursor.key)
+
+  def _next_from_cache(self):
+    """ Retrieves the next index entry from the cache.
+
+    Returns:
+      An IndexEntry.
+    Raises:
+      ValueError if the cache does not contain a suitable entry.
+    """
+    lo = 0
+    hi = len(self._cache)
+    # Bisect the cache to find the smallest key that is >= the cursor.
+    while lo < hi:
+      mid = (lo + hi) // 2
+      if self._cache[mid].keys()[0] < self._cursor.key:
+        lo = mid + 1
+      else:
+        hi = mid
+
+    try:
+      entry = self.entry_from_result(self._cache[lo])
+    except IndexError:
+      raise ValueError
+
+    # If cursor is not inclusive, exclude matching entries.
+    if entry.key == self._cursor.key and not self._cursor.inclusive:
+      try:
+        entry = self.entry_from_result(self._cache[lo + 1])
+      except IndexError:
+        raise ValueError
+
+    return entry

--- a/AppDB/appscale/datastore/utils.py
+++ b/AppDB/appscale/datastore/utils.py
@@ -700,3 +700,34 @@ def encode_path_from_filter(query_filter):
     path.add_element().MergeFrom(element)
 
   return str(encode_index_pb(path))
+
+
+def decode_path(encoded_path):
+  """ Parse a Cassandra-encoded reference path.
+
+  Args:
+    encoded_path: A string specifying the encoded path.
+  Returns:
+    An entity_pb.Path object.
+  """
+  path = entity_pb.Path()
+
+  for element in encoded_path.split(dbconstants.KIND_SEPARATOR):
+    # For some reason, encoded keys have a trailing separator, so ignore the
+    # last empty element.
+    if not element:
+      continue
+
+    kind, identifier = element.split(dbconstants.ID_SEPARATOR)
+
+    new_element = path.add_element()
+    new_element.set_type(kind)
+
+    # We don't know for sure if an encoded key is an ID or a name, so we guess.
+    # IDs often exceed the ID_KEY_LENGTH.
+    if len(identifier) >= ID_KEY_LENGTH and identifier.isdigit():
+      new_element.set_id(int(identifier))
+    else:
+      new_element.set_name(identifier)
+
+  return path

--- a/AppDB/test/unit/test_datastore_server.py
+++ b/AppDB/test/unit/test_datastore_server.py
@@ -24,6 +24,7 @@ from appscale.datastore.cassandra_env.utils import index_deletions
 from appscale.datastore.cassandra_env.utils import mutations_for_entity
 
 from appscale.datastore.utils import (
+  encode_index_pb,
   get_entity_key,
   get_entity_kind,
   get_index_key_from_params,
@@ -1074,6 +1075,46 @@ class TestDatastoreServer(unittest.TestCase):
     entity_lock.should_receive('release')
 
     dd.apply_txn_changes(app, txn)
+
+  def test_extract_entities_from_composite_indexes(self):
+    project_id = 'guestbook'
+    props = ['prop1', 'prop2']
+    db_batch = flexmock()
+    db_batch.should_receive('valid_data_version').and_return(True)
+    transaction_manager = flexmock()
+    dd = DatastoreDistributed(db_batch, transaction_manager,
+                              self.get_zookeeper())
+    query = datastore_pb.Query()
+    for prop_name in props:
+      query.add_property_name(prop_name)
+
+    index = query.add_composite_index()
+    definition = index.mutable_definition()
+    for prop_name in props:
+      prop = definition.add_property()
+      prop.set_name(prop_name)
+
+    entity_id = 1524699263329044
+    val1 = entity_pb.PropertyValue()
+    val1.set_int64value(5)
+    val2 = entity_pb.PropertyValue()
+    val2.set_stringvalue('test')
+    index_key = '\x00'.join(
+      [project_id, 'namespace', 'index1', str(encode_index_pb(val1)),
+       str(encode_index_pb(val2)), 'Greeting:{}\x01'.format(entity_id)])
+
+    index_results = [{index_key: {'reference': 'ignored-ref'}}]
+    entities = dd._extract_entities_from_composite_indexes(
+      query, index_results)
+    self.assertEqual(len(entities), 1)
+    returned_entity = entity_pb.EntityProto(entities[0])
+    self.assertEqual(returned_entity.property_size(), 2)
+    self.assertEqual(returned_entity.key().path().element(0).type(), 'Greeting')
+    self.assertEqual(returned_entity.key().path().element(0).id(), entity_id)
+    self.assertEqual(returned_entity.property(0).name(), 'prop1')
+    self.assertEqual(returned_entity.property(0).value().int64value(), 5)
+    self.assertEqual(returned_entity.property(1).name(), 'prop2')
+    self.assertEqual(returned_entity.property(1).value().stringvalue(), 'test')
 
 if __name__ == "__main__":
   unittest.main()    

--- a/AppDB/test/unit/test_utils.py
+++ b/AppDB/test/unit/test_utils.py
@@ -1,0 +1,26 @@
+import unittest
+
+from appscale.datastore import utils
+
+
+class TestUtils(unittest.TestCase):
+  def test_decode_path(self):
+    # Test an entity name.
+    path = utils.decode_path('Project:Hadoop\x01')
+    self.assertEqual(path.element_size(), 1)
+    self.assertEqual(path.element(0).type(), 'Project')
+    self.assertEqual(path.element(0).name(), 'Hadoop')
+
+    # Test a path with more than one element.
+    path = utils.decode_path('Org:Apache\x01Project:Hadoop\x01')
+    self.assertEqual(path.element_size(), 2)
+    self.assertEqual(path.element(0).type(), 'Org')
+    self.assertEqual(path.element(0).name(), 'Apache')
+    self.assertEqual(path.element(1).type(), 'Project')
+    self.assertEqual(path.element(1).name(), 'Hadoop')
+
+    # Test an entity ID.
+    path = utils.decode_path('Greeting:0000000000000002\x01')
+    self.assertEqual(path.element_size(), 1)
+    self.assertEqual(path.element(0).type(), 'Greeting')
+    self.assertEqual(path.element(0).id(), 2)


### PR DESCRIPTION
This allows the matcher to skip ahead with only the ranges that need to be adjusted. It also reduces the index entry fetch size from 10,000 to 1000.

Resolves #2730 