### PR TITLE
Fix blobstore-backed GCS operations

### DIFF
--- a/APIServer/app_identity_service.proto
+++ b/APIServer/app_identity_service.proto
@@ -50,3 +50,10 @@ message GetAccessTokenResponse {
   optional bytes access_token = 1;
   optional int64 expiration_time = 2;
 }
+
+message GetDefaultGcsBucketNameRequest {
+}
+
+message GetDefaultGcsBucketNameResponse {
+  optional string default_gcs_bucket_name = 1;
+}

--- a/APIServer/appscale/api_server/app_identity.py
+++ b/APIServer/appscale/api_server/app_identity.py
@@ -28,6 +28,9 @@ class AppIdentityService(BaseService):
     """ Implements the App Identity API. """
     SERVICE_NAME = 'app_identity_service'
 
+    # A dummy bucket name for satisfying calls.
+    DEFAULT_GCS_BUCKET_NAME = 'app_default_bucket'
+
     # The appropriate messages for each API call.
     METHODS = {'SignForApp': (service_pb.SignForAppRequest,
                               service_pb.SignForAppResponse),
@@ -38,7 +41,10 @@ class AppIdentityService(BaseService):
                    service_pb.GetServiceAccountNameRequest,
                    service_pb.GetServiceAccountNameResponse),
                'GetAccessToken': (service_pb.GetAccessTokenRequest,
-                                  service_pb.GetAccessTokenResponse)}
+                                  service_pb.GetAccessTokenResponse),
+               'GetDefaultGcsBucketName': (
+                   service_pb.GetDefaultGcsBucketNameRequest,
+                   service_pb.GetDefaultGcsBucketNameResponse)}
 
     def __init__(self, project_id, zk_client):
         """ Creates a new AppIdentityService.
@@ -203,6 +209,8 @@ class AppIdentityService(BaseService):
 
             response.access_token = token.token
             response.expiration_time = token.expiration_time
+        elif method == 'GetDefaultGcsBucketName':
+            response.default_gcs_bucket_name = self.DEFAULT_GCS_BUCKET_NAME
 
         return response.SerializeToString()
 

--- a/AppServer/google/appengine/api/app_identity/app_identity_service_pb.py
+++ b/AppServer/google/appengine/api/app_identity/app_identity_service_pb.py
@@ -171,7 +171,7 @@ class AppIdentityServiceError(ProtocolBuffer.ProtocolMessage):
   _STYLE_CONTENT_TYPE = """"""
   _PROTO_DESCRIPTOR_NAME = 'apphosting.AppIdentityServiceError'
   _SERIALIZED_DESCRIPTOR = array.array('B')
-  _SERIALIZED_DESCRIPTOR.fromstring(base64.decodestring("WjZhcHBob3N0aW5nL2FwaS9hcHBfaWRlbnRpdHkvYXBwX2lkZW50aXR5X3NlcnZpY2UucHJvdG8KImFwcGhvc3RpbmcuQXBwSWRlbnRpdHlTZXJ2aWNlRXJyb3JzeglFcnJvckNvZGWLAZIBB1NVQ0NFU1OYAQCMAYsBkgENVU5LTk9XTl9TQ09QRZgBCYwBiwGSAQ5CTE9CX1RPT19MQVJHRZgB6AeMAYsBkgERREVBRExJTkVfRVhDRUVERUSYAekHjAGLAZIBD05PVF9BX1ZBTElEX0FQUJgB6geMAYsBkgENVU5LTk9XTl9FUlJPUpgB6weMAYsBkgEZR0FJQU1JTlRfTk9UX0lOSVRJQUlMSVpFRJgB7AeMAYsBkgELTk9UX0FMTE9XRUSYAe0HjAGLAZIBD05PVF9JTVBMRU1FTlRFRJgB7geMAXS6Ae8KCjZhcHBob3N0aW5nL2FwaS9hcHBfaWRlbnRpdHkvYXBwX2lkZW50aXR5X3NlcnZpY2UucHJvdG8SCmFwcGhvc3Rpbmci5gEKF0FwcElkZW50aXR5U2VydmljZUVycm9yIsoBCglFcnJvckNvZGUSCwoHU1VDQ0VTUxAAEhEKDVVOS05PV05fU0NPUEUQCRITCg5CTE9CX1RPT19MQVJHRRDoBxIWChFERUFETElORV9FWENFRURFRBDpBxIUCg9OT1RfQV9WQUxJRF9BUFAQ6gcSEgoNVU5LTk9XTl9FUlJPUhDrBxIeChlHQUlBTUlOVF9OT1RfSU5JVElBSUxJWkVEEOwHEhAKC05PVF9BTExPV0VEEO0HEhQKD05PVF9JTVBMRU1FTlRFRBDuByIqChFTaWduRm9yQXBwUmVxdWVzdBIVCg1ieXRlc190b19zaWduGAEgASgMIj8KElNpZ25Gb3JBcHBSZXNwb25zZRIQCghrZXlfbmFtZRgBIAEoCRIXCg9zaWduYXR1cmVfYnl0ZXMYAiABKAwiIwohR2V0UHVibGljQ2VydGlmaWNhdGVGb3JBcHBSZXF1ZXN0IkMKEVB1YmxpY0NlcnRpZmljYXRlEhAKCGtleV9uYW1lGAEgASgJEhwKFHg1MDlfY2VydGlmaWNhdGVfcGVtGAIgASgJIo0BCiJHZXRQdWJsaWNDZXJ0aWZpY2F0ZUZvckFwcFJlc3BvbnNlEj4KF3B1YmxpY19jZXJ0aWZpY2F0ZV9saXN0GAEgAygLMh0uYXBwaG9zdGluZy5QdWJsaWNDZXJ0aWZpY2F0ZRInCh9tYXhfY2xpZW50X2NhY2hlX3RpbWVfaW5fc2Vjb25kGAIgASgDIh4KHEdldFNlcnZpY2VBY2NvdW50TmFtZVJlcXVlc3QiPQodR2V0U2VydmljZUFjY291bnROYW1lUmVzcG9uc2USHAoUc2VydmljZV9hY2NvdW50X25hbWUYASABKAkiQgoVR2V0QWNjZXNzVG9rZW5SZXF1ZXN0Eg0KBXNjb3BlGAEgAygJEhoKEnNlcnZpY2VfYWNjb3VudF9pZBgCIAEoAyJHChZHZXRBY2Nlc3NUb2tlblJlc3BvbnNlEhQKDGFjY2Vzc190b2tlbhgBIAEoCRIXCg9leHBpcmF0aW9uX3RpbWUYAiABKAMyqgMKDlNpZ25pbmdTZXJ2aWNlEk0KClNpZ25Gb3JBcHASHS5hcHBob3N0aW5nLlNpZ25Gb3JBcHBSZXF1ZXN0Gh4uYXBwaG9zdGluZy5TaWduRm9yQXBwUmVzcG9uc2UiABJ+ChtHZXRQdWJsaWNDZXJ0aWZpY2F0ZXNGb3JBcHASLS5hcHBob3N0aW5nLkdldFB1YmxpY0NlcnRpZmljYXRlRm9yQXBwUmVxdWVzdBouLmFwcGhvc3RpbmcuR2V0UHVibGljQ2VydGlmaWNhdGVGb3JBcHBSZXNwb25zZSIAEm4KFUdldFNlcnZpY2VBY2NvdW50TmFtZRIoLmFwcGhvc3RpbmcuR2V0U2VydmljZUFjY291bnROYW1lUmVxdWVzdBopLmFwcGhvc3RpbmcuR2V0U2VydmljZUFjY291bnROYW1lUmVzcG9uc2UiABJZCg5HZXRBY2Nlc3NUb2tlbhIhLmFwcGhvc3RpbmcuR2V0QWNjZXNzVG9rZW5SZXF1ZXN0GiIuYXBwaG9zdGluZy5HZXRBY2Nlc3NUb2tlblJlc3BvbnNlIgBCQAokY29tLmdvb2dsZS5hcHBlbmdpbmUuYXBpLmFwcGlkZW50aXR5IAEoAkIUQXBwSWRlbnRpdHlTZXJ2aWNlUGI="))
+  _SERIALIZED_DESCRIPTOR.fromstring(base64.decodestring("WjZhcHBob3N0aW5nL2FwaS9hcHBfaWRlbnRpdHkvYXBwX2lkZW50aXR5X3NlcnZpY2UucHJvdG8KImFwcGhvc3RpbmcuQXBwSWRlbnRpdHlTZXJ2aWNlRXJyb3JzeglFcnJvckNvZGWLAZIBB1NVQ0NFU1OYAQCMAYsBkgENVU5LTk9XTl9TQ09QRZgBCYwBiwGSAQ5CTE9CX1RPT19MQVJHRZgB6AeMAYsBkgERREVBRExJTkVfRVhDRUVERUSYAekHjAGLAZIBD05PVF9BX1ZBTElEX0FQUJgB6geMAYsBkgENVU5LTk9XTl9FUlJPUpgB6weMAYsBkgEZR0FJQU1JTlRfTk9UX0lOSVRJQUlMSVpFRJgB7AeMAYsBkgELTk9UX0FMTE9XRUSYAe0HjAGLAZIBD05PVF9JTVBMRU1FTlRFRJgB7geMAXS6AekMCjZhcHBob3N0aW5nL2FwaS9hcHBfaWRlbnRpdHkvYXBwX2lkZW50aXR5X3NlcnZpY2UucHJvdG8SCmFwcGhvc3Rpbmci5gEKF0FwcElkZW50aXR5U2VydmljZUVycm9yIsoBCglFcnJvckNvZGUSCwoHU1VDQ0VTUxAAEhEKDVVOS05PV05fU0NPUEUQCRITCg5CTE9CX1RPT19MQVJHRRDoBxIWChFERUFETElORV9FWENFRURFRBDpBxIUCg9OT1RfQV9WQUxJRF9BUFAQ6gcSEgoNVU5LTk9XTl9FUlJPUhDrBxIeChlHQUlBTUlOVF9OT1RfSU5JVElBSUxJWkVEEOwHEhAKC05PVF9BTExPV0VEEO0HEhQKD05PVF9JTVBMRU1FTlRFRBDuByIqChFTaWduRm9yQXBwUmVxdWVzdBIVCg1ieXRlc190b19zaWduGAEgASgMIj8KElNpZ25Gb3JBcHBSZXNwb25zZRIQCghrZXlfbmFtZRgBIAEoCRIXCg9zaWduYXR1cmVfYnl0ZXMYAiABKAwiIwohR2V0UHVibGljQ2VydGlmaWNhdGVGb3JBcHBSZXF1ZXN0IkMKEVB1YmxpY0NlcnRpZmljYXRlEhAKCGtleV9uYW1lGAEgASgJEhwKFHg1MDlfY2VydGlmaWNhdGVfcGVtGAIgASgJIo0BCiJHZXRQdWJsaWNDZXJ0aWZpY2F0ZUZvckFwcFJlc3BvbnNlEj4KF3B1YmxpY19jZXJ0aWZpY2F0ZV9saXN0GAEgAygLMh0uYXBwaG9zdGluZy5QdWJsaWNDZXJ0aWZpY2F0ZRInCh9tYXhfY2xpZW50X2NhY2hlX3RpbWVfaW5fc2Vjb25kGAIgASgDIh4KHEdldFNlcnZpY2VBY2NvdW50TmFtZVJlcXVlc3QiPQodR2V0U2VydmljZUFjY291bnROYW1lUmVzcG9uc2USHAoUc2VydmljZV9hY2NvdW50X25hbWUYASABKAkiYAoVR2V0QWNjZXNzVG9rZW5SZXF1ZXN0Eg0KBXNjb3BlGAEgAygJEhoKEnNlcnZpY2VfYWNjb3VudF9pZBgCIAEoAxIcChRzZXJ2aWNlX2FjY291bnRfbmFtZRgDIAEoCSJHChZHZXRBY2Nlc3NUb2tlblJlc3BvbnNlEhQKDGFjY2Vzc190b2tlbhgBIAEoCRIXCg9leHBpcmF0aW9uX3RpbWUYAiABKAMiIAoeR2V0RGVmYXVsdEdjc0J1Y2tldE5hbWVSZXF1ZXN0IkIKH0dldERlZmF1bHRHY3NCdWNrZXROYW1lUmVzcG9uc2USHwoXZGVmYXVsdF9nY3NfYnVja2V0X25hbWUYASABKAkyoAQKDlNpZ25pbmdTZXJ2aWNlEk0KClNpZ25Gb3JBcHASHS5hcHBob3N0aW5nLlNpZ25Gb3JBcHBSZXF1ZXN0Gh4uYXBwaG9zdGluZy5TaWduRm9yQXBwUmVzcG9uc2UiABJ+ChtHZXRQdWJsaWNDZXJ0aWZpY2F0ZXNGb3JBcHASLS5hcHBob3N0aW5nLkdldFB1YmxpY0NlcnRpZmljYXRlRm9yQXBwUmVxdWVzdBouLmFwcGhvc3RpbmcuR2V0UHVibGljQ2VydGlmaWNhdGVGb3JBcHBSZXNwb25zZSIAEm4KFUdldFNlcnZpY2VBY2NvdW50TmFtZRIoLmFwcGhvc3RpbmcuR2V0U2VydmljZUFjY291bnROYW1lUmVxdWVzdBopLmFwcGhvc3RpbmcuR2V0U2VydmljZUFjY291bnROYW1lUmVzcG9uc2UiABJZCg5HZXRBY2Nlc3NUb2tlbhIhLmFwcGhvc3RpbmcuR2V0QWNjZXNzVG9rZW5SZXF1ZXN0GiIuYXBwaG9zdGluZy5HZXRBY2Nlc3NUb2tlblJlc3BvbnNlIgASdAoXR2V0RGVmYXVsdEdjc0J1Y2tldE5hbWUSKi5hcHBob3N0aW5nLkdldERlZmF1bHRHY3NCdWNrZXROYW1lUmVxdWVzdBorLmFwcGhvc3RpbmcuR2V0RGVmYXVsdEdjc0J1Y2tldE5hbWVSZXNwb25zZSIAQkAKJGNvbS5nb29nbGUuYXBwZW5naW5lLmFwaS5hcHBpZGVudGl0eSABKAJCFEFwcElkZW50aXR5U2VydmljZVBi"))
   if _net_proto___parse__python is not None:
     _net_proto___parse__python.RegisterType(
         _SERIALIZED_DESCRIPTOR.tostring())
@@ -1466,6 +1466,232 @@ class GetAccessTokenResponse(ProtocolBuffer.ProtocolMessage):
     _net_proto___parse__python.RegisterType(
         _SERIALIZED_DESCRIPTOR.tostring())
 
+class GetDefaultGcsBucketNameRequest(ProtocolBuffer.ProtocolMessage):
+
+  def __init__(self, contents=None):
+    pass
+    if contents is not None: self.MergeFromString(contents)
+
+
+  def MergeFrom(self, x):
+    assert x is not self
+
+  if _net_proto___parse__python is not None:
+    def _CMergeFromString(self, s):
+      _net_proto___parse__python.MergeFromString(self, 'apphosting.GetDefaultGcsBucketNameRequest', s)
+
+  if _net_proto___parse__python is not None:
+    def _CEncode(self):
+      return _net_proto___parse__python.Encode(self, 'apphosting.GetDefaultGcsBucketNameRequest')
+
+  if _net_proto___parse__python is not None:
+    def _CEncodePartial(self):
+      return _net_proto___parse__python.EncodePartial(self, 'apphosting.GetDefaultGcsBucketNameRequest')
+
+  if _net_proto___parse__python is not None:
+    def _CToASCII(self, output_format):
+      return _net_proto___parse__python.ToASCII(self, 'apphosting.GetDefaultGcsBucketNameRequest', output_format)
+
+
+  if _net_proto___parse__python is not None:
+    def ParseASCII(self, s):
+      _net_proto___parse__python.ParseASCII(self, 'apphosting.GetDefaultGcsBucketNameRequest', s)
+
+
+  if _net_proto___parse__python is not None:
+    def ParseASCIIIgnoreUnknown(self, s):
+      _net_proto___parse__python.ParseASCIIIgnoreUnknown(self, 'apphosting.GetDefaultGcsBucketNameRequest', s)
+
+
+  def Equals(self, x):
+    if x is self: return 1
+    return 1
+
+  def IsInitialized(self, debug_strs=None):
+    initialized = 1
+    return initialized
+
+  def ByteSize(self):
+    n = 0
+    return n
+
+  def ByteSizePartial(self):
+    n = 0
+    return n
+
+  def Clear(self):
+    pass
+
+  def OutputUnchecked(self, out):
+    pass
+
+  def OutputPartial(self, out):
+    pass
+
+  def TryMerge(self, d):
+    while d.avail() > 0:
+      tt = d.getVarInt32()
+
+
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      d.skipData(tt)
+
+
+  def __str__(self, prefix="", printElemNumber=0):
+    res=""
+    return res
+
+
+  def _BuildTagLookupTable(sparse, maxtag, default=None):
+    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+
+
+  _TEXT = _BuildTagLookupTable({
+    0: "ErrorCode",
+  }, 0)
+
+  _TYPES = _BuildTagLookupTable({
+    0: ProtocolBuffer.Encoder.NUMERIC,
+  }, 0, ProtocolBuffer.Encoder.MAX_TYPE)
+
+
+  _STYLE = """"""
+  _STYLE_CONTENT_TYPE = """"""
+  _PROTO_DESCRIPTOR_NAME = 'apphosting.GetDefaultGcsBucketNameRequest'
+  _SERIALIZED_DESCRIPTOR = array.array('B')
+  _SERIALIZED_DESCRIPTOR.fromstring(base64.decodestring("WjZhcHBob3N0aW5nL2FwaS9hcHBfaWRlbnRpdHkvYXBwX2lkZW50aXR5X3NlcnZpY2UucHJvdG8KKWFwcGhvc3RpbmcuR2V0RGVmYXVsdEdjc0J1Y2tldE5hbWVSZXF1ZXN0wgEiYXBwaG9zdGluZy5BcHBJZGVudGl0eVNlcnZpY2VFcnJvcg=="))
+  if _net_proto___parse__python is not None:
+    _net_proto___parse__python.RegisterType(
+        _SERIALIZED_DESCRIPTOR.tostring())
+
+class GetDefaultGcsBucketNameResponse(ProtocolBuffer.ProtocolMessage):
+  has_default_gcs_bucket_name_ = 0
+  default_gcs_bucket_name_ = ""
+
+  def __init__(self, contents=None):
+    if contents is not None: self.MergeFromString(contents)
+
+  def default_gcs_bucket_name(self): return self.default_gcs_bucket_name_
+
+  def set_default_gcs_bucket_name(self, x):
+    self.has_default_gcs_bucket_name_ = 1
+    self.default_gcs_bucket_name_ = x
+
+  def clear_default_gcs_bucket_name(self):
+    if self.has_default_gcs_bucket_name_:
+      self.has_default_gcs_bucket_name_ = 0
+      self.default_gcs_bucket_name_ = ""
+
+  def has_default_gcs_bucket_name(self): return self.has_default_gcs_bucket_name_
+
+
+  def MergeFrom(self, x):
+    assert x is not self
+    if (x.has_default_gcs_bucket_name()): self.set_default_gcs_bucket_name(x.default_gcs_bucket_name())
+
+  if _net_proto___parse__python is not None:
+    def _CMergeFromString(self, s):
+      _net_proto___parse__python.MergeFromString(self, 'apphosting.GetDefaultGcsBucketNameResponse', s)
+
+  if _net_proto___parse__python is not None:
+    def _CEncode(self):
+      return _net_proto___parse__python.Encode(self, 'apphosting.GetDefaultGcsBucketNameResponse')
+
+  if _net_proto___parse__python is not None:
+    def _CEncodePartial(self):
+      return _net_proto___parse__python.EncodePartial(self, 'apphosting.GetDefaultGcsBucketNameResponse')
+
+  if _net_proto___parse__python is not None:
+    def _CToASCII(self, output_format):
+      return _net_proto___parse__python.ToASCII(self, 'apphosting.GetDefaultGcsBucketNameResponse', output_format)
+
+
+  if _net_proto___parse__python is not None:
+    def ParseASCII(self, s):
+      _net_proto___parse__python.ParseASCII(self, 'apphosting.GetDefaultGcsBucketNameResponse', s)
+
+
+  if _net_proto___parse__python is not None:
+    def ParseASCIIIgnoreUnknown(self, s):
+      _net_proto___parse__python.ParseASCIIIgnoreUnknown(self, 'apphosting.GetDefaultGcsBucketNameResponse', s)
+
+
+  def Equals(self, x):
+    if x is self: return 1
+    if self.has_default_gcs_bucket_name_ != x.has_default_gcs_bucket_name_: return 0
+    if self.has_default_gcs_bucket_name_ and self.default_gcs_bucket_name_ != x.default_gcs_bucket_name_: return 0
+    return 1
+
+  def IsInitialized(self, debug_strs=None):
+    initialized = 1
+    return initialized
+
+  def ByteSize(self):
+    n = 0
+    if (self.has_default_gcs_bucket_name_): n += 1 + self.lengthString(len(self.default_gcs_bucket_name_))
+    return n
+
+  def ByteSizePartial(self):
+    n = 0
+    if (self.has_default_gcs_bucket_name_): n += 1 + self.lengthString(len(self.default_gcs_bucket_name_))
+    return n
+
+  def Clear(self):
+    self.clear_default_gcs_bucket_name()
+
+  def OutputUnchecked(self, out):
+    if (self.has_default_gcs_bucket_name_):
+      out.putVarInt32(10)
+      out.putPrefixedString(self.default_gcs_bucket_name_)
+
+  def OutputPartial(self, out):
+    if (self.has_default_gcs_bucket_name_):
+      out.putVarInt32(10)
+      out.putPrefixedString(self.default_gcs_bucket_name_)
+
+  def TryMerge(self, d):
+    while d.avail() > 0:
+      tt = d.getVarInt32()
+      if tt == 10:
+        self.set_default_gcs_bucket_name(d.getPrefixedString())
+        continue
+
+
+      if (tt == 0): raise ProtocolBuffer.ProtocolBufferDecodeError
+      d.skipData(tt)
+
+
+  def __str__(self, prefix="", printElemNumber=0):
+    res=""
+    if self.has_default_gcs_bucket_name_: res+=prefix+("default_gcs_bucket_name: %s\n" % self.DebugFormatString(self.default_gcs_bucket_name_))
+    return res
+
+
+  def _BuildTagLookupTable(sparse, maxtag, default=None):
+    return tuple([sparse.get(i, default) for i in xrange(0, 1+maxtag)])
+
+  kdefault_gcs_bucket_name = 1
+
+  _TEXT = _BuildTagLookupTable({
+    0: "ErrorCode",
+    1: "default_gcs_bucket_name",
+  }, 1)
+
+  _TYPES = _BuildTagLookupTable({
+    0: ProtocolBuffer.Encoder.NUMERIC,
+    1: ProtocolBuffer.Encoder.STRING,
+  }, 1, ProtocolBuffer.Encoder.MAX_TYPE)
+
+
+  _STYLE = """"""
+  _STYLE_CONTENT_TYPE = """"""
+  _PROTO_DESCRIPTOR_NAME = 'apphosting.GetDefaultGcsBucketNameResponse'
+  _SERIALIZED_DESCRIPTOR = array.array('B')
+  _SERIALIZED_DESCRIPTOR.fromstring(base64.decodestring("WjZhcHBob3N0aW5nL2FwaS9hcHBfaWRlbnRpdHkvYXBwX2lkZW50aXR5X3NlcnZpY2UucHJvdG8KKmFwcGhvc3RpbmcuR2V0RGVmYXVsdEdjc0J1Y2tldE5hbWVSZXNwb25zZRMaF2RlZmF1bHRfZ2NzX2J1Y2tldF9uYW1lIAEoAjAJOAEUwgEiYXBwaG9zdGluZy5BcHBJZGVudGl0eVNlcnZpY2VFcnJvcg=="))
+  if _net_proto___parse__python is not None:
+    _net_proto___parse__python.RegisterType(
+        _SERIALIZED_DESCRIPTOR.tostring())
+
 
 
 class _SigningService_ClientBaseStub(_client_stub_base_class):
@@ -1476,6 +1702,7 @@ class _SigningService_ClientBaseStub(_client_stub_base_class):
       '_protorpc_GetPublicCertificatesForApp', '_full_name_GetPublicCertificatesForApp',
       '_protorpc_GetServiceAccountName', '_full_name_GetServiceAccountName',
       '_protorpc_GetAccessToken', '_full_name_GetAccessToken',
+      '_protorpc_GetDefaultGcsBucketName', '_full_name_GetDefaultGcsBucketName',
   )
 
   def __init__(self, rpc_stub):
@@ -1496,6 +1723,10 @@ class _SigningService_ClientBaseStub(_client_stub_base_class):
     self._protorpc_GetAccessToken = pywraprpc.RPC()
     self._full_name_GetAccessToken = self._stub.GetFullMethodName(
         'GetAccessToken')
+
+    self._protorpc_GetDefaultGcsBucketName = pywraprpc.RPC()
+    self._full_name_GetDefaultGcsBucketName = self._stub.GetFullMethodName(
+        'GetDefaultGcsBucketName')
 
   def SignForApp(self, request, rpc=None, callback=None, response=None):
     """Make a SignForApp RPC call.
