### PR TITLE
Use real AppScale Cloud Storage when configured

### DIFF
--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -674,6 +674,16 @@ def create_python_app_env(public_ip, app_name):
   env_vars['GOMAXPROCS'] = appscale_info.get_num_cpus()
   env_vars['APPSCALE_HOME'] = constants.APPSCALE_HOME
   env_vars['PYTHON_LIB'] = "{0}/AppServer/".format(constants.APPSCALE_HOME)
+
+  gcs_config = {'scheme': 'https', 'port': 443}
+  try:
+    gcs_config.update(deployment_config.get_config('gcs'))
+  except ConfigInaccessible:
+    logging.warning('Unable to fetch GCS configuration.')
+
+  if 'host' in gcs_config:
+    env_vars['GCS_HOST'] = '{scheme}://{host}:{port}'.format(**gcs_config)
+
   return env_vars
 
 

--- a/AppServer/google/appengine/ext/cloudstorage/appscale_cloud_storage.py
+++ b/AppServer/google/appengine/ext/cloudstorage/appscale_cloud_storage.py
@@ -1,0 +1,180 @@
+""" Implements a Cloud Storage stub using an AppScale Cloud Storage server. """
+import base64
+import urlparse
+
+import requests
+
+from google.appengine.ext.cloudstorage import common
+
+
+class InternalError(Exception):
+  """ Indicates that there was a problem fulfilling an API request. """
+  pass
+
+
+class AppScaleCloudStorageStub(object):
+  """ A Cloud Storage stub implementation.
+
+  Uses an AppScale Cloud Storage server to store files.
+
+  Note: this Cloud Storage stub is designed to work with
+  apphosting.ext.cloudstorage.storage_api.py.
+  It only implements the part of GCS storage_api.py uses, and its interface
+  maps to GCS XML APIs.
+  """
+
+  def __init__(self, acs_location):
+    """Initialize.
+
+    Args:
+      acs_location: The location of an AppScale Cloud Storage server.
+    """
+    self.location = acs_location
+
+  def post_start_creation(self, filename, options):
+    """Start object creation with a POST.
+
+    This implements the resumable upload XML API.
+
+    Args:
+      filename: gs filename of form /bucket/filename.
+      options: a dict containing all user specified request headers.
+        e.g. {'content-type': 'foo', 'x-goog-meta-bar': 'bar'}.
+
+    Returns:
+      a token used for continuing upload. Also used as blobkey to store
+    the content.
+    """
+    common.validate_file_path(filename)
+
+    url = ''.join([self.location, filename])
+    options['x-goog-resumable'] = 'start'
+
+    response = requests.post(url, headers=options)
+    if response.status_code != 201:
+      raise InternalError(response.text)
+
+    location = response.headers.get('Location')
+    if location is None:
+      raise InternalError('Missing location from response')
+
+    query = urlparse.urlparse(location).query
+    try:
+      token = urlparse.parse_qs(query)['upload_id']
+    except KeyError:
+      raise InternalError('Upload ID missing from response')
+
+    # To keep this class stateless, include the filename with the token.
+    return base64.b64encode(':'.join([filename, token]))
+
+  def put_continue_creation(self, token, content, content_range, last=False):
+    """Continue object upload with PUTs.
+
+    This implements the resumable upload XML API.
+
+    Args:
+      token: upload token returned by post_start_creation.
+      content: object content.
+      content_range: a (start, end) tuple specifying the content range of this
+        chunk. Both are inclusive according to XML API.
+      last: True if this is the last chunk of file content.
+
+    Raises:
+      ValueError: if token is invalid.
+    """
+    filename, token = base64.b64decode(token).split(':', 1)
+
+    url = ''.join([self.location, filename, '?upload_id=', token])
+
+    start, end = content_range
+    total_size = '*'
+    if last:
+      total_size = end + 1
+    range_header = 'bytes {}-{}/{}'.format(start, end, total_size)
+    headers = {'Content-Length': len(content),
+               'Content-Range': range_header}
+
+    response = requests.put(url, headers=headers)
+    if not last and response.status_code != 308:
+      raise InternalError(response.text)
+
+    if last and response.status_code != 200:
+      raise InternalError(response.text)
+
+  def get_bucket(self,
+                 bucketpath,
+                 prefix,
+                 marker,
+                 max_keys):
+    """Get bucket listing with a GET.
+
+    Args:
+      bucketpath: gs bucket path of form '/bucket'
+      prefix: prefix to limit listing.
+      marker: a str after which to start listing.
+      max_keys: max size of listing.
+
+    See https://developers.google.com/storage/docs/reference-methods#getbucket
+    for details.
+
+    Returns:
+      A list of CSFileStat sorted by filename.
+    """
+    raise NotImplementedError()
+
+  def get_object(self, filename, start=0, end=None):
+    """Get file content with a GET.
+
+    Args:
+      filename: gs filename of form '/bucket/filename'.
+      start: start offset to request. Inclusive.
+      end: end offset to request. Inclusive.
+
+    Returns:
+      The segment of file content requested.
+
+    Raises:
+      ValueError: if file doesn't exist.
+    """
+    common.validate_file_path(filename)
+
+    url = ''.join([self.location, filename])
+    headers = {}
+    if start != 0 or end is not None:
+      headers['Range'] = 'bytes={}-{}'.format(start, end or '')
+
+    response = requests.get(url, headers=headers)
+    return response.content
+
+  def head_object(self, filename):
+    """Get file stat with a HEAD.
+
+    Args:
+      filename: gs filename of form '/bucket/filename'
+
+    Returns:
+      A CSFileStat object containing file stat. None if file doesn't exist.
+    """
+    raise NotImplementedError()
+
+  def delete_object(self, filename):
+    """Delete file with a DELETE.
+
+    Args:
+      filename: gs filename of form '/bucket/filename'
+
+    Returns:
+      True if file is deleted. False if file doesn't exist.
+    """
+    common.validate_file_path(filename)
+
+    url = ''.join([self.location, filename])
+    response = requests.delete(url)
+
+    if response.status_code == 204:
+      return True
+
+    if response.status_code == 404:
+      return False
+
+    raise InternalError(response.text)

