### PR TITLE
Reject lease modifications that specify wrong ETA

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/distributed_tq.py
+++ b/AppTaskQueue/appscale/taskqueue/distributed_tq.py
@@ -843,7 +843,8 @@ class DistributedTaskQueue():
     except QueueNotFound as error:
       return '', TaskQueueServiceError.UNKNOWN_QUEUE, str(error)
 
-    task_info = {'id': request.task_name()}
+    task_info = {'id': request.task_name(),
+                 'leaseTimestamp': request.eta_usec()}
     try:
       # The Python AppServer sets eta_usec with a resolution of 1 second,
       # so update_lease can't be used. It checks with millisecond precision.

--- a/AppTaskQueue/appscale/taskqueue/task.py
+++ b/AppTaskQueue/appscale/taskqueue/task.py
@@ -210,7 +210,7 @@ class Task(object):
     task_pb.set_task_name(self.id)
     epoch = datetime.datetime.utcfromtimestamp(0)
     task_pb.set_eta_usec(
-      int((self.get_eta() - epoch).total_seconds()) * 1000000)
+      int((self.get_eta() - epoch).total_seconds() * 1000000))
     task_pb.set_retry_count(self.retry_count)
     task_pb.set_body(base64.urlsafe_b64decode(self.payloadBase64))
     try:


### PR DESCRIPTION
This prevents a worker that does not currently hold a lease from updating the task lease. Without this check, it may shorten the lease for another holder.

This also fixes a bug where task ETAs were being encoded with the wrong precision for protobuf responses.

Resolves #2819.