### PR TITLE
Create additional table for tag queries

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/constants.py
+++ b/AppTaskQueue/appscale/taskqueue/constants.py
@@ -1,6 +1,10 @@
 import re
 
 
+class EmptyQueue(Exception):
+  """ Indicates that there are no tasks in the queue. """
+  pass
+
 class QueueNotFound(Exception):
   """ Indicates that the specified queue does not exist. """
   pass

--- a/AppTaskQueue/appscale/taskqueue/distributed_tq.py
+++ b/AppTaskQueue/appscale/taskqueue/distributed_tq.py
@@ -20,6 +20,7 @@ from appscale.common import (
 from appscale.common.constants import SCHEMA_CHANGE_TIMEOUT
 from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
 from appscale.datastore.cassandra_env.cassandra_interface import KEYSPACE
+from appscale.datastore.cassandra_env.retry_policies import BASIC_RETRIES
 from cassandra import (
   InvalidRequest,
   OperationTimedOut
@@ -59,6 +60,53 @@ from google.appengine.runtime import apiproxy_errors
 
 # A policy that does not retry statements.
 NO_RETRIES = FallthroughRetryPolicy()
+
+
+def rebuild_task_indexes(session):
+  """ Creates index entries for all pull queue tasks.
+
+  Args:
+    session: A cassandra-driver session.
+  """
+  logger.info('Rebuilding task indexes')
+  batch_size = 100
+  total_tasks = 0
+  app = ''
+  queue = ''
+  id = ''
+  while True:
+    results = session.execute("""
+      SELECT app, queue, id, lease_expires, tag FROM pull_queue_tasks
+      WHERE token(app, queue, id) > token(%(app)s, %(queue)s, %(id)s)
+      LIMIT {}
+    """.format(batch_size), {'app': app, 'queue': queue, 'id': id})
+    results_list = list(results)
+    for result in results_list:
+      parameters = {'app': result.app, 'queue': result.queue,
+                    'eta': result.lease_expires, 'id': result.id,
+                    'tag': result.tag or ''}
+
+      insert_eta_index = SimpleStatement("""
+        INSERT INTO pull_queue_tasks_index (app, queue, eta, id, tag)
+        VALUES (%(app)s, %(queue)s, %(eta)s, %(id)s, %(tag)s)
+      """, retry_policy=BASIC_RETRIES)
+      session.execute(insert_eta_index, parameters)
+
+      insert_tag_index = SimpleStatement("""
+        INSERT INTO pull_queue_tags_index (app, queue, tag, eta, id)
+        VALUES (%(app)s, %(queue)s, %(tag)s, %(eta)s, %(id)s)
+      """, retry_policy=BASIC_RETRIES)
+      session.execute(insert_tag_index, parameters)
+
+    total_tasks += len(results_list)
+    if len(results_list) < batch_size:
+      break
+
+    app = results_list[-1].app
+    queue = results_list[-1].queue
+    id = results_list[-1].id
+
+  logger.info('Created entries for {} tasks'.format(total_tasks))
 
 
 def create_pull_queue_tables(cluster, session):
@@ -105,6 +153,22 @@ def create_pull_queue_tables(cluster, session):
       time.sleep(SCHEMA_CHANGE_TIMEOUT)
       raise
 
+  rebuild_indexes = False
+  if ('pull_queue_tasks_index' in keyspace_metadata.tables and
+      'tag_exists' in keyspace_metadata.tables['pull_queue_tasks_index'].columns):
+    rebuild_indexes = True
+    logger.info('Dropping outdated pull_queue_tags index')
+    session.execute('DROP INDEX IF EXISTS pull_queue_tags',
+                    timeout=SCHEMA_CHANGE_TIMEOUT)
+
+    logger.info('Dropping outdated pull_queue_tag_exists index')
+    session.execute('DROP INDEX IF EXISTS pull_queue_tag_exists',
+                    timeout=SCHEMA_CHANGE_TIMEOUT)
+
+    logger.info('Dropping outdated pull_queue_tasks_index table')
+    session.execute('DROP TABLE pull_queue_tasks_index',
+                    timeout=SCHEMA_CHANGE_TIMEOUT)
+
   logger.info('Trying to create pull_queue_tasks_index')
   create_index_table = """
     CREATE TABLE IF NOT EXISTS pull_queue_tasks_index (
@@ -113,8 +177,7 @@ def create_pull_queue_tables(cluster, session):
       eta timestamp,
       id text,
       tag text,
-      tag_exists boolean,
-      PRIMARY KEY ((app, queue, eta), id)
+      PRIMARY KEY ((app, queue, eta, id))
     ) WITH gc_grace_seconds = 120
   """
   statement = SimpleStatement(create_index_table, retry_policy=NO_RETRIES)
@@ -128,34 +191,30 @@ def create_pull_queue_tables(cluster, session):
     time.sleep(SCHEMA_CHANGE_TIMEOUT)
     raise
 
-  logger.info('Trying to create pull_queue_tags index')
-  create_index = """
-    CREATE INDEX IF NOT EXISTS pull_queue_tags ON pull_queue_tasks_index (tag);
+  logger.info('Trying to create pull_queue_tags_index')
+  create_tags_index_table = """
+    CREATE TABLE IF NOT EXISTS pull_queue_tags_index (
+      app text,
+      queue text,
+      tag text,
+      eta timestamp,
+      id text,
+      PRIMARY KEY ((app, queue, tag, eta, id))
+    ) WITH gc_grace_seconds = 120
   """
+  statement = SimpleStatement(create_tags_index_table, retry_policy=NO_RETRIES)
   try:
-    session.execute(create_index, timeout=SCHEMA_CHANGE_TIMEOUT)
-  except (OperationTimedOut, InvalidRequest):
+    session.execute(statement, timeout=SCHEMA_CHANGE_TIMEOUT)
+  except OperationTimedOut:
     logger.warning(
-      'Encountered error while creating pull_queue_tags index. Waiting {} '
-      'seconds for schema to settle.'.format(SCHEMA_CHANGE_TIMEOUT))
+      'Encountered an operation timeout while creating pull_queue_tags_index.'
+      ' Waiting {} seconds for schema to settle.'
+        .format(SCHEMA_CHANGE_TIMEOUT))
     time.sleep(SCHEMA_CHANGE_TIMEOUT)
     raise
 
-  # This additional index is needed for groupByTag=true,tag=None queries
-  # because Cassandra can only do '=' queries on secondary indices.
-  logger.info('Trying to create pull_queue_tag_exists index')
-  create_index = """
-    CREATE INDEX IF NOT EXISTS pull_queue_tag_exists
-    ON pull_queue_tasks_index (tag_exists);
-  """
-  try:
-    session.execute(create_index, timeout=SCHEMA_CHANGE_TIMEOUT)
-  except (OperationTimedOut, InvalidRequest):
-    logger.warning(
-      'Encountered error while creating pull_queue_tag_exists index. '
-      'Waiting {} seconds for schema to settle.'.format(SCHEMA_CHANGE_TIMEOUT))
-    time.sleep(SCHEMA_CHANGE_TIMEOUT)
-    raise
+  if rebuild_indexes:
+    rebuild_task_indexes(session)
 
   logger.info('Trying to create pull_queue_leases')
   create_leases_table = """

--- a/AppTaskQueue/appscale/taskqueue/distributed_tq.py
+++ b/AppTaskQueue/appscale/taskqueue/distributed_tq.py
@@ -73,13 +73,13 @@ def rebuild_task_indexes(session):
   total_tasks = 0
   app = ''
   queue = ''
-  id = ''
+  id_ = ''
   while True:
     results = session.execute("""
       SELECT app, queue, id, lease_expires, tag FROM pull_queue_tasks
       WHERE token(app, queue, id) > token(%(app)s, %(queue)s, %(id)s)
       LIMIT {}
-    """.format(batch_size), {'app': app, 'queue': queue, 'id': id})
+    """.format(batch_size), {'app': app, 'queue': queue, 'id': id_})
     results_list = list(results)
     for result in results_list:
       parameters = {'app': result.app, 'queue': result.queue,
@@ -104,7 +104,7 @@ def rebuild_task_indexes(session):
 
     app = results_list[-1].app
     queue = results_list[-1].queue
-    id = results_list[-1].id
+    id_ = results_list[-1].id
 
   logger.info('Created entries for {} tasks'.format(total_tasks))
 

--- a/AppTaskQueue/appscale/taskqueue/distributed_tq.py
+++ b/AppTaskQueue/appscale/taskqueue/distributed_tq.py
@@ -87,7 +87,7 @@ def rebuild_task_indexes(session):
                     'tag': result.tag or ''}
 
       insert_eta_index = SimpleStatement("""
-        INSERT INTO pull_queue_tasks_index (app, queue, eta, id, tag)
+        INSERT INTO pull_queue_eta_index (app, queue, eta, id, tag)
         VALUES (%(app)s, %(queue)s, %(eta)s, %(id)s, %(tag)s)
       """, retry_policy=BASIC_RETRIES)
       session.execute(insert_eta_index, parameters)
@@ -169,9 +169,9 @@ def create_pull_queue_tables(cluster, session):
     session.execute('DROP TABLE pull_queue_tasks_index',
                     timeout=SCHEMA_CHANGE_TIMEOUT)
 
-  logger.info('Trying to create pull_queue_tasks_index')
+  logger.info('Trying to create pull_queue_eta_index')
   create_index_table = """
-    CREATE TABLE IF NOT EXISTS pull_queue_tasks_index (
+    CREATE TABLE IF NOT EXISTS pull_queue_eta_index (
       app text,
       queue text,
       eta timestamp,
@@ -185,7 +185,7 @@ def create_pull_queue_tables(cluster, session):
     session.execute(statement, timeout=SCHEMA_CHANGE_TIMEOUT)
   except OperationTimedOut:
     logger.warning(
-      'Encountered an operation timeout while creating pull_queue_tasks_index.'
+      'Encountered an operation timeout while creating pull_queue_eta_index.'
       ' Waiting {} seconds for schema to settle.'
         .format(SCHEMA_CHANGE_TIMEOUT))
     time.sleep(SCHEMA_CHANGE_TIMEOUT)

--- a/AppTaskQueue/appscale/taskqueue/queue.py
+++ b/AppTaskQueue/appscale/taskqueue/queue.py
@@ -17,6 +17,7 @@ from cassandra.query import SimpleStatement
 from collections import deque
 from threading import Lock
 from .constants import AGE_LIMIT_REGEX
+from .constants import EmptyQueue
 from .constants import InvalidQueueConfiguration
 from .constants import RATE_REGEX
 from .constants import TaskNotFound
@@ -305,27 +306,34 @@ class PullQueue(Queue):
     task.enqueueTimestamp = enqueue_time
     task.leaseTimestamp = lease_expires
 
-    # Create an index entry so the task can be queried by ETA. This can't be
-    # done in a batch because the payload from the previous insert can be up
-    # to 1MB, and Cassandra does not approve of large batches.
-    insert_index = SimpleStatement("""
-      INSERT INTO pull_queue_tasks_index (app, queue, eta, id, tag, tag_exists)
-      VALUES (%(app)s, %(queue)s, %(eta)s, %(id)s, %(tag)s, %(tag_exists)s)
+    # Create index entries so the task can be queried by ETA and (tag, ETA).
+    # This can't be done in a batch because the payload from the previous
+    # insert can be up to 1MB, and Cassandra does not approve of large batches.
+    try:
+      tag = task.tag
+    except AttributeError:
+      # The API does not differentiate between empty and unspecified tags.
+      tag = ''
+
+    insert_eta_index = SimpleStatement("""
+      INSERT INTO pull_queue_tasks_index (app, queue, eta, id, tag)
+      VALUES (%(app)s, %(queue)s, %(eta)s, %(id)s, %(tag)s)
     """, retry_policy=BASIC_RETRIES)
     parameters = {
       'app': self.app,
       'queue': self.name,
       'eta': task.get_eta(),
-      'id': task.id
+      'id': task.id,
+      'tag': tag
     }
-    try:
-      parameters['tag'] = task.tag
-    except AttributeError:
-      # Insert an empty string for null values so that Cassandra can query for
-      # tasks where tag is not null.
-      parameters['tag'] = ''
-    parameters['tag_exists'] = parameters['tag'] != ''
-    self.db_access.session.execute(insert_index, parameters)
+    self.db_access.session.execute(insert_eta_index, parameters)
+
+    insert_tag_index = SimpleStatement("""
+      INSERT INTO pull_queue_tags_index (app, queue, tag, eta, id)
+      VALUES (%(app)s, %(queue)s, %(tag)s, %(eta)s, %(id)s)
+    """, retry_policy=BASIC_RETRIES)
+    self.db_access.session.execute(insert_tag_index, parameters)
+
     logger.debug('Added task: {}'.format(task))
 
   def get_task(self, task, omit_payload=False):
@@ -456,15 +464,16 @@ class PullQueue(Queue):
 
     tasks = []
     start_date = datetime.datetime.utcfromtimestamp(0)
+    task_id = ''
     while True:
       query_tasks = """
         SELECT eta, id FROM pull_queue_tasks_index
-        WHERE token(app, queue, eta) > token(%(app)s, %(queue)s, %(eta)s)
-        AND token(app, queue, eta) < token(%(app)s, %(next_queue)s, 0)
+        WHERE token(app, queue, eta, id) > token(%(app)s, %(queue)s, %(eta)s, %(id)s)
+        AND token(app, queue, eta, id) < token(%(app)s, %(next_queue)s, 0, '')
         LIMIT {limit}
       """.format(limit=limit)
       parameters = {'app': self.app, 'queue': self.name, 'eta': start_date,
-                    'next_queue': next_key(self.name)}
+                    'id': task_id, 'next_queue': next_key(self.name)}
       results = [result for result in session.execute(query_tasks, parameters)]
 
       if not results:
@@ -474,7 +483,7 @@ class PullQueue(Queue):
       for result in results:
         task = self.get_task(Task({'id': result.id}), omit_payload=True)
         if task is None:
-          self._delete_index(result.eta, result.id)
+          self._delete_index(result.eta, result.id, result.tag)
           continue
 
         tasks.append(task)
@@ -486,6 +495,7 @@ class PullQueue(Queue):
 
       # Update the cursor.
       start_date = results[-1].eta
+      task_id = results[-1].id
 
     return tasks
 
@@ -515,8 +525,9 @@ class PullQueue(Queue):
                  format(num_tasks, lease_seconds, group_by_tag, tag))
     # If not specified, the tag is assumed to be that of the oldest task.
     if group_by_tag and tag is None:
-      tag = self._get_earliest_tag()
-      if tag is None:
+      try:
+        tag = self._get_earliest_tag()
+      except EmptyQueue:
         return []
 
     # Fetch available tasks and try to lease them until the requested number
@@ -595,8 +606,8 @@ class PullQueue(Queue):
     session = self.db_access.session
     select_oldest = """
       SELECT eta FROM pull_queue_tasks_index
-      WHERE token(app, queue, eta) >= token(%(app)s, %(queue)s, 0)
-      AND token(app, queue, eta) < token(%(app)s, %(next_queue)s, 0)
+      WHERE token(app, queue, eta, id) >= token(%(app)s, %(queue)s, 0, '')
+      AND token(app, queue, eta, id) < token(%(app)s, %(next_queue)s, 0, '')
       LIMIT 1
     """
     parameters = {'app': self.app, 'queue': self.name,
@@ -613,7 +624,7 @@ class PullQueue(Queue):
     selects all the tasks before deleting them one at a time.
     """
     select_tasks = """
-      SELECT id, enqueued, lease_expires FROM pull_queue_tasks
+      SELECT id, enqueued, lease_expires, tag FROM pull_queue_tasks
       WHERE token(app, queue, id) >= token(%(app)s, %(queue)s, '')
       AND token(app, queue, id) < token(%(app)s, %(next_queue)s, '')
     """
@@ -624,7 +635,8 @@ class PullQueue(Queue):
     for result in results:
       task_info = {'id': result.id,
                    'enqueueTimestamp': result.enqueued,
-                   'leaseTimestamp': result.lease_expires}
+                   'leaseTimestamp': result.lease_expires,
+                   'tag': result.tag}
       self._delete_task_and_index(Task(task_info))
 
   def to_json(self, include_stats=False, fields=None):
@@ -768,7 +780,7 @@ class PullQueue(Queue):
     if not self._task_mutated_by_id(parameters['id'], parameters['op_id']):
       raise InvalidLeaseRequest('The task lease has expired.')
 
-  def _query_index(self, num_tasks, group_by_tag=False, tag=None):
+  def _query_index(self, num_tasks, group_by_tag, tag):
     """ Query the index table for available tasks.
 
     Args:
@@ -782,26 +794,25 @@ class PullQueue(Queue):
     """
     if group_by_tag:
       query_tasks = """
-        SELECT eta, id FROM pull_queue_tasks_index
-        WHERE token(app, queue, eta) >= token(%(app)s, %(queue)s, 0)
-        AND token(app, queue, eta) <= token(%(app)s, %(queue)s, dateof(now()))
-        AND tag = %(tag)s
+        SELECT tag, eta, id FROM pull_queue_tags_index
+        WHERE token(app, queue, tag, eta, id) >= token(%(app)s, %(queue)s, %(tag)s, 0, '')
+        AND token(app, queue, tag, eta, id) <= token(%(app)s, %(queue)s, %(tag)s, dateof(now()), '')
         LIMIT {limit}
       """.format(limit=num_tasks)
       parameters = {'app': self.app, 'queue': self.name, 'tag': tag}
       results = self.db_access.session.execute(query_tasks, parameters)
     else:
       query_tasks = """
-        SELECT eta, id FROM pull_queue_tasks_index
-        WHERE token(app, queue, eta) >= token(%(app)s, %(queue)s, 0)
-        AND token(app, queue, eta) <= token(%(app)s, %(queue)s, dateof(now()))
+        SELECT eta, id, tag FROM pull_queue_tasks_index
+        WHERE token(app, queue, eta, id) >= token(%(app)s, %(queue)s, 0, '')
+        AND token(app, queue, eta, id) <= token(%(app)s, %(queue)s, dateof(now()), '')
         LIMIT {limit}
       """.format(limit=num_tasks)
       parameters = {'app': self.app, 'queue': self.name}
       results = self.db_access.session.execute(query_tasks, parameters)
     return results
 
-  def _query_available_tasks(self, num_tasks, group_by_tag=False, tag=None):
+  def _query_available_tasks(self, num_tasks, group_by_tag, tag):
     """ Query the cache or index table for available tasks.
 
     Args:
@@ -863,15 +874,20 @@ class PullQueue(Queue):
     """ Get the tag with the earliest ETA.
 
     Returns:
-      A string containing a tag or None.
+      A string containing a tag.
+    Raises:
+      EmptyQueue if there are no tasks.
     """
     get_earliest_tag = """
-      SELECT tag FROM pull_queue_tasks_index WHERE tag_exists = true LIMIT 1
+      SELECT tag FROM pull_queue_tasks_index
+      WHERE token(app, queue, eta, id) > token(%(app)s, %(queue)s, 0, '')
+      LIMIT 1
     """
+    parameters = {'app': self.app, 'queue': self.name}
     try:
-      tag = self.db_access.session.execute(get_earliest_tag)[0].tag
+      tag = self.db_access.session.execute(get_earliest_tag, parameters)[0].tag
     except IndexError:
-      return None
+      raise EmptyQueue('No entries in queue index')
     return tag
 
   def _increment_count_async(self, task):
@@ -1017,39 +1033,64 @@ class PullQueue(Queue):
     """
     if statement not in self.prepared_statements:
       self.prepared_statements[statement] = session.prepare(statement)
-    delete_old_index = self.prepared_statements[statement]
+    delete_old_eta_index = self.prepared_statements[statement]
 
     parameters = [self.app, self.name, old_eta, task.id]
-    update_index.add(delete_old_index, parameters)
+    update_index.add(delete_old_eta_index, parameters)
 
     statement = """
-      INSERT INTO pull_queue_tasks_index (app, queue, eta, id, tag, tag_exists)
-      VALUES (?, ?, ?, ?, ?, ?)
+      DELETE FROM pull_queue_tags_index
+      WHERE app=?
+      AND queue=?
+      AND tag=?
+      AND eta=?
+      AND id=?
     """
     if statement not in self.prepared_statements:
       self.prepared_statements[statement] = session.prepare(statement)
-    create_new_index = self.prepared_statements[statement]
+    delete_old_tag_index = self.prepared_statements[statement]
+
+    parameters = [self.app, self.name, old_index.tag, old_eta, task.id]
+    update_index.add(delete_old_tag_index, parameters)
 
     try:
       tag = task.tag
     except AttributeError:
       tag = ''
-    tag_exists = tag != ''
 
-    parameters = [self.app, self.name, task.leaseTimestamp, task.id, tag,
-                  tag_exists]
-    update_index.add(create_new_index, parameters)
+    statement = """
+      INSERT INTO pull_queue_tasks_index (app, queue, eta, id, tag)
+      VALUES (?, ?, ?, ?, ?)
+    """
+    if statement not in self.prepared_statements:
+      self.prepared_statements[statement] = session.prepare(statement)
+    create_new_eta_index = self.prepared_statements[statement]
+
+    parameters = [self.app, self.name, task.leaseTimestamp, task.id, tag]
+    update_index.add(create_new_eta_index, parameters)
+
+    statement = """
+      INSERT INTO pull_queue_tags_index (app, queue, tag, eta, id)
+      VALUES (?, ?, ?, ?, ?)
+    """
+    if statement not in self.prepared_statements:
+      self.prepared_statements[statement] = session.prepare(statement)
+    create_new_tag_index = self.prepared_statements[statement]
+
+    parameters = [self.app, self.name, tag, task.leaseTimestamp, task.id]
+    update_index.add(create_new_tag_index, parameters)
 
     return self.db_access.session.execute_async(update_index)
 
-  def _delete_index(self, eta, task_id):
+  def _delete_index(self, eta, task_id, tag):
     """ Deletes an index entry for a task.
 
     Args:
       eta: A datetime object.
       task_id: A string containing the task ID.
+      tag: A string containing the task tag.
     """
-    delete_index = """
+    delete_eta_index = """
       DELETE FROM pull_queue_tasks_index
       WHERE app = %(app)s
       AND queue = %(queue)s
@@ -1058,10 +1099,22 @@ class PullQueue(Queue):
     """
     parameters = {'app': self.app, 'queue': self.name, 'eta': eta,
                   'id': task_id}
-    self.db_access.session.execute(delete_index, parameters)
+    self.db_access.session.execute(delete_eta_index, parameters)
+
+    delete_tag_index = """
+      DELETE FROM pull_queue_tags_index
+      WHERE app = %(app)s
+      AND queue = %(queue)s
+      AND tag = %(tag)s
+      AND eta = %(eta)s
+      AND id = %(id)s
+    """
+    parameters = {'app': self.app, 'queue': self.name, 'tag': tag, 'eta': eta,
+                  'id': task_id}
+    self.db_access.session.execute(delete_tag_index, parameters)
 
   def _delete_task_and_index(self, task, retries=5):
-    """ Deletes a task and its index atomically.
+    """ Deletes a task and its index.
 
     Args:
       task: A Task object.
@@ -1082,7 +1135,7 @@ class PullQueue(Queue):
         'Encountered error while deleting task: {}. Retrying.'.format(error))
       return self._delete_task_and_index(task, retries=retries_left)
 
-    delete_task_index = SimpleStatement("""
+    delete_task_eta_index = SimpleStatement("""
       DELETE FROM pull_queue_tasks_index
       WHERE app = %(app)s
       AND queue = %(queue)s
@@ -1095,7 +1148,29 @@ class PullQueue(Queue):
       'eta': task.get_eta(),
       'id': task.id
     }
-    self.db_access.session.execute(delete_task_index, parameters=parameters)
+    self.db_access.session.execute(delete_task_eta_index, parameters=parameters)
+
+    try:
+      tag = task.tag
+    except AttributeError:
+      tag = ''
+
+    delete_task_tag_index = SimpleStatement("""
+      DELETE FROM pull_queue_tags_index
+      WHERE app = %(app)s
+      AND queue = %(queue)s
+      AND tag = %(tag)s
+      AND eta = %(eta)s
+      AND id = %(id)s
+    """)
+    parameters = {
+      'app': self.app,
+      'queue': self.name,
+      'tag': tag,
+      'eta': task.get_eta(),
+      'id': task.id
+    }
+    self.db_access.session.execute(delete_task_tag_index, parameters=parameters)
 
   def _resolve_task(self, index):
     """ Cleans up expired tasks and indices.
@@ -1105,7 +1180,7 @@ class PullQueue(Queue):
     """
     task = self.get_task(Task({'id': index.id}), omit_payload=True)
     if task is None:
-      self._delete_index(index.eta, index.id)
+      self._delete_index(index.eta, index.id, index.tag)
       return
 
     if self.task_retry_limit != 0 and task.expired(self.task_retry_limit):


### PR DESCRIPTION
The previous method of using secondary indexes on the ETA index table was inefficient when grouping by tag and ordering by ETA.