### PR TITLE
Clean up group locks when possible

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/large_batch.py
+++ b/AppDB/appscale/datastore/cassandra_env/large_batch.py
@@ -18,8 +18,14 @@ sys.path.append(APPSCALE_PYTHON_APPSERVER)
 from google.appengine.datastore import entity_pb
 
 
+class BatchNotApplied(Exception):
+  """ Indicates that a large batch failed before it could be applied. """
+  pass
+
+
 class BatchNotFound(Exception):
   """ Indicates that the batch status is not defined. """
+  pass
 
 
 class BatchNotOwned(Exception):

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -17,8 +17,12 @@ from kazoo.client import KazooState
 from appscale.datastore.dbconstants import (
   APP_ENTITY_SCHEMA, ID_KEY_LENGTH, MAX_TX_DURATION, Timeout
 )
+from appscale.datastore.cassandra_env.cassandra_interface import (
+  batch_size, LARGE_BATCH_THRESHOLD)
 from appscale.datastore.cassandra_env.entity_id_allocator import EntityIDAllocator
 from appscale.datastore.cassandra_env.entity_id_allocator import ScatteredAllocator
+from appscale.datastore.cassandra_env.large_batch import (
+  BatchNotApplied, FailedBatch)
 from appscale.datastore.cassandra_env.utils import deletions_for_entity
 from appscale.datastore.cassandra_env.utils import mutations_for_entity
 from appscale.datastore.utils import clean_app_id
@@ -573,8 +577,13 @@ class DatastoreDistributed():
         entity_keys = [
           get_entity_key(self.get_table_prefix(entity), entity.key().path())
           for entity in entity_list]
-        current_values = yield self.datastore_batch.batch_get_entity(
-          dbconstants.APP_ENTITY_TABLE, entity_keys, APP_ENTITY_SCHEMA)
+        try:
+          current_values = yield self.datastore_batch.batch_get_entity(
+            dbconstants.APP_ENTITY_TABLE, entity_keys, APP_ENTITY_SCHEMA)
+        except dbconstants.AppScaleDBConnectionError:
+          lock.release()
+          self.transaction_manager.delete_transaction_id(app, txid)
+          raise
 
         batch = []
         entity_changes = []
@@ -596,8 +605,27 @@ class DatastoreDistributed():
 
           entity_changes.append(
             {'key': entity.key(), 'old': current_value, 'new': entity})
-        yield self.datastore_batch.batch_mutate(
-          app, batch, entity_changes, txid)
+
+        if batch_size(batch) > LARGE_BATCH_THRESHOLD:
+          try:
+            yield self.datastore_batch.large_batch(app, batch, entity_changes,
+                                                   txid)
+          except BatchNotApplied as error:
+            # If the "applied" switch has not been flipped, the lock can be
+            # released. The transaction ID is kept so that the groomer can
+            # clean up the batch tables.
+            lock.release()
+            raise dbconstants.AppScaleDBConnectionError(str(error))
+        else:
+          try:
+            yield self.datastore_batch.normal_batch(batch, txid)
+          except dbconstants.AppScaleDBConnectionError:
+            # Since normal batches are guaranteed to be atomic, the lock can
+            # be released.
+            lock.release()
+            self.transaction_manager.delete_transaction_id(app, txid)
+            raise
+
         lock.release()
 
       finally:
@@ -639,7 +667,7 @@ class DatastoreDistributed():
                     'key': bytearray(group.Encode()),
                     'last_update': txid})
 
-      yield self.datastore_batch._normal_batch(batch, txid)
+      yield self.datastore_batch.normal_batch(batch, txid)
 
   @gen.coroutine
   def dynamic_put(self, app_id, put_request, put_response):
@@ -3251,7 +3279,15 @@ class DatastoreDistributed():
       raise Timeout('Unable to acquire entity group locks')
 
     try:
-      group_txids = yield self.datastore_batch.group_updates(metadata['reads'])
+      try:
+        group_txids = yield self.datastore_batch.group_updates(
+          metadata['reads'])
+      except dbconstants.TRANSIENT_CASSANDRA_ERRORS:
+        lock.release()
+        self.transaction_manager.delete_transaction_id(app, txn)
+        raise dbconstants.AppScaleDBConnectionError(
+          'Unable to fetch group updates')
+
       for group_txid in group_txids:
         if group_txid in metadata['in_progress'] or group_txid > txn:
           lock.release()
@@ -3264,8 +3300,13 @@ class DatastoreDistributed():
                            for key, _ in metadata['puts'].iteritems()]
       entity_table_keys.extend([encode_entity_table_key(key)
                                 for key in metadata['deletes']])
-      current_values = yield self.datastore_batch.batch_get_entity(
-        dbconstants.APP_ENTITY_TABLE, entity_table_keys, APP_ENTITY_SCHEMA)
+      try:
+        current_values = yield self.datastore_batch.batch_get_entity(
+          dbconstants.APP_ENTITY_TABLE, entity_table_keys, APP_ENTITY_SCHEMA)
+      except dbconstants.AppScaleDBConnectionError:
+        lock.release()
+        self.transaction_manager.delete_transaction_id(app, txn)
+        raise
 
       batch = []
       entity_changes = []