@@ -1597,6 +1828,31 @@ class _SigningService_ClientBaseStub(_client_stub_base_class):
                           callback,
                           self._protorpc_GetAccessToken)
 
+  def GetDefaultGcsBucketName(self, request, rpc=None, callback=None, response=None):
+    """Make a GetDefaultGcsBucketName RPC call.
+
+    Args:
+      request: a GetDefaultGcsBucketNameRequest instance.
+      rpc: Optional RPC instance to use for the call.
+      callback: Optional final callback. Will be called as
+          callback(rpc, result) when the rpc completes. If None, the
+          call is synchronous.
+      response: Optional ProtocolMessage to be filled in with response.
+
+    Returns:
+      The GetDefaultGcsBucketNameResponse if callback is None. Otherwise, returns None.
+    """
+
+    if response is None:
+      response = GetDefaultGcsBucketNameResponse
+    return self._MakeCall(rpc,
+                          self._full_name_GetDefaultGcsBucketName,
+                          'GetDefaultGcsBucketName',
+                          request,
+                          response,
+                          callback,
+                          self._protorpc_GetDefaultGcsBucketName)
+
 
 class _SigningService_ClientStub(_SigningService_ClientBaseStub):
   __slots__ = ('_params',)
@@ -1632,6 +1888,7 @@ class SigningService(_server_stub_base_class):
       'GetPublicCertificatesForApp': (GetPublicCertificateForAppRequest, GetPublicCertificateForAppResponse),
       'GetServiceAccountName': (GetServiceAccountNameRequest, GetServiceAccountNameResponse),
       'GetAccessToken': (GetAccessTokenRequest, GetAccessTokenResponse),
