### PR TITLE
Don't fail if instance was already deleted

### DIFF
--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -838,7 +838,10 @@ def unregister_instance(instance):
   except NoNodeError:
     pass
 
-  running_instances.remove(instance)
+  try:
+    running_instances.remove(instance)
+  except KeyError:
+    logging.debug('unregister_instance: non-existent instance {}'.format(instance))
 
 
 def register_instance(instance):

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -841,7 +841,7 @@ def unregister_instance(instance):
   try:
     running_instances.remove(instance)
   except KeyError:
-    logging.debug('unregister_instance: non-existent instance {}'.format(instance))
+    logging.info('unregister_instance: non-existent instance {}'.format(instance))
 
 
 def register_instance(instance):


### PR DESCRIPTION
This prevent this starcktrace while stopping applications:

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 1415, in _execute
    result = yield result
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/root/appscale/AppManager/app_manager_server.py", line 1052, in delete
    yield stop_app(version_key)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 879, in run
    yielded = self.gen.send(value)
  File "/root/appscale/AppManager/app_manager_server.py", line 589, in stop_app
    unregister_instance(Instance(revision_key, port))
  File "/root/appscale/AppManager/app_manager_server.py", line 841, in unregister_instance
    running_instances.remove(instance)
KeyError: <Instance: guestbook_default_v1_1528322266663:20001>