### PR TITLE
Controller application upload error output now escaped

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1073,7 +1073,7 @@ class Djinn
       if output.include?("Your app can be reached at the following URL")
         result = "true"
       else
-        result = output
+        result = output.dump
       end
 
       @app_upload_reservations[reservation_id]['status'] = result


### PR DESCRIPTION
When deploying an application using the dashboard fails the error message can be lost due to the response message containing characters not permitted in XML (i.e. ESC)

This pull request escapes non-printable characters so they can be returned. Clients could then interpret these characters as desired for output to users. An example error message from the dashboard is now:

> There was an error uploading your application: Unknown app upload status: "\e[31mInvalid application ID. You can only use alphanumeric characters and/or '-'.\e[0m\n\nA log with more information is available at\n/root/.appscale/log-f8830ad9-6324-4a2d-86f2-34f5390a123b.\n"

So `ESC` becomes `\e` and newlines are `\n`, etc.

This error response could be further improved but this small change allows dashboard users to see why their upload is failing.