--- a/AppServer/google/appengine/ext/cloudstorage/stub_dispatcher.py
+++ b/AppServer/google/appengine/ext/cloudstorage/stub_dispatcher.py
@@ -26,6 +26,7 @@
 
 import cgi
 import httplib
+import os
 import re
 import urllib
 import urlparse
@@ -33,6 +34,7 @@ import xml.etree.ElementTree as ET
 
 from google.appengine.api import apiproxy_stub_map
 from google.appengine.api import urlfetch_stub
+from google.appengine.ext.cloudstorage import appscale_cloud_storage
 from google.appengine.ext.cloudstorage import cloudstorage_stub
 from google.appengine.ext.cloudstorage import common
 
@@ -100,7 +102,13 @@ def dispatch(method, headers, url, payload):
     ValueError: invalid request method.
   """
   method, headers, filename, param_dict = _preprocess(method, headers, url)
-  gcs_stub = cloudstorage_stub.CloudStorageStub(
+
+  # AppScale: Use an AppScale Cloud Storage client when GCS_HOST is set.
+  if os.getenv('GCS_HOST'):
+    gcs_stub = appscale_cloud_storage.AppScaleCloudStorageStub(
+      os.getenv('GCS_HOST'))
+  else:
+    gcs_stub = cloudstorage_stub.CloudStorageStub(
       apiproxy_stub_map.apiproxy.GetStub('blobstore').storage)
 
   if method == 'POST':


### PR DESCRIPTION
By default, the dispatcher for non-Java runtimes uses the blobstore backend for GCS operations. This change allows users to use a real GCS service instead.