### PR TITLE
Add appscale-admin restart command

### DIFF
--- a/APIServer/appscale/api_server/server.py
+++ b/APIServer/appscale/api_server/server.py
@@ -14,7 +14,7 @@ from appscale.api_server.app_identity import AppIdentityService
 from appscale.api_server.base_service import BaseService
 from appscale.api_server.constants import ApplicationError
 from appscale.common.constants import LOG_FORMAT
-from appscale.common.constants import PID_DIR
+from appscale.common.constants import VAR_DIR
 from appscale.common.constants import ZK_PERSISTENT_RECONNECTS
 
 logger = logging.getLogger('appscale-api-server')
@@ -69,7 +69,7 @@ def main():
     args = parser.parse_args()
 
     pidfile_location = os.path.join(
-        PID_DIR, 'api-server_{}-{}.pid'.format(args.project_id, args.port))
+        VAR_DIR, 'api-server_{}-{}.pid'.format(args.project_id, args.port))
     with open(pidfile_location, 'w') as pidfile:
         pidfile.write(str(os.getpid()))
 

--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -11,6 +11,13 @@ import re
 import sys
 import time
 
+try:
+  from urllib import quote as urlquote
+except ImportError:
+  from urllib.parse import quote as urlquote
+
+import requests_unixsocket
+
 from appscale.appcontroller_client import AppControllerException
 from appscale.common import appscale_info
 from appscale.common.constants import (
@@ -35,7 +42,9 @@ from tornado.options import options
 from tornado import web
 from tornado.escape import json_decode
 from tornado.escape import json_encode
+from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
+from tornado.netutil import bind_unix_socket
 from . import utils
 from . import constants
 from .appengine_api import UpdateCronHandler
@@ -59,7 +68,7 @@ from .operation import (
 )
 from .operations_cache import OperationsCache
 from .push_worker_manager import GlobalPushWorkerManager
-from .service_manager import ServiceManager
+from .service_manager import ServiceManager, ServiceManagerHandler
 from .summary import get_combined_services
 
 logger = logging.getLogger('appscale-admin')
@@ -1201,12 +1210,26 @@ def main():
 
   subparsers.add_parser(
     'summary', description='Lists AppScale processes running on this machine')
+  restart_parser = subparsers.add_parser(
+    'restart',
+    description='Restart AppScale processes running on this machine')
+  restart_parser.add_argument('service', nargs='+',
+                              help='The process or service ID to restart')
 
   args = parser.parse_args()
   if args.command == 'summary':
     table = sorted(list(get_combined_services().items()))
     print(tabulate(table, headers=['Service', 'State']))
     sys.exit(0)
+
+  if args.command == 'restart':
+    socket_path = urlquote(ServiceManagerHandler.SOCKET_PATH, safe='')
+    session = requests_unixsocket.Session()
+    response = session.post(
+      'http+unix://{}/'.format(socket_path),
+      data={'command': 'restart', 'arg': [args.service]})
+    response.raise_for_status()
+    return
 
   if args.verbose:
     logger.setLevel(logging.DEBUG)
@@ -1259,5 +1282,12 @@ def main():
   ])
   logger.info('Starting AdminServer')
   app.listen(args.port)
+
+  management_app = web.Application([
+    ('/', ServiceManagerHandler, {'service_manager': service_manager})])
+  management_server = HTTPServer(management_app)
+  management_socket = bind_unix_socket(ServiceManagerHandler.SOCKET_PATH)
+  management_server.add_socket(management_socket)
+
   io_loop = IOLoop.current()
   io_loop.start()

--- a/AdminServer/appscale/admin/instance_manager/stop_instance.py
+++ b/AdminServer/appscale/admin/instance_manager/stop_instance.py
@@ -5,7 +5,7 @@ import os
 import psutil
 import signal
 
-from appscale.common.constants import PID_DIR
+from appscale.common.constants import VAR_DIR
 
 # The number of seconds to wait for an instance to terminate.
 DEFAULT_WAIT_TIME = 20
