### PR TITLE
Java AppServer javac build options update for version and debug

### DIFF
--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -5,6 +5,8 @@
   <property name="gae_version" value="1.8.4" />
   <property name="gae_org" location="appengine-java-sdk-${gae_version}" />
   <property name="gae_dist" location="appengine-java-sdk-repacked" />
+  <property name="java_source_version" value="1.7" />
+  <property name="java_target_version" value="${java_source_version}" />
 
   <path id="gae.classpath">
     <fileset dir="${gae_dist}/lib">
@@ -31,27 +33,28 @@
     <mkdir dir="${gae_dist}" />
     <copy todir="${gae_dist}" overwrite="true">
       <fileset dir="${gae_org}">
-	<include name="**/*" />
-	<exclude name="demos/**" />
-	<exclude name="docs/**" />
-	<exclude name="src/**" />
+      <include name="**/*" />
+      <exclude name="demos/**" />
+      <exclude name="docs/**" />
+      <exclude name="src/**" />
       </fileset>
     </copy>
     <copy todir="${gae_dist}/lib/impl">
       <fileset dir="lib">
-	<include name="*.jar" />
+        <include name="*.jar" />
       </fileset>
     </copy>
     <chmod perm="a+x" verbose="true">
       <fileset dir="${gae_dist}/bin">
-	<include name="*.sh" />
+        <include name="*.sh" />
       </fileset>
     </chmod>
   </target>
 
   <target name="compile" depends="repack-sdk">
     <mkdir dir="${build}" />
-    <javac srcdir="${src}" destdir="${build}" includeantruntime="false">
+    <javac srcdir="${src}" destdir="${build}" source="${java_source_version}" target="${java_target_version}"
+           encoding="utf-8" debug="true" includeantruntime="false">
       <classpath refid="gae.classpath" />
       <include name="com/google/appengine/api/**" />
       <include name="com/google/appengine/tools/**" />
@@ -92,7 +95,7 @@
   <target name="update-api-stubs-jar" depends="compile, repack-sdk">
     <unjar src="${gae_dist}/lib/impl/appengine-api-stubs.jar" dest="${build}" overwrite="true">
       <patternset>
-	<include name="META-INF/services/*" />
+        <include name="META-INF/services/*" />
       </patternset>
     </unjar>
     <jar destfile="${gae_dist}/lib/impl/appengine-api-stubs.jar" basedir="${build}" update="true">


### PR DESCRIPTION
This pull request sets the debug flag for javac and adds explicit source/target versions and file encoding. 

These are the javac command equivalents for the ant task:

```
  -g                         Generate all debugging info
  -g:none                    Generate no debugging info
  -encoding <encoding>       Specify character encoding used by source files
  -source <release>          Provide source compatibility with specified release
  -target <release>          Generate class files for specific VM version
```

Including debug info is common for java as it allows debugging and improves stacktrace utility. By default the ant task adds '-g:none' to remove all debug information.

There's also some white space clean up (tab to space)