### PR TITLE
Disable TLS for ejabberd's http_bind module

### DIFF
--- a/AppController/templates/ejabberd.yml
+++ b/AppController/templates/ejabberd.yml
@@ -170,7 +170,10 @@ listen:
     http_bind: true
     ## register: true
     captcha: true
-    tls: true
+    ## AppScale: The nginx proxy entry tries to use HTTP. Disabling tls here
+    ## prevents ejabberd from trying to upgrade the connection. When enabled,
+    ## nginx returns 502 to the client.
+    ## tls: true
     certfile: "APPSCALE-CERTFILE"
 
 ## Disabling digest-md5 SASL authentication. digest-md5 requires plain-text


### PR DESCRIPTION
This allows the client to connect to ejabberd through nginx. This fixes the channel API on Xenial.