### PR TITLE
faster way to get cpu count which takes .003ms vs .014ms

### DIFF
--- a/AppController/lib/datastore_server.rb
+++ b/AppController/lib/datastore_server.rb
@@ -66,7 +66,7 @@ module DatastoreServer
   # Number of servers is based on the number of CPUs.
   def self.number_of_servers
     # If this is NaN then it returns 0
-    num_procs = `cat /proc/cpuinfo | grep processor | wc -l`.to_i
+    num_procs = `grep -c processor /proc/cpuinfo`.to_i
     return DEFAULT_NUM_SERVERS if num_procs.zero?
     servers = num_procs * MULTIPLIER
     return 1 if servers.zero?

--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -288,7 +288,7 @@ module TaskQueue
   # Number of servers is based on the number of CPUs.
   def self.number_of_servers
     # If this is NaN then it returns 0
-    num_procs = `cat /proc/cpuinfo | grep processor | wc -l`.to_i
+    num_procs = `grep -c processor /proc/cpuinfo`.to_i
     return DEFAULT_NUM_SERVERS if num_procs.zero?
     (num_procs * MULTIPLIER)
   end


### PR DESCRIPTION
Stumbled across this, not sure if we really need the change. But its faster to just use grep on the file and get the count directly via the grep command:

```
1514% time cat /proc/cpuinfo | grep processor | wc -l
4
cat /proc/cpuinfo  0.00s user 0.00s system 48% cpu 0.004 total
grep processor  0.00s user 0.00s system 26% cpu 0.006 total
wc -l  0.00s user 0.00s system 39% cpu 0.004 total


1515% time grep -c processor /proc/cpuinfo
4
grep -c processor /proc/cpuinfo  0.00s user 0.00s system 65% cpu 0.003 total

```