### PR TITLE
Detect missing row when applying transaction

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/constants.py
+++ b/AppTaskQueue/appscale/taskqueue/constants.py
@@ -13,6 +13,10 @@ class InvalidTarget(Exception):
   """ Indicates an invalid target. """
   pass
 
+class TaskNotFound(Exception):
+  """ Indicates that the specified task does not exist. """
+  pass
+
 def non_negative_int(value):
   """ Checks if a value is greater than 0. """
   return isinstance(value, int) and value >= 0

--- a/AppTaskQueue/appscale/taskqueue/rest_api.py
+++ b/AppTaskQueue/appscale/taskqueue/rest_api.py
@@ -9,6 +9,7 @@ from tornado.web import MissingArgumentError, RequestHandler
 from appscale.common.constants import HTTPCodes
 from appscale.taskqueue.statistics import service_stats, stats_lock, REST_API
 
+from .constants import TaskNotFound
 from .task import InvalidTaskInfo, Task, TASK_FIELDS
 from .queue import (InvalidLeaseRequest,
                     LONG_QUEUE_FORM,
@@ -197,6 +198,8 @@ class RESTTasks(TrackedRequestHandler):
     except InvalidTaskInfo as insert_error:
       write_error(self, HTTPCodes.BAD_REQUEST, insert_error.message)
       return
+    except TransientError as error:
+      write_error(self, HTTPCodes.INTERNAL_ERROR, str(error))
 
     self.write(json.dumps(task.json_safe_dict(fields=fields)))
 
@@ -369,6 +372,9 @@ class RESTTask(TrackedRequestHandler):
     except InvalidLeaseRequest as lease_error:
       write_error(self, HTTPCodes.BAD_REQUEST, lease_error.message)
       return
+    except TaskNotFound as error:
+      write_error(self, HTTPCodes.NOT_FOUND, str(error))
+      return
 
     self.write(json.dumps(task.json_safe_dict(fields=fields)))
 
@@ -449,6 +455,9 @@ class RESTTask(TrackedRequestHandler):
       task = queue.update_task(new_task, new_lease_seconds)
     except InvalidLeaseRequest as lease_error:
       write_error(self, HTTPCodes.BAD_REQUEST, lease_error.message)
+      return
+    except TaskNotFound as error:
+      write_error(self, HTTPCodes.NOT_FOUND, str(error))
       return
 
     self.write(json.dumps(task.json_safe_dict(fields=fields)))


### PR DESCRIPTION
This allows the service to return a different error when the client tries to extend the lease of a task that doesn't exist. Previously, it would return an error indicating that the lease has expired.