### PR TITLE
Install older tornado when Python is too old

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -632,9 +632,20 @@ installapiserver()
 
     # The activate script fails under `set -u`.
     unset_opt=$(shopt -po nounset)
+    case ${DIST} in
+        wheezy|trusty)
+            # Tornado 5 does not work with Python<2.7.9.
+            tornado_package='tornado<5'
+            ;;
+        *)
+            tornado_package='tornado'
+            ;;
+    esac
+
     set +u
     (source /opt/appscale_api_server/bin/activate && \
      pip install -U pip && \
+     pip install "${tornado_package}" && \
      pip install ${APPSCALE_HOME}/AppControllerClient ${APPSCALE_HOME}/common \
      ${APPSCALE_HOME}/APIServer)
     eval ${unset_opt}


### PR DESCRIPTION
Tornado 5 requires at least Python 2.7.9 due to the changes in the SSL module.