### PR TITLE
AppController appserver check thread should exit when there is no work

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4846,6 +4846,8 @@ HOSTS
             version_key, port = instance_key.split(":")
             ret = remove_appserver_process(version_key, port)
             Djinn.log_debug("remove_appserver_process returned: #{ret}.")
+          else
+            break
           end
         end
       }


### PR DESCRIPTION
The AppControllers appserver check spawns a thread to perform appserver scaling work. When there is no work to be done this thread should exit rather than entering a busy-wait / spinning until the end of the duty cycle.