### PR TITLE
Force the push worker to time out stuck tasks

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/push_worker.py
+++ b/AppTaskQueue/appscale/taskqueue/push_worker.py
@@ -228,7 +228,7 @@ def execute_task(task, headers, args):
     if thrown_timeout != timeout:
       raise
 
-    logger.exception('Task timed out')
+    logger.exception('Task {} timed out. Retrying.'.format(args['task_name']))
     # This could probably be calculated, but for now, just retry immediately.
     raise task.retry(countdown=0)
   finally:

--- a/AppTaskQueue/appscale/taskqueue/push_worker.py
+++ b/AppTaskQueue/appscale/taskqueue/push_worker.py
@@ -28,7 +28,7 @@ from google.appengine.ext import db
 
 
 # The maximum number of seconds a task is permitted to take.
-MAX_TASK_DURATION = 10 * 60
+MAX_TASK_DURATION = 13 * 60
 
 app_id = os.environ['APP_ID']
 remote_host = os.environ['HOST']


### PR DESCRIPTION
The original problem was that the HTTP client would hang indefinitely every once in a while instead of timing out after 10 minutes. Every time this happened, the celery worker's capacity for concurrent tasks was reduced by 1.

This branch prevents that from happening by wrapping the whole task request in a timeout so that even if the HTTP client hangs indefinitely for some reason, the celery worker will abort and retry after 13 min.

This may not be a problem any longer, but I don't think it hurts to have in master as a safety measure. I've had this branch sitting around for about a year, so I decided to submit it rather than delete it. When we change out the push queue implementation, we should no longer need this.