### PR TITLE
AppDashboard incorrect credential escaping

### DIFF
--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -171,21 +171,21 @@ class NewUserPage(AppDashboard):
     """
     users = {}
     error_msgs = {}
-    users['email'] = cgi.escape(self.request.get('user_email'))
+    users['email'] = self.request.get('user_email')
     if re.match(self.USER_EMAIL_REGEX, users['email']):
       error_msgs['email'] = None
     else:
       error_msgs['email'] = 'Format must be foo@boo.goo.'
 
-    users['password'] = cgi.escape(self.request.get('user_password'))
+    users['password'] = self.request.get('user_password')
     if len(users['password']) >= self.MIN_PASSWORD_LENGTH:
       error_msgs['password'] = None
     else:
       error_msgs['password'] = 'Password must be at least {0} characters ' \
                                'long.'.format(self.MIN_PASSWORD_LENGTH)
 
-    users['password_confirmation'] = cgi.escape(
-      self.request.get('user_password_confirmation'))
+    users['password_confirmation'] = \
+        self.request.get('user_password_confirmation')
     if users['password_confirmation'] == users['password']:
       error_msgs['password_confirmation'] = None
     else:
@@ -205,9 +205,10 @@ class NewUserPage(AppDashboard):
     if errors['email'] or errors['password'] or errors['password_confirmation']:
       return False
     else:
-      return self.helper.create_new_user(cgi.escape(
-        self.request.get('user_email')), cgi.escape(
-        self.request.get('user_password')), self.response)
+      return self.helper.create_new_user(
+        self.request.get('user_email'),
+        self.request.get('user_password'),
+        self.response)
 
   def post(self):
     """ Handler for POST requests. """
@@ -225,10 +226,10 @@ class NewUserPage(AppDashboard):
       err_msgs['email'] = str(err)
 
     users = {}
-    users['email'] = cgi.escape(self.request.get('user_email'))
-    users['password'] = cgi.escape(self.request.get('user_password'))
+    users['email'] = cgi.escape(self.request.get('user_email'), True)
+    users['password'] = cgi.escape(self.request.get('user_password'), True)
     users['password_confirmation'] = cgi.escape(
-      self.request.get('user_password_confirmation'))
+      self.request.get('user_password_confirmation'), True)
 
     self.render_page(page='users', template_file=self.TEMPLATE, values={
       'continue': self.request.get('continue'),
@@ -481,8 +482,7 @@ class ChangePasswordPage(AppDashboard):
     email = self.request.get("email")
     password = self.request.get("password")
     if self.dstore.is_user_cloud_admin():
-      success, message = self.helper.change_password(cgi.escape(email),
-                                                     cgi.escape(password))
+      success, message = self.helper.change_password(email, password)
     else:
       success = False
       message = "Only the cloud administrator can change passwords."

--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -9,7 +9,6 @@ Engine applications.
 # pylint: disable-msg=E1101
 # pylint: disable-msg=W0613
 
-import cgi
 import datetime
 import json
 import logging
@@ -226,10 +225,10 @@ class NewUserPage(AppDashboard):
       err_msgs['email'] = str(err)
 
     users = {}
-    users['email'] = cgi.escape(self.request.get('user_email'), True)
-    users['password'] = cgi.escape(self.request.get('user_password'), True)
-    users['password_confirmation'] = cgi.escape(
-      self.request.get('user_password_confirmation'), True)
+    users['email'] = self.request.get('user_email')
+    users['password'] = self.request.get('user_password')
+    users['password_confirmation'] = \
+        self.request.get('user_password_confirmation')
 
     self.render_page(page='users', template_file=self.TEMPLATE, values={
       'continue': self.request.get('continue'),

--- a/AppDashboard/templates/users/confirm.html
+++ b/AppDashboard/templates/users/confirm.html
@@ -6,7 +6,7 @@
     <div>
        <form action="/users/verify" method="post"><div style="margin:0;padding:0;display:inline">
        {% if continue %}
-       <input type="hidden" name="continue" value="{{ continue }}">
+       <input type="hidden" name="continue" value="{{ continue|e }}">
        {% endif %}
        </div>
         <p>Everything looks good. Continue?</p>

--- a/AppDashboard/templates/users/login.html
+++ b/AppDashboard/templates/users/login.html
@@ -21,7 +21,7 @@
                   </div>
                   <p class="form-label span12">
                     <label for="user_email">Email:</label>
-                    <input id="user_email" name="user_email" size="40" type="text" value="{{ user_email|default }}" />
+                    <input id="user_email" name="user_email" size="40" type="text" value="{{ user_email|default|e }}" />
                   </p>
                   <p class="form-label span12">
                     <label for="user_password">Password:</label>

--- a/AppDashboard/templates/users/new.html
+++ b/AppDashboard/templates/users/new.html
@@ -12,7 +12,7 @@
                         {% else %}
                         <label for="user_email">Email:</label>
                         {% endif %}
-                        <input id="user_email" name="user_email" size="40" type="text" value="{{ user.email|default }}" />
+                        <input id="user_email" name="user_email" size="40" type="text" value="{{ user.email|default|e }}" />
                         {% if error_message_content.email|default  %}
                         <div class="red">{{ error_message_content.email }} </div>
                         {% endif %}
@@ -28,7 +28,7 @@
                         {% else %}
                         <label for="user_password">Password:</label>
                         {% endif %}
-                        <input id="user_password" name="user_password" size="40" type="password" value="{{ user.password|default }}">
+                        <input id="user_password" name="user_password" size="40" type="password" value="{{ user.password|default|e }}">
                         {%  if error_message_content.password|default %}
                         <div class="red">{{ error_message_content.password }}</div>
                         {% endif %}
@@ -43,7 +43,7 @@
                         {% else %}
                         <label for="user_password_confirmation">Password Confirmation:</label>
                         {% endif %}
-                          <input id="user_password_confirmation" name="user_password_confirmation" size="40" type="password" value="{{ user.password_confirmation|default }}">
+                          <input id="user_password_confirmation" name="user_password_confirmation" size="40" type="password" value="{{ user.password_confirmation|default|e }}">
                         {%  if error_message_content.password_confirmation|default %}
                           <div class="red">{{ error_message_content.password_confirmation }}</div>
                         {% endif %}


### PR DESCRIPTION
Remove incorrect use of cgi.escape for passwords when creating new users or changing passwords via the dashboard. The email/password should only be escaped when the values are for use in a view, and in this case should also escape the double quote character (so < > & " are all escaped)

To reproduce the issue, create a user via the dashboard with the password `p&ssword`, and then login using the password `p&amp;ssword`.  The quote character not being escaped can be tested by entering the value `" style="background: lime` in the email field (for example)

You can work around this issue by using the "appscale" command to create users.