+      'GetDefaultGcsBucketName': (GetDefaultGcsBucketNameRequest, GetDefaultGcsBucketNameResponse),
       }
 
   def __init__(self, *args, **kwargs):
@@ -1715,6 +1972,17 @@ class SigningService(_server_stub_base_class):
     """
     raise NotImplementedError
 
+
+  def GetDefaultGcsBucketName(self, rpc, request, response):
+    """Handles a GetDefaultGcsBucketName RPC call. You should override this.
+
+    Args:
+      rpc: a Stubby RPC object
+      request: a GetDefaultGcsBucketNameRequest that contains the client request
+      response: a GetDefaultGcsBucketNameResponse that should be modified to send the response
+    """
+    raise NotImplementedError
+
   def _AddMethodAttributes(self):
     """Sets attributes on Python RPC handlers.
 
@@ -1744,8 +2012,14 @@ class SigningService(_server_stub_base_class):
         GetAccessTokenResponse,
         None,
         'none')
+    rpcserver._GetHandlerDecorator(
+        self.GetDefaultGcsBucketName.im_func,
+        GetDefaultGcsBucketNameRequest,
+        GetDefaultGcsBucketNameResponse,
+        None,
+        'none')
 
 if _extension_runtime:
   pass
 
-__all__ = ['AppIdentityServiceError','SignForAppRequest','SignForAppResponse','GetPublicCertificateForAppRequest','PublicCertificate','GetPublicCertificateForAppResponse','GetServiceAccountNameRequest','GetServiceAccountNameResponse','GetAccessTokenRequest','GetAccessTokenResponse','SigningService']
+__all__ = ['AppIdentityServiceError','SignForAppRequest','SignForAppResponse','GetPublicCertificateForAppRequest','PublicCertificate','GetPublicCertificateForAppResponse','GetServiceAccountNameRequest','GetServiceAccountNameResponse','GetAccessTokenRequest','GetAccessTokenResponse','GetDefaultGcsBucketNameRequest','GetDefaultGcsBucketNameResponse','SigningService']

