### PR TITLE
Limit version of soap4r-ng

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -314,7 +314,7 @@ installgems()
     sleep 1
     gem install json ${GEMOPT} -v 1.8.3
     sleep 1
-    gem install soap4r-ng ${GEMOPT}
+    gem install soap4r-ng ${GEMOPT} -v 2.0.3
     gem install httparty ${GEMOPT} -v 0.14.0
     gem install httpclient ${GEMOPT}
     gem install posixpsutil ${GEMOPT}


### PR DESCRIPTION
The controller does not start with version 2.0.4.