@@ -23,7 +23,7 @@ def stop_instance(watch, timeout, force=False):
     IOError if the pidfile does not exist.
     OSError if the process does not exist.
   """
-  pidfile_location = os.path.join(PID_DIR, '{}.pid'.format(watch))
+  pidfile_location = os.path.join(VAR_DIR, '{}.pid'.format(watch))
   with open(pidfile_location) as pidfile:
     pid = int(pidfile.read().strip())
 

--- a/AdminServer/appscale/admin/push_worker_manager.py
+++ b/AdminServer/appscale/admin/push_worker_manager.py
@@ -13,12 +13,8 @@ from tornado.options import options
 from appscale.common.async_retrying import (
   retry_children_watch_coroutine, retry_coroutine, retry_data_watch_coroutine
 )
-from appscale.common.constants import (
-  LOG_DIR,
-  MonitStates,
-  PID_DIR,
-  CONFIG_DIR
-)
+from appscale.common.constants import (CONFIG_DIR, LOG_DIR, MonitStates,
+                                       VAR_DIR)
 from appscale.common.monit_app_configuration import create_config_file
 from appscale.common.monit_app_configuration import MONIT_CONFIG_DIR
 
@@ -83,7 +79,7 @@ class ProjectPushWorkerManager(object):
     self._write_worker_configuration(queue_config)
     status = yield self._wait_for_stable_state()
 
-    pid_location = os.path.join(PID_DIR, 'celery-{}.pid'.format(self.project_id))
+    pid_location = os.path.join(VAR_DIR, 'celery-{}.pid'.format(self.project_id))
     try:
       with open(pid_location) as pidfile:
         old_pid = int(pidfile.read().strip())
@@ -144,7 +140,7 @@ class ProjectPushWorkerManager(object):
     """ Generates the Celery command for a project's push worker. """
     log_file = os.path.join(CELERY_WORKER_LOG_DIR,
                             '{}.log'.format(self.project_id))
-    pidfile = os.path.join(PID_DIR, 'celery-{}.pid'.format(self.project_id))
+    pidfile = os.path.join(VAR_DIR, 'celery-{}.pid'.format(self.project_id))
     state_db = os.path.join(CELERY_STATE_DIR,
                             'worker___{}.db'.format(self.project_id))
 

--- a/AdminServer/setup.py
+++ b/AdminServer/setup.py
@@ -7,6 +7,7 @@ install_requires = [
   'kazoo',
   'psutil',
   'PyYaml',
+  'requests-unixsocket',
   'SOAPpy',
   'tabulate',
   'tornado',

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -50,9 +50,7 @@ from appscale.common import (
   monit_interface,
   misc
 )
-from appscale.common.constants import HTTPCodes
-from appscale.common.constants import PID_DIR
-from appscale.common.constants import MonitStates
+from appscale.common.constants import HTTPCodes, MonitStates, VAR_DIR
 from appscale.common.constants import VERSION_PATH_SEPARATOR
 from appscale.common.deployment_config import ConfigInaccessible
 from appscale.common.deployment_config import DeploymentConfig
@@ -232,7 +230,7 @@ def ensure_api_server(project_id):
 
   watch = ''.join([API_SERVER_PREFIX, project_id])
   full_watch = '-'.join([watch, str(server_port)])
-  pidfile = os.path.join(PID_DIR, '{}.pid'.format(full_watch))
+  pidfile = os.path.join(VAR_DIR, '{}.pid'.format(full_watch))
   monit_app_configuration.create_config_file(
     watch,
     start_cmd,

--- a/common/appscale/common/constants.py
+++ b/common/appscale/common/constants.py
@@ -145,8 +145,8 @@ CGROUP_DIR = os.path.join('/', 'sys', 'fs', 'cgroup')
 # The default log directory for AppScale services.
 LOG_DIR = os.path.join('/var', 'log', 'appscale')
 
-# The default directory for pidfiles.
-PID_DIR = os.path.join('/', 'var', 'run', 'appscale')
+# The default directory for run-time variable data (eg. pidfiles).
+VAR_DIR = os.path.join('/', 'var', 'run', 'appscale')
 
 # The number of seconds to wait before retrying some operations.
 SMALL_WAIT = 5


### PR DESCRIPTION
This gives the ServiceManager a unix socket at /var/run/appscale/service_manager.sock that accepts management requests.

This allows the user to immediately restart datastore servers without waiting for the ServiceManager to periodically check and fulfill assignments.

Resolves #2829.