--- a/AppServer/google/appengine/api/app_identity/app_identity_stub.py
+++ b/AppServer/google/appengine/api/app_identity/app_identity_stub.py
@@ -48,6 +48,7 @@ except ImportError, e:
 from google.appengine.api import apiproxy_stub
 
 APP_SERVICE_ACCOUNT_NAME = 'test@localhost'
+APP_DEFAULT_GCS_BUCKET_NAME = 'app_default_bucket'
 
 SIGNING_KEY_NAME = 'key'
 
@@ -97,9 +98,12 @@ class AppIdentityServiceStub(apiproxy_stub.APIProxyStub):
   Provides stub functions which allow a developer to test integration before
   deployment.
   """
+  THREADSAFE = True
+
   def __init__(self, service_name='app_identity_service'):
     """Constructor."""
     super(AppIdentityServiceStub, self).__init__(service_name)
+    self.__default_gcs_bucket_name = APP_DEFAULT_GCS_BUCKET_NAME
 
   def _Dynamic_SignForApp(self, request, response):
     """Implementation of AppIdentityService::SignForApp."""
@@ -125,6 +129,16 @@ class AppIdentityServiceStub(apiproxy_stub.APIProxyStub):
   def _Dynamic_GetServiceAccountName(self, request, response):
     """Implementation of AppIdentityService::GetServiceAccountName"""
     response.set_service_account_name(APP_SERVICE_ACCOUNT_NAME)
+
+  def _Dynamic_GetDefaultGcsBucketName(self, unused_request, response):
+    """Implementation of AppIdentityService::GetDefaultGcsBucketName."""
+    response.set_default_gcs_bucket_name(self.__default_gcs_bucket_name)
+
+  def SetDefaultGcsBucketName(self, default_gcs_bucket_name):
+    if default_gcs_bucket_name:
+      self.__default_gcs_bucket_name = default_gcs_bucket_name
+    else:
+      self.__default_gcs_bucket_name = APP_DEFAULT_GCS_BUCKET_NAME
 
   def _Dynamic_GetAccessToken(self, request, response):
     """Implementation of AppIdentityService::GetAccessToken.

