### PR TITLE
Handle "service" element

### DIFF
--- a/AppServer/google/appengine/api/appinfo.py
+++ b/AppServer/google/appengine/api/appinfo.py
@@ -211,6 +211,7 @@ APPLICATION_READABLE = 'application_readable'
 
 APPLICATION = 'application'
 MODULE = 'module'
+SERVICE = 'service'
 AUTOMATIC_SCALING = 'automatic_scaling'
 MANUAL_SCALING = 'manual_scaling'
 BASIC_SCALING = 'basic_scaling'
@@ -1503,6 +1504,8 @@ class AppInfoExternal(validation.Validated):
 
       APPLICATION: validation.Optional(APPLICATION_RE_STRING),
       MODULE: validation.Optional(MODULE_ID_RE_STRING),
+
+      SERVICE: validation.Optional(MODULE_ID_RE_STRING),
       VERSION: validation.Optional(MODULE_VERSION_ID_RE_STRING),
       RUNTIME: RUNTIME_RE_STRING,
 
@@ -1559,6 +1562,7 @@ class AppInfoExternal(validation.Validated):
       - If the runtime is python27 and threadsafe is set, then no CGI handlers
         can be used.
       - That the version name doesn't start with BUILTIN_NAME_PREFIX
+      - That module and service aren't both set
 
     Raises:
       DuplicateLibrary: if the name library name is specified more than once.
@@ -1570,6 +1574,7 @@ class AppInfoExternal(validation.Validated):
           and CGI handlers are specified.
       TooManyScalingSettingsError: if more than one scaling settings block is
           present.
+      ModuleAndServiceDefined: if both 'module' and 'service' keywords are used.
     """
     super(AppInfoExternal, self).CheckInitialized()
     if not self.handlers and not self.builtins and not self.includes:
@@ -1579,6 +1584,9 @@ class AppInfoExternal(validation.Validated):
       raise appinfo_errors.TooManyURLMappings(
           'Found more than %d URLMap entries in application configuration' %
           MAX_URL_MAPS)
+    if self.service and self.module:
+      raise appinfo_errors.ModuleAndServiceDefined(
+          'Cannot define both "module" and "service" in configuration')
 
     if (self.threadsafe is None and
         self.runtime == 'python27' and

--- a/AppServer/google/appengine/api/appinfo_errors.py
+++ b/AppServer/google/appengine/api/appinfo_errors.py
@@ -38,6 +38,10 @@ class EmptyConfigurationFile(Error):
   """Tried to load empty configuration file"""
 
 
+class ModuleAndServiceDefined(Error):
+  """Configuration has both 'module' and 'service' instead of just one."""
+
+
 class MultipleConfigurationFile(Error):
   """Tried to load configuration file with multiple AppInfo objects"""
 

--- a/AppServer/google/appengine/tools/devappserver2/application_configuration.py
+++ b/AppServer/google/appengine/tools/devappserver2/application_configuration.py
@@ -82,6 +82,12 @@ class ModuleConfiguration(object):
 
     self._app_info_external, files_to_check = self._parse_configuration(
         self._yaml_path)
+
+    # TODO: As in AppengineApiClient._CreateVersionResource,
+    # add deprecation warnings and remove this code
+    if self._app_info_external.service:
+      self._app_info_external.module = self._app_info_external.service
+
     if app_id:
       self._app_info_external.application = app_id
     self._mtimes = self._get_mtimes([self._yaml_path] + files_to_check)


### PR DESCRIPTION
This allows instances to start with the "service" element instead of "module".

Resolves #2747 