### PR TITLE
Replace stub with TaskQueue client

### DIFF
--- a/AppDB/appscale/datastore/scripts/datastore.py
+++ b/AppDB/appscale/datastore/scripts/datastore.py
@@ -15,6 +15,7 @@ import tornado.httpserver
 import tornado.web
 
 from appscale.common import appscale_info
+from appscale.common.appscale_info import get_load_balancer_ips
 from appscale.common.async_retrying import retry_data_watch_coroutine
 from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
 from kazoo.client import KazooState
@@ -849,6 +850,7 @@ def main():
 
   options.define('private_ip', appscale_info.get_private_ip())
   options.define('port', args.port)
+  taskqueue_locations = get_load_balancer_ips()
 
   server_node = '{}/{}:{}'.format(DATASTORE_SERVERS_NODE, options.private_ip,
                                   options.port)
@@ -869,7 +871,8 @@ def main():
   transaction_manager = TransactionManager(zookeeper.handle)
   datastore_access = DatastoreDistributed(
     datastore_batch, transaction_manager, zookeeper=zookeeper,
-    log_level=logger.getEffectiveLevel())
+    log_level=logger.getEffectiveLevel(),
+    taskqueue_locations=taskqueue_locations)
 
   server = tornado.httpserver.HTTPServer(pb_application)
   server.listen(args.port)

--- a/AppDB/appscale/datastore/taskqueue_client.py
+++ b/AppDB/appscale/datastore/taskqueue_client.py
@@ -1,0 +1,91 @@
+""" Performs TaskQueue service enqueue requests. """
+
+import sys
+
+import requests
+from requests.exceptions import ConnectionError, HTTPError
+
+from appscale.common.constants import TASKQUEUE_SERVICE_PORT
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.api.taskqueue import taskqueue_service_pb
+from google.appengine.ext.remote_api import remote_api_pb
+
+
+class EnqueueError(Exception):
+  """ Indicates that the tasks could not be enqueued. """
+  pass
+
+
+class TaskQueueClient(object):
+  """ Performs TaskQueue service enqueue requests. """
+  def __init__(self, locations):
+    """ Creates a new TaskQueueClient.
+
+    Args:
+      locations: A list of IP addresses specifying TaskQueue service locations.
+    """
+    self._locations = [':'.join([ip, str(TASKQUEUE_SERVICE_PORT)])
+                       for ip in locations]
+
+  def add_tasks(self, project_id, service_id, version_id, add_requests):
+    """ Makes a call to the TaskQueue service to enqueue tasks.
+
+    Args:
+      project_id: A string specifying the project ID.
+      service_id: A string specifying the service ID.
+      version_id: A string specifying the version ID.
+      add_requests: A list of TaskQueueAddRequest messages.
+    Raises:
+      EnqueueError if unable to enqueue tasks.
+    """
+    request = taskqueue_service_pb.TaskQueueBulkAddRequest()
+    for add_request in add_requests:
+      request.add_add_request().MergeFrom(add_request)
+
+    api_request = remote_api_pb.Request()
+    api_request.set_method('BulkAdd')
+    api_request.set_service_name('taskqueue')
+    api_request.set_request(request.Encode())
+
+    encoded_api_request = api_request.Encode()
+    headers = {'ProtocolBufferType': 'Request',
+               'AppData': project_id,
+               'Module': service_id,
+               'Version': version_id}
+    api_response = None
+    for location in self._locations:
+      url = 'http://{}'.format(location)
+      try:
+        response = requests.post(url, data=encoded_api_request,
+                                 headers=headers)
+        response.raise_for_status()
+      except ConnectionError:
+        # Try a different location if the load balancer is not available.
+        continue
+      except HTTPError as error:
+        raise EnqueueError(str(error))
+
+      api_response = remote_api_pb.Response(response.content)
+      break
+
+    if api_response is None:
+      raise EnqueueError('Unable to connect to any load balancers')
+
+    if api_response.has_application_error():
+      error_pb = api_response.application_error()
+      raise EnqueueError(error_pb.detail())
+
+    if api_response.has_exception():
+      raise EnqueueError(api_response.exception())
+
+    bulk_response = taskqueue_service_pb.TaskQueueBulkAddResponse(
+      api_response.response())
+
+    if bulk_response.taskresult_size() != len(add_requests):
+      raise EnqueueError('Unexpected number of task results')
+
+    for task_result in bulk_response.taskresult_list():
+      if task_result.result() != taskqueue_service_pb.TaskQueueServiceError.OK:
+        raise EnqueueError('Unable to enqueue task: {}'.format(task_result))

--- a/common/appscale/common/constants.py
+++ b/common/appscale/common/constants.py
@@ -82,6 +82,9 @@ UA_SERVER_PORT = 4343
 # The port of the application manager soap server.
 APP_MANAGER_PORT = 17445
 
+# The HAProxy port for the TaskQueue service.
+TASKQUEUE_SERVICE_PORT = 17446
+
 # Python programs.
 PYTHON = "python"
 


### PR DESCRIPTION
This allows the datastore to make TaskQueue service requests without importing AppServer code.

These changes make progress toward #2740 