--- a/AppServer/google/appengine/api/blobstore/blobstore_stub.py
+++ b/AppServer/google/appengine/api/blobstore/blobstore_stub.py
@@ -304,8 +304,12 @@ class BlobstoreServiceStub(apiproxy_stub.APIProxyStub):
       blobkey: blobkey in str.
       storage: blobstore storage stub.
     """
-    # We need blobinfo to tell us how big the blob is. The delete happens
-    # within DeleteBlob.
+    datastore.Delete(cls.ToDatastoreBlobKey(blobkey))
+
+    blobinfo = datastore_types.Key.from_path(blobstore.BLOB_INFO_KIND,
+                                             blobkey,
+                                             namespace='')
+    datastore.Delete(blobinfo)
     storage.DeleteBlob(blobkey)
 
   def _Dynamic_DeleteBlob(self, request, response, unused_request_id):

--- a/AppServer/google/appengine/ext/cloudstorage/cloudstorage_stub.py
+++ b/AppServer/google/appengine/ext/cloudstorage/cloudstorage_stub.py
@@ -31,6 +31,9 @@ from google.appengine.ext import db
 from google.appengine.ext.cloudstorage import common
 
 
+_GCS_DEFAULT_CONTENT_TYPE = 'binary/octet-stream'
+
+
 class _AE_GCSFileInfo_(db.Model):
   """Store GCS specific info.
 
