### PR TITLE
Skip Nginx connection change for Docker build

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -163,7 +163,7 @@ EOF
 
     # On distros with systemd, the open file limit must be adjusted for each
     # service.
-    if which systemctl > /dev/null; then
+    if which systemctl > /dev/null && [ "${IN_DOCKER}" != "yes" ]; then
         mkdir -p /etc/systemd/system/nginx.service.d
         cat <<EOF > /etc/systemd/system/nginx.service.d/override.conf
 [Service]


### PR DESCRIPTION
The call to systemctl fails when building on Docker.