### PR TITLE
Restart rsyslog so the app logs can be recreated

### DIFF
--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -84,6 +84,10 @@ module TerminateHelper
   def self.erase_appscale_full_state
     # Delete logs.
     `rm -rf /var/log/appscale/*`
+
+    # Restart rsyslog so that the combined app logs can be recreated.
+    `service rsyslog restart`
+
     `rm -rf /var/log/rabbitmq/*`
     `rm -rf /var/log/zookeeper/*`
     `rm -rf /var/log/nginx/appscale-*`


### PR DESCRIPTION
Without this, the daemon continues writing to the file descriptors of the deleted combined application logs.

Resolves #2772.