### PR TITLE
Stop services in a particular order

### DIFF
--- a/AdminServer/appscale/admin/stop_services.py
+++ b/AdminServer/appscale/admin/stop_services.py
@@ -6,6 +6,57 @@ import time
 from appscale.common.monit_interface import MonitOperator, MonitStates
 
 
+def order_services(running_services):
+  """ Arranges a list of running services in the order they should be stopped.
+
+  Args:
+    running_services: A list of strings specifying running services.
+  Returns:
+    A list of strings specifying services that should be stopped.
+  """
+  service_order = [
+    # First, stop the services that manage other services.
+    'controller',
+    'admin_server',
+    'appmanagerserver',
+
+    # Next, stop application runtime instances.
+    'app___',
+    'api-server_',
+
+    # Next, stop services that depend on other services.
+    'app_haproxy',
+    'service_haproxy',
+    'blobstore',
+    'celery-',
+    'flower',
+    'groomer_service',
+    'hermes',
+    'iaas_manager',
+    'log_service',
+    'taskqueue-',
+    'transaction_groomer',
+    'uaserver',
+
+    # Finally, stop the underlying backend services.
+    'cassandra',
+    'ejabberd',
+    'memcached',
+    'rabbitmq',
+    'zookeeper'
+  ]
+
+  ordered_services = []
+  for service_type in service_order:
+    relevant_entries = [service for service in running_services
+                        if service.startswith(service_type)]
+    for entry in relevant_entries:
+      index = running_services.index(entry)
+      ordered_services.append(running_services.pop(index))
+
+  return ordered_services + running_services
+
+
 def main():
   """ Tries to stop all Monit services until they are stopped. """
   monit_operator = MonitOperator()
@@ -28,7 +79,7 @@ def main():
       print('Stopped {}/{} services'.format(stopped_count, len(services)))
 
     try:
-      service = next((service for service in sorted(running.keys())
+      service = next((service for service in order_services(running.keys())
                       if services[service] != MonitStates.PENDING))
       subprocess.Popen(['monit', 'stop', service])
     except StopIteration:

--- a/AdminServer/appscale/admin/stop_services.py
+++ b/AdminServer/appscale/admin/stop_services.py
@@ -1,8 +1,10 @@
 """ Tries to stop all Monit services until they are stopped. """
+import logging
 import socket
 import subprocess
 import time
 
+from appscale.common.constants import LOG_FORMAT
 from appscale.common.monit_interface import MonitOperator, MonitStates
 
 
@@ -12,7 +14,8 @@ def order_services(running_services):
   Args:
     running_services: A list of strings specifying running services.
   Returns:
-    A list of strings specifying services that should be stopped.
+    A tuple with two items. The first is a list of ordered services. The second
+    is a list of remaining services that are not recognized.
   """
   service_order = [
     # First, stop the services that manage other services.
@@ -20,12 +23,15 @@ def order_services(running_services):
     'admin_server',
     'appmanagerserver',
 
+    # Next, stop routing requests to running instances.
+    'nginx',
+    'app_haproxy',
+
     # Next, stop application runtime instances.
     'app___',
     'api-server_',
 
     # Next, stop services that depend on other services.
-    'app_haproxy',
     'service_haproxy',
     'blobstore',
     'celery-',
@@ -54,15 +60,17 @@ def order_services(running_services):
       index = running_services.index(entry)
       ordered_services.append(running_services.pop(index))
 
-  return ordered_services + running_services
+  return ordered_services, running_services
 
 
 def main():
   """ Tries to stop all Monit services until they are stopped. """
+  logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
   monit_operator = MonitOperator()
   hostname = socket.gethostname()
 
-  print('Waiting for monit to stop services')
+  logging.info('Waiting for monit to stop services')
+  logged_service_warning = False
   stopped_count = 0
   while True:
     entries = monit_operator.get_entries_sync()
@@ -71,15 +79,23 @@ def main():
     running = {service: state for service, state in services.items()
                if state not in (MonitStates.STOPPED, MonitStates.UNMONITORED)}
     if not running:
-      print('Finished stopping services')
+      logging.info('Finished stopping services')
       break
 
     if len(services) - len(running) != stopped_count:
       stopped_count = len(services) - len(running)
-      print('Stopped {}/{} services'.format(stopped_count, len(services)))
+      logging.info(
+        'Stopped {}/{} services'.format(stopped_count, len(services)))
 
     try:
-      service = next((service for service in order_services(running.keys())
+      ordered_services, unrecognized_services = order_services(running.keys())
+      if unrecognized_services and not logged_service_warning:
+        logging.warning(
+          'Unrecognized running services: {}'.format(unrecognized_services))
+        logged_service_warning = True
+
+      ordered_services = ordered_services + unrecognized_services
+      service = next((service for service in ordered_services
                       if services[service] != MonitStates.PENDING))
       subprocess.Popen(['monit', 'stop', service])
     except StopIteration:


### PR DESCRIPTION
This orders services roughly by their dependencies. The services that rely on other services are stopped before the underlying backend services.

This is mainly meant to address a Monit issue where the controller is designated as "Initializing" sometime during the stop process, preventing any other services from being stopped until its status is resolved.

Resolves #2830.