### PR TITLE
Define CURRENT_MODULE_ID

### DIFF
--- a/AppServer/google/appengine/api/modules/modules.py
+++ b/AppServer/google/appengine/api/modules/modules.py
@@ -97,12 +97,7 @@ def get_current_module_name():
   If this is version "v1" of module "module5" for app "my-app", this function
   will return "module5".
   """
-  module = _split_version_id(os.environ['CURRENT_VERSION_ID'])[0]
-  if not module:
-
-
-    return 'default'
-  return module
+  return os.environ['CURRENT_MODULE_ID']
 
 
 def get_current_version_name():

--- a/AppServer/google/appengine/tools/devappserver2/python/request_handler.py
+++ b/AppServer/google/appengine/tools/devappserver2/python/request_handler.py
@@ -33,6 +33,7 @@ import google
 
 from google.appengine.api import api_base_pb
 from google.appengine.api import apiproxy_stub_map
+from google.appengine.api import appinfo
 from google.appengine.api.logservice import log_service_pb
 from google.appengine.api.logservice import logservice
 from google.appengine.ext.remote_api import remote_api_stub
@@ -51,8 +52,15 @@ class RequestHandler(object):
 
   def __init__(self, config):
     self.config = config
+    if appinfo.MODULE_SEPARATOR not in config.version_id:
+      module_id = appinfo.DEFAULT_MODULE
+    else:
+      module_id, _ = config.version_id.split(appinfo.MODULE_SEPARATOR)
+
     self.environ_template = {
         'APPLICATION_ID': config.app_id,
+        'CURRENT_MODULE_ID': module_id,
+        # AppScale TODO: Use the actual version ID here.
         'CURRENT_VERSION_ID': config.version_id,
         'DATACENTER': config.datacenter.encode('ascii'),
         'INSTANCE_ID': config.instance_id.encode('ascii'),


### PR DESCRIPTION
This environment variable was introduced in the 1.8.3 SDK. For now, CURRENT_VERSION_ID remains as it was before (eg. service-id:version-id.minor-version) for compatibility reasons.