### PR TITLE
Add more logging to pull queue operations

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/queue.py
+++ b/AppTaskQueue/appscale/taskqueue/queue.py
@@ -380,6 +380,8 @@ class PullQueue(Queue):
     if task is not None:
       self._delete_task_and_index(task)
 
+    logger.debug('Deleted task: {}'.format(task))
+
   def update_lease(self, task, new_lease_seconds, retries=5):
     """ Updates the duration of a task lease.
 
@@ -560,6 +562,7 @@ class PullQueue(Queue):
 
     time_elapsed = datetime.datetime.utcnow() - start_time
     logger.debug('Leased {} tasks [time elapsed: {}]'.format(len(leased), str(time_elapsed)))
+    logger.debug('IDs leased: {}'.format([task.id for task in leased]))
     return leased
 
   def total_tasks(self):

--- a/AppTaskQueue/appscale/taskqueue/task.py
+++ b/AppTaskQueue/appscale/taskqueue/task.py
@@ -157,7 +157,13 @@ class Task(object):
     Returns:
       A string representing the task.
     """
-    return '<Task: {}>'.format(self.id)
+    attributes = {'id': self.id}
+    if hasattr(self, 'queueName'):
+      attributes['queue'] = self.queueName
+
+    values = ', '.join(['='.join([attr, val])
+                        for attr, val in attributes.items()])
+    return '<Task: {}>'.format(values)
 
   def json_safe_dict(self, fields=TASK_FIELDS):
     """ Generate a JSON-safe dictionary representation of the task.


### PR DESCRIPTION
When debug-level logging is turned on, this makes it easier to trace particular pull queue tasks.