### PR TITLE
Increase open file limit for nginx

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -163,9 +163,9 @@ EOF
 
     # On distros with systemd, the open file limit must be adjusted for each
     # service.
-    if which systemctl; then
+    if which systemctl > /dev/null; then
         mkdir -p /etc/systemd/system/nginx.service.d
-        cat <<EOF | tee /etc/systemd/system/nginx.service.d/override.conf
+        cat <<EOF > /etc/systemd/system/nginx.service.d/override.conf
 [Service]
 LimitNOFILE=200000
 EOF

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -160,6 +160,17 @@ root            soft    nofile           200000
 *               soft    nofile           200000
 *               -       nproc            32768
 EOF
+
+    # On distros with systemd, the open file limit must be adjusted for each
+    # service.
+    if which systemctl; then
+        mkdir -p /etc/systemd/system/nginx.service.d
+        cat <<EOF | tee /etc/systemd/system/nginx.service.d/override.conf
+[Service]
+LimitNOFILE=200000
+EOF
+        systemctl daemon-reload
+    fi
 }
 
 installappscaleprofile()


### PR DESCRIPTION
This allows nginx to open more than 1024 concurrent connections.

Resolves #2779.