### PR TITLE
Assign the proper number of datastore to machines

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3526,7 +3526,7 @@ class Djinn
       }
     }
 
-    HelperFunctions.log_and_crash('db proxy was empty') if db_proxiex.empty?
+    HelperFunctions.log_and_crash('db proxy was empty') if db_proxies.empty?
 
     # Assign the proper number of Datastore processes on each database
     # machine.
@@ -3548,9 +3548,9 @@ class Djinn
     loop do
       db_proxies.each { |db_proxy|
         break if HelperFunctions.is_port_open?(db_proxy, DatastoreServer::PROXY_PORT)
-        Djinn.log_debug("Waiting for datastore to be active...")
-        sleep(SMALL_WAIT)
       }
+      Djinn.log_debug("Waiting for datastore to be active...")
+      sleep(SMALL_WAIT)
     end
   end
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1742,17 +1742,9 @@ class Djinn
     end
 
     # Wait till the Datastore is functional.
-    db_proxies = []
-    @state_change_lock.synchronize {
-      @nodes.each { |node|
-        db_proxies << node.private_ip if node.is_load_balancer?
-      }
-    }
-    HelperFunctions.log_and_crash('db proxy was empty') if db_proxies.empty?
     loop do
-      db_proxies.each { |db_proxy|
-        break if HelperFunctions.is_port_open?(db_proxy, DatastoreServer::PROXY_PORT)
-      }
+      break if HelperFunctions.is_port_open?(get_load_balancer.private_ip,
+                                             DatastoreServer::PROXY_PORT)
       Djinn.log_debug("Waiting for Datastore to be active...")
       sleep(SMALL_WAIT)
     end

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1753,7 +1753,7 @@ class Djinn
     # At this point all nodes are fully functional, so the Shadow will do
     # another assignments of the datastore processes to ensure we got the
     # accurate CPU count.
-    assign_datastore_process if my_node.is_shadow?
+    assign_datastore_processes if my_node.is_shadow?
   end
 
   def job_start(secret)

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3539,7 +3539,7 @@ class Djinn
     }
 
     # Let's wait for at least one datastore server to be active. Since
-    # only the Shadow assign Datastore, we can safely check locally when
+    # only the Shadow assigns Datastore, we can safely check locally when
     # haproxy is setup.
     until HelperFunctions.is_port_open?(@my__private_ip, DatastoreServer::PROXY_PORT)
       update_db_haproxy

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1749,6 +1749,11 @@ class Djinn
       sleep(SMALL_WAIT)
     end
     Djinn.log_info("Datastore service is active.")
+
+    # At this point all nodes are fully functional, so the Shadow will do
+    # another assignments of the datastore processes to ensure we got the
+    # accurate CPU count.
+    assign_datastore_process if my_node.is_shadow?
   end
 
   def job_start(secret)
@@ -3375,7 +3380,7 @@ class Djinn
     # Leader node starts additional services.
     if my_node.is_shadow?
       @state = "Assigning Datastore processes"
-      start_datastore
+      assign_datastore_processes
       update_node_info_cache
       TaskQueue.start_flower(@options['flower_password'])
     else
@@ -3530,7 +3535,7 @@ class Djinn
     MonitInterface.start(:uaserver, start_cmd, nil, env_vars)
   end
 
-  def start_datastore
+  def assign_datastore_processes
     # Shadow is the only node to call this method, and is called upon
     # startup.
     return unless my_node.is_shadow?

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3514,7 +3514,7 @@ class Djinn
   def start_datastore
     # Shadow is the only node to call this method, and is called upon
     # startup.
-    return unless my_node.is_shadow
+    return unless my_node.is_shadow?
 
     verbose = @options['verbose'].downcase == 'true'
     db_proxies = []

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3524,7 +3524,7 @@ class Djinn
 
     # Assign the proper number of Datastore processes on each database
     # machine.
-    @nodes.each { |node|
+    db_nodes.each { |node|
       assignments = {}
       begin
         cpu_count = HermesClient.get_cpu_count(node.private_ip, @@secret)


### PR DESCRIPTION
This fixes an issues that under certain configuration, the datastores
wouldn't be assigned appropriately to the database machines.