@@ -3303,7 +3344,26 @@ class DatastoreDistributed():
           {'table': 'group_updates', 'key': bytearray(group),
            'last_update': txn})
 
-      yield self.datastore_batch.batch_mutate(app, batch, entity_changes, txn)
+      if batch_size(batch) > LARGE_BATCH_THRESHOLD:
+        try:
+          yield self.datastore_batch.large_batch(app, batch, entity_changes,
+                                                 txn)
+        except BatchNotApplied as error:
+          # If the "applied" switch has not been flipped, the lock can be
+          # released. The transaction ID is kept so that the groomer can
+          # clean up the batch tables.
+          lock.release()
+          raise dbconstants.AppScaleDBConnectionError(str(error))
+      else:
+        try:
+          yield self.datastore_batch.normal_batch(batch, txn)
+        except dbconstants.AppScaleDBConnectionError:
+          # Since normal batches are guaranteed to be atomic, the lock can
+          # be released.
+          lock.release()
+          self.transaction_manager.delete_transaction_id(app, txn)
+          raise
+
       lock.release()
 
     finally:

--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -21,8 +21,7 @@ from appscale.datastore.cassandra_env.cassandra_interface import (
   batch_size, LARGE_BATCH_THRESHOLD)
 from appscale.datastore.cassandra_env.entity_id_allocator import EntityIDAllocator
 from appscale.datastore.cassandra_env.entity_id_allocator import ScatteredAllocator
-from appscale.datastore.cassandra_env.large_batch import (
-  BatchNotApplied, FailedBatch)
+from appscale.datastore.cassandra_env.large_batch import BatchNotApplied
 from appscale.datastore.cassandra_env.utils import deletions_for_entity
 from appscale.datastore.cassandra_env.utils import mutations_for_entity
 from appscale.datastore.utils import clean_app_id

--- a/AppDB/test/unit/test_cassandra_interface.py
+++ b/AppDB/test/unit/test_cassandra_interface.py
@@ -162,21 +162,6 @@ class TestCassandra(testing.AsyncTestCase):
       {'keyC': {'c1': '7', 'c2': '8'}}
     ])
 
-  @testing.gen_test
-  def test_batch_mutate(self):
-    app_id = 'guestbook'
-    transaction = 1
-    # Mock cassandra response
-    async_response = Future()
-    async_response.set_result(None)
-    self.execute_mock.return_value = async_response
-
-    # Call function under test making sure it doesn't through exception
-    result = yield self.db.batch_mutate(app_id, [], [], transaction)
-
-    # Simple check for now
-    self.assertEqual(result, None)
-
 
 if __name__ == "__main__":
   unittest.main()

--- a/AppDB/test/unit/test_datastore_server.py
+++ b/AppDB/test/unit/test_datastore_server.py
@@ -371,7 +371,7 @@ class TestDatastoreServer(testing.AsyncTestCase):
     async_result.set_result({entity_key1: {}, entity_key2: {}})
 
     db_batch.should_receive('batch_get_entity').and_return(async_result)
-    db_batch.should_receive('batch_mutate').and_return(ASYNC_NONE)
+    db_batch.should_receive('normal_batch').and_return(ASYNC_NONE)
     transaction_manager = flexmock(
       create_transaction_id=lambda project, xg: 1,
       delete_transaction_id=lambda project, txid: None,
@@ -415,7 +415,7 @@ class TestDatastoreServer(testing.AsyncTestCase):
     async_result.set_result({entity_key1: {}, entity_key2: {}})
 
     db_batch.should_receive('batch_get_entity').and_return(async_result)
-    db_batch.should_receive('batch_mutate').and_return(ASYNC_NONE)
+    db_batch.should_receive('normal_batch').and_return(ASYNC_NONE)
     transaction_manager = flexmock(
       create_transaction_id=lambda project, xg: 1,
       delete_transaction_id=lambda project, txid: None,
@@ -499,8 +499,7 @@ class TestDatastoreServer(testing.AsyncTestCase):
     db_batch = flexmock()
     db_batch.should_receive('valid_data_version_sync').and_return(True)
     db_batch.should_receive("batch_get_entity").and_return(async_result)
-    db_batch.should_receive('batch_mutate').and_return(ASYNC_NONE)
-    db_batch.should_receive('_normal_batch').and_return(ASYNC_NONE)
+    db_batch.should_receive('normal_batch').and_return(ASYNC_NONE)
 
     transaction_manager = flexmock()
     dd = DatastoreDistributed(db_batch, transaction_manager, zookeeper)
@@ -1093,7 +1092,7 @@ class TestDatastoreServer(testing.AsyncTestCase):
     async_result.set_result({entity_key: {}})
 
     db_batch.should_receive('batch_get_entity').and_return(async_result)
-    db_batch.should_receive('batch_mutate').and_return(ASYNC_NONE)
+    db_batch.should_receive('normal_batch').and_return(ASYNC_NONE)
 
     async_true = gen.Future()
     async_true.set_result(True)


### PR DESCRIPTION
This allows the datastore server to clean up entity group locks when it can. When a failure happens during a normal batch or before a large batch has been marked as "applied", the server can release the locks before returning the error.

This also makes the server more persistent after it passes the point of no return for large batches. The additional retries makes it less likely for the server to give up and leave the locks around for the transaction groomer to clean up.