@@ -53,7 +56,7 @@ class _AE_GCSFileInfo_(db.Model):
 
   creation = db.DateTimeProperty()
 
-  content_type = db.StringProperty()
+  content_type = db.StringProperty(default=_GCS_DEFAULT_CONTENT_TYPE)
   etag = db.ByteStringProperty()
 
   def get_options(self):
@@ -234,11 +237,11 @@ class CloudStorageStub(object):
     common.validate_file_path(dst)
 
 
-    src_blobkey = self._filename_to_blobkey(src)
-    source = _AE_GCSFileInfo_.get_by_key_name(src_blobkey)
     ns = namespace_manager.get_namespace()
     try:
       namespace_manager.set_namespace('')
+      src_blobkey = self._filename_to_blobkey(src)
+      source = _AE_GCSFileInfo_.get_by_key_name(src_blobkey)
       token = self._filename_to_blobkey(dst)
       new_file = _AE_GCSFileInfo_(key_name=token,
                                   filename=dst,

--- a/AppServer/google/appengine/ext/cloudstorage/common.py
+++ b/AppServer/google/appengine/ext/cloudstorage/common.py
@@ -52,6 +52,7 @@ __all__ = ['CS_XML_NS',
            'posix_to_dt_str',
            'set_access_token',
            'validate_options',
+           'validate_bucket_name',
            'validate_bucket_path',
            'validate_file_path',
           ]
@@ -71,8 +72,10 @@ except ImportError:
   from google.appengine.api import runtime
 
 
-_GCS_BUCKET_REGEX = re.compile(r'/[a-z0-9\.\-_]{3,}$')
-_GCS_FULLPATH_REGEX = re.compile(r'/[a-z0-9\.\-_]{3,}/.*')
+_GCS_BUCKET_REGEX_BASE = r'[a-z0-9\.\-_]{3,63}'
+_GCS_BUCKET_REGEX = re.compile(_GCS_BUCKET_REGEX_BASE + r'$')
+_GCS_BUCKET_PATH_REGEX = re.compile(r'/' + _GCS_BUCKET_REGEX_BASE + r'$')
+_GCS_FULLPATH_REGEX = re.compile(r'/' + _GCS_BUCKET_REGEX_BASE + r'/.*')
 _GCS_OPTIONS = ('x-goog-acl',
                 'x-goog-meta-')
 
@@ -161,6 +164,21 @@ def get_metadata(headers):
               if k.startswith('x-goog-meta-'))
 
 
+def validate_bucket_name(name):
+  """Validate a Google Storage bucket name.
+
+  Args:
+    name: a Google Storage bucket name with no prefix or suffix.
+
+  Raises:
+    ValueError: if name is invalid.
+  """
+  _validate_path(name)
+  if not _GCS_BUCKET_REGEX.match(name):
+    raise ValueError('Bucket should be 3-63 characters long using only a-z,'
+                     '0-9, underscore, dash or dot but got %s' % name)
+
+
 def validate_bucket_path(path):
   """Validate a Google Cloud Storage bucket path.
 
@@ -171,7 +189,7 @@ def validate_bucket_path(path):
     ValueError: if path is invalid.
   """
   _validate_path(path)
-  if not _GCS_BUCKET_REGEX.match(path):
+  if not _GCS_BUCKET_PATH_REGEX.match(path):
     raise ValueError('Bucket should have format /bucket '
                      'but got %s' % path)
 

