### PR TITLE
Define proper Java version for Trusty

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -17,7 +17,7 @@ fi
 
 JAVA_VERSION="java-8-openjdk"
 case "${DIST}" in
-    trusty|wheezy) JAVA_VERSION="java-7-openjdk" ;;
+    wheezy) JAVA_VERSION="java-7-openjdk" ;;
 esac
 
 export UNAME_MACHINE=$(uname -m)


### PR DESCRIPTION
Without this, a build on a clean box fails because JAVA_HOME is set to the OpenJDK 7 directory.