### PR TITLE
Continue starting deployment if system user exists

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4458,6 +4458,8 @@ HOSTS
       retries ||= 0
       result = uac.commit_new_user(APPSCALE_USER, password, "app")
       Djinn.log_info("Created/confirmed system user: (#{result})")
+    rescue UserExists
+      Djinn.log_info('System user already exists')
     rescue InternalError, FailedNodeException
       Djinn.log_warn('Failed to create a new user')
       retries += 1
@@ -5959,6 +5961,12 @@ HOSTS
     begin
       retries ||= 0
       result = uac.commit_new_user(xmpp_user, xmpp_pass, "app")
+    rescue UserExists
+      Djinn.log_info("User #{xmpp_user} already exists")
+      # We need to update the password of the channel XMPP account for
+      # authorization.
+      result = uac.change_password(xmpp_user, xmpp_pass)
+      Djinn.log_debug("Change password returned: #{result}")
     rescue InternalError
       Djinn.log_warn('Failed to create a new user')
       retries += 1
@@ -5968,14 +5976,6 @@ HOSTS
       else
         raise
       end
-    end
-
-    Djinn.log_debug("User creation returned: #{result}")
-    if result.include?('Error: user already exists')
-      # We need to update the password of the channel XMPP account for
-      # authorization.
-      result = uac.change_password(xmpp_user, xmpp_pass)
-      Djinn.log_debug("Change password returned: #{result}")
     end
 
     Djinn.log_debug("Created user [#{xmpp_user}] with password " \

--- a/AppController/lib/custom_exceptions.rb
+++ b/AppController/lib/custom_exceptions.rb
@@ -29,3 +29,7 @@ end
 # do not return properly (specifically, not having a return value of zero).
 class FailedShellExec < StandardError
 end
+
+# Indicates that the user being created already exists.
+class UserExists < StandardError
+end

--- a/AppController/lib/user_app_client.rb
+++ b/AppController/lib/user_app_client.rb
@@ -89,6 +89,8 @@ class UserAppClient
       puts "\nYour user account has been created successfully."
     elsif result == 'false'
       raise InternalError.new('Unable to create user')
+    elsif result == 'Error: user already exists'
+      raise UserExists.new(result)
     else
       raise InternalError.new(result)
     end


### PR DESCRIPTION
Without this, the controller on a rebooted machine will crash when trying to create the system user.