### PR TITLE
Wait for all hosts before creating tables

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/schema.py
+++ b/AppDB/appscale/datastore/cassandra_env/schema.py
@@ -250,6 +250,8 @@ def prime_cassandra(replication):
   deadline = time.time() + SCHEMA_CHANGE_TIMEOUT
   while True:
     if time.time() > deadline:
+      logging.warning('Timeout when waiting for hosts to join. Continuing '
+                      'with connected hosts.')
       break
 
     if len(session.get_pool_state()) == len(hosts):

--- a/AppDB/appscale/datastore/cassandra_env/schema.py
+++ b/AppDB/appscale/datastore/cassandra_env/schema.py
@@ -223,8 +223,6 @@ def prime_cassandra(replication):
 
   hosts = appscale_info.get_db_ips()
 
-  cluster = None
-  session = None
   remaining_retries = INITIAL_CONNECT_RETRIES
   while True:
     try:
@@ -247,6 +245,17 @@ def prime_cassandra(replication):
   session.execute(create_keyspace, {'replication': keyspace_replication},
                   timeout=SCHEMA_CHANGE_TIMEOUT)
   session.set_keyspace(KEYSPACE)
+
+  logging.info('Waiting for all hosts to be connected')
+  deadline = time.time() + SCHEMA_CHANGE_TIMEOUT
+  while True:
+    if time.time() > deadline:
+      break
+
+    if len(session.get_pool_state()) == len(hosts):
+      break
+
+    time.sleep(1)
 
   for table in dbconstants.INITIAL_TABLES:
     create_table = """


### PR DESCRIPTION
The most common error we see when running the prime script is that one or more hosts are immediately marked as "down" after the connect call finishes. Those machines later rejoin and cause a schema disagreement. This change is meant to prevent the script from continuing immediately if not all hosts are available.