### PR TITLE
Handle exception when fetching datastore servers

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2611,9 +2611,15 @@ class Djinn
   end
 
   def update_db_haproxy
-    servers = ZKInterface.get_datastore_servers.map { |machine_ip, port|
-      {'ip' => machine_ip, 'port' => port}
-    }
+    begin
+      servers = ZKInterface.get_datastore_servers.map { |machine_ip, port|
+        {'ip' => machine_ip, 'port' => port}
+      }
+    rescue FailedZooKeeperOperationException
+      Djinn.log_warn('Unable to fetch list of datastore servers')
+      return
+    end
+
     HAProxy.create_app_config(servers, '*', DatastoreServer::PROXY_PORT,
                               DatastoreServer::NAME)
   end


### PR DESCRIPTION
This fixes an issue I introduced with https://github.com/AppScale/appscale/pull/2696 where the controller will crash if the list of datastore servers does not exist.