--- a/AppServer/google/appengine/ext/cloudstorage/common.py
+++ b/AppServer/google/appengine/ext/cloudstorage/common.py
@@ -45,6 +45,7 @@ __all__ = ['CS_XML_NS',
            'local_run',
            'get_access_token',
            'get_metadata',
+           'GCSFileStat',
            'http_time_to_posix',
            'memory_usage',
            'posix_time_to_http',
@@ -70,10 +71,10 @@ except ImportError:
   from google.appengine.api import runtime
 
 
-_CS_BUCKET_REGEX = re.compile(r'/[a-z0-9\.\-_]{3,}$')
-_CS_FULLPATH_REGEX = re.compile(r'/[a-z0-9\.\-_]{3,}/.*')
-_CS_OPTIONS = ('x-goog-acl',
-               'x-goog-meta-')
+_GCS_BUCKET_REGEX = re.compile(r'/[a-z0-9\.\-_]{3,}$')
+_GCS_FULLPATH_REGEX = re.compile(r'/[a-z0-9\.\-_]{3,}/.*')
+_GCS_OPTIONS = ('x-goog-acl',
+                'x-goog-meta-')
 
 CS_XML_NS = 'http://doc.s3.amazonaws.com/2006-03-01'
 
@@ -83,14 +84,14 @@ _access_token = ''
 
 
 def set_access_token(access_token):
-  """Set the shared access token to authenticate with Cloud Storage.
+  """Set the shared access token to authenticate with Google Cloud Storage.
 
   When set, the library will always attempt to communicate with the
-  real Cloud Storage with this token even when running on dev appserver.
+  real Google Cloud Storage with this token even when running on dev appserver.
   Note the token could expire so it's up to you to renew it.
 
   When absent, the library will automatically request and refresh a token
-  on appserver, or when on dev appserver, talk to a Cloud Storage
+  on appserver, or when on dev appserver, talk to a Google Cloud Storage
   stub.
 
   Args:
@@ -106,8 +107,8 @@ def get_access_token():
   return _access_token
 
 
-class CSFileStat(object):
-  """Container for CS file stat."""
+class GCSFileStat(object):
+  """Container for GCS file stat."""
 
   def __init__(self,
                filename,
@@ -119,7 +120,7 @@ class CSFileStat(object):
     """Initialize.
 
     Args:
-      filename: a Google Storage filename of form '/bucket/filename'.
+      filename: a Google Cloud Storage filename of form '/bucket/filename'.
       st_size: file size in bytes. long compatible.
       etag: hex digest of the md5 hash of the file's content. str.
       st_ctime: posix file creation time. float compatible.
@@ -150,6 +151,10 @@ class CSFileStat(object):
              metadata=self.metadata))
 
 
+
+CSFileStat = GCSFileStat
+
+
 def get_metadata(headers):
   """Get user defined metadata from HTTP response headers."""
   return dict((k, v) for k, v in headers.iteritems()
@@ -157,23 +162,22 @@ def get_metadata(headers):
 
 
 def validate_bucket_path(path):
-  """Validate a Google Storage bucket path.
+  """Validate a Google Cloud Storage bucket path.
 
   Args:
     path: a Google Storage bucket path. It should have form '/bucket'.
-    is_bucket: whether this is a bucket path or file path.
 
   Raises:
     ValueError: if path is invalid.
   """
   _validate_path(path)
-  if not _CS_BUCKET_REGEX.match(path):
+  if not _GCS_BUCKET_REGEX.match(path):
     raise ValueError('Bucket should have format /bucket '
                      'but got %s' % path)
 
 
 def validate_file_path(path):
-  """Validate a Google Storage file path.
+  """Validate a Google Cloud Storage file path.
 
   Args:
     path: a Google Storage file path. It should have form '/bucket/filename'.
@@ -182,7 +186,7 @@ def validate_file_path(path):
     ValueError: if path is invalid.
   """
   _validate_path(path)
-  if not _CS_FULLPATH_REGEX.match(path):
+  if not _GCS_FULLPATH_REGEX.match(path):
     raise ValueError('Path should have format /bucket/filename '
                      'but got %s' % path)
 
@@ -206,10 +210,10 @@ def _validate_path(path):
 
 
 def validate_options(options):
-  """Validate Cloud Storage options.
+  """Validate Google Cloud Storage options.
 
   Args:
-    options: a str->basestring dict of options to pass to Cloud Storage.
+    options: a str->basestring dict of options to pass to Google Cloud Storage.
 
   Raises:
     ValueError: if option is not supported.
@@ -222,7 +226,7 @@ def validate_options(options):
   for k, v in options.iteritems():
     if not isinstance(k, str):
       raise TypeError('option %r should be a str.' % k)
-    if not any(k.startswith(valid) for valid in _CS_OPTIONS):
+    if not any(k.startswith(valid) for valid in _GCS_OPTIONS):
       raise ValueError('option %s is not supported.' % k)
     if not isinstance(v, basestring):
       raise TypeError('value %r for option %s should be of type basestring.' %

--- a/AppServer/google/appengine/ext/cloudstorage/common.py
+++ b/AppServer/google/appengine/ext/cloudstorage/common.py
@@ -399,7 +399,7 @@ def local_run():
     return True
   if 'remote_api' in server_software:
     return False
-  if server_software.startswith('Development'):
+  if server_software.startswith(('Development', 'testutil')):
     return True
   return False
 

--- a/AppServer/google/appengine/ext/cloudstorage/common.py
+++ b/AppServer/google/appengine/ext/cloudstorage/common.py
@@ -75,6 +75,7 @@ except ImportError:
 _GCS_BUCKET_REGEX_BASE = r'[a-z0-9\.\-_]{3,63}'
 _GCS_BUCKET_REGEX = re.compile(_GCS_BUCKET_REGEX_BASE + r'$')
 _GCS_BUCKET_PATH_REGEX = re.compile(r'/' + _GCS_BUCKET_REGEX_BASE + r'$')
+_GCS_PATH_PREFIX_REGEX = re.compile(r'/' + _GCS_BUCKET_REGEX_BASE + r'.*')
 _GCS_FULLPATH_REGEX = re.compile(r'/' + _GCS_BUCKET_REGEX_BASE + r'/.*')
 
 _GCS_METADATA = ['x-goog-meta-',
@@ -89,6 +90,10 @@ CS_XML_NS = 'http://doc.s3.amazonaws.com/2006-03-01'
 LOCAL_API_HOST = 'gcs-magicstring.appspot.com'
 
 _access_token = ''
+
+
+
+_MAX_GET_BUCKET_RESULT = 1000
 
 
 def set_access_token(access_token):
@@ -124,8 +129,12 @@ class GCSFileStat(object):
                etag,
                st_ctime,
                content_type=None,
-               metadata=None):
+               metadata=None,
+               is_dir=False):
     """Initialize.
+
+    For files, the non optional arguments are always set.
+    For directories, only filename and is_dir is set.
 
     Args:
       filename: a Google Cloud Storage filename of form '/bucket/filename'.
@@ -136,17 +145,27 @@ class GCSFileStat(object):
       metadata: a str->str dict of user specified options when creating
         the file. Possible keys are x-goog-meta-, content-disposition,
         content-encoding, and cache-control.
+      is_dir: True if this represents a directory. False if this is a real file.
     """
     self.filename = filename
-    self.st_size = long(st_size)
-    self.st_ctime = float(st_ctime)
-    if etag[0] == '"' and etag[-1] == '"':
-      etag = etag[1:-1]
-    self.etag = etag
+    self.is_dir = is_dir
+    self.st_size = None
+    self.st_ctime = None
+    self.etag = None
     self.content_type = content_type
     self.metadata = metadata
 
+    if not is_dir:
+      self.st_size = long(st_size)
+      self.st_ctime = float(st_ctime)
+      if etag[0] == '"' and etag[-1] == '"':
+        etag = etag[1:-1]
+      self.etag = etag
+
   def __repr__(self):
+    if self.is_dir:
+      return '(directory: %s)' % self.filename
+
     return (
         '(filename: %(filename)s, st_size: %(st_size)s, '
         'st_ctime: %(st_ctime)s, etag: %(etag)s, '
@@ -158,6 +177,22 @@ class GCSFileStat(object):
              etag=self.etag,
              content_type=self.content_type,
              metadata=self.metadata))
+
+  def __cmp__(self, other):
+    if not isinstance(other, self.__class__):
+      raise ValueError('Argument to cmp must have the same type. '
+                       'Expect %s, got %s', self.__class__.__name__,
+                       other.__class__.__name__)
+    if self.filename > other.filename:
+      return 1
+    elif self.filename < other.filename:
+      return -1
+    return 0
+
+  def __hash__(self):
+    if self.etag:
+      return hash(self.etag)
+    return hash(self.filename)
 
 
 
@@ -213,6 +248,32 @@ def validate_file_path(path):
   if not _GCS_FULLPATH_REGEX.match(path):
     raise ValueError('Path should have format /bucket/filename '
                      'but got %s' % path)
+
+
+def _process_path_prefix(path_prefix):
+  """Validate and process a Google Cloud Stoarge path prefix.
+
+  Args:
+    path_prefix: a Google Cloud Storage path prefix of format '/bucket/prefix'
+      or '/bucket/' or '/bucket'.
+
+  Raises:
+    ValueError: if path is invalid.
+
+  Returns:
+    a tuple of /bucket and prefix. prefix can be None.
+  """
+  _validate_path(path_prefix)
+  if not _GCS_PATH_PREFIX_REGEX.match(path_prefix):
+    raise ValueError('Path prefix should have format /bucket, /bucket/, '
+                     'or /bucket/prefix but got %s.' % path_prefix)
+  bucket_name_end = path_prefix.find('/', 1)
+  bucket = path_prefix
+  prefix = None
+  if bucket_name_end != -1:
+    bucket = path_prefix[:bucket_name_end]
+    prefix = path_prefix[bucket_name_end + 1:] or None
+  return bucket, prefix
 
 
 def _validate_path(path):
@@ -332,9 +393,15 @@ def posix_to_dt_str(posix):
 
 
 def local_run():
-  """Whether running in dev appserver."""
-  return ('SERVER_SOFTWARE' not in os.environ or
-          os.environ['SERVER_SOFTWARE'].startswith('Development'))
+  """Whether we should hit GCS dev appserver stub."""
+  server_software = os.environ.get('SERVER_SOFTWARE')
+  if server_software is None:
+    return True
+  if 'remote_api' in server_software:
+    return False
+  if server_software.startswith('Development'):
+    return True
+  return False
 
 
 def memory_usage(method):
@@ -347,3 +414,20 @@ def memory_usage(method):
                  method.__name__, runtime.memory_usage().current())
     return result
   return wrapper
+
+
+def _add_ns(tagname):
+  return '{%(ns)s}%(tag)s' % {'ns': CS_XML_NS,
+                              'tag': tagname}
+
+
+
+_T_CONTENTS = _add_ns('Contents')
+_T_LAST_MODIFIED = _add_ns('LastModified')
+_T_ETAG = _add_ns('ETag')
+_T_KEY = _add_ns('Key')
+_T_SIZE = _add_ns('Size')
+_T_PREFIX = _add_ns('Prefix')
+_T_COMMON_PREFIXES = _add_ns('CommonPrefixes')
+_T_NEXT_MARKER = _add_ns('NextMarker')
+_T_IS_TRUNCATED = _add_ns('IsTruncated')

--- a/AppServer/google/appengine/ext/cloudstorage/stub_dispatcher.py
+++ b/AppServer/google/appengine/ext/cloudstorage/stub_dispatcher.py
@@ -145,7 +145,7 @@ def _preprocess(method, headers, url):
     param_dict[k] = urllib.unquote(param_dict[k][0])
 
   headers = dict((k.lower(), v) for k, v in headers.iteritems())
-  return method, headers, filename, param_dict
+  return method, headers, urllib.unquote(filename), param_dict
 
 
 def _handle_post(gcs_stub, filename, headers):
@@ -173,6 +173,18 @@ def _handle_put(gcs_stub, filename, param_dict, headers, payload):
 
   if not content_range.value:
     raise ValueError('Missing header content-range.')
+
+
+
+  if not token:
+
+    if not content_range.last:
+      raise ValueError('Content-Range must have a final length.')
+    elif not content_range.no_data and content_range.range[0] != 0:
+      raise ValueError('Content-Range must specify complete object.')
+    else:
+
+      token = gcs_stub.post_start_creation(filename, headers)
 
   gcs_stub.put_continue_creation(token,
                                  payload,


### PR DESCRIPTION
This updates the Cloud Storage stub to the 1.8.6 SDK. This was necessary because other places assume the stub's methods have signatures from that version.

It also adds a dummy response for the `app_identity.get_default_gcs_bucket_name` call.

Finally, it removes references to "\_\_BlobInfo\_\_" entities from the datastore-backed BlobStorage.

Resolves #2752 