### PR TITLE
Handle ID separator in key name

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/get_token.py
+++ b/AppDB/appscale/datastore/cassandra_env/get_token.py
@@ -13,6 +13,7 @@ from ..cassandra_env.constants import LB_POLICY
 from ..cassandra_env.retry_policies import BASIC_RETRIES
 from ..dbconstants import APP_ENTITY_TABLE
 from ..dbconstants import APP_ENTITY_SCHEMA
+from ..dbconstants import ID_SEPARATOR
 from ..dbconstants import KEY_DELIMITER
 from ..dbconstants import KIND_SEPARATOR
 
@@ -63,7 +64,7 @@ def get_kind_averages(keys):
     key = key_dict['key']
     if is_entity(key):
       key_parts = key.split(KEY_DELIMITER)
-      kind = key_parts[2].split(':')[0]
+      kind = key_parts[2].split(ID_SEPARATOR, 1)[0]
       kind_id = KEY_DELIMITER.join([key_parts[0], key_parts[1], kind])
       if kind_id not in entities_by_kind:
         entities_by_kind[kind_id] = {'keys': [], 'size': 0, 'fetched': 0}
@@ -146,7 +147,7 @@ def main():
       continue
 
     key_parts = key.split(KEY_DELIMITER)
-    kind = key_parts[2].split(':')[0]
+    kind = key_parts[2].split(ID_SEPARATOR, 1)[0]
     kind_id = KEY_DELIMITER.join([key_parts[0], key_parts[1], kind])
     if kind_id in kind_averages:
       key_dict['size'] += kind_averages[kind_id]

--- a/AppDB/appscale/datastore/entity_utils.py
+++ b/AppDB/appscale/datastore/entity_utils.py
@@ -3,6 +3,7 @@
 from appscale.datastore import dbconstants
 from appscale.datastore.dbconstants import JOURNAL_SCHEMA
 from appscale.datastore.dbconstants import JOURNAL_TABLE
+from appscale.datastore.dbconstants import ID_SEPARATOR
 from appscale.datastore.dbconstants import KEY_DELIMITER
 from appscale.datastore.dbconstants import KIND_SEPARATOR
 from google.appengine.datastore import entity_pb
@@ -31,7 +32,7 @@ def get_kind_from_entity_key(entity_key):
     A str representing the kind.
   """
   tokens = entity_key.split(KEY_DELIMITER)
-  return tokens[2].split(":")[0]
+  return tokens[2].split(ID_SEPARATOR, 1)[0]
 
 
 def fetch_journal_entry(db_access, key):

--- a/AppDB/appscale/datastore/groomer.py
+++ b/AppDB/appscale/datastore/groomer.py
@@ -297,7 +297,8 @@ class DatastoreGroomer(threading.Thread):
 
     mutable_path = group.mutable_path()
     first_element = mutable_path.add_element()
-    kind, id_ = path.split(dbconstants.KIND_SEPARATOR)[0].split(':')
+    encoded_first_element = path.split(dbconstants.KIND_SEPARATOR)[0]
+    kind, id_ = encoded_first_element.split(dbconstants.ID_SEPARATOR, 1)
     first_element.set_type(kind)
 
     # At this point, there's no way to tell if the ID was originally a name,
@@ -452,7 +453,8 @@ class DatastoreGroomer(threading.Thread):
         element = entity_pb.Path_Element()
         # IDs are treated as names here. This avoids having to fetch the entity
         # to tell the difference.
-        element.set_name(encoded_element.split(dbconstants.ID_SEPARATOR)[-1])
+        key_name = encoded_element.split(dbconstants.ID_SEPARATOR, 1)[-1]
+        element.set_name(key_name)
         return element
 
       key = None

--- a/AppDB/test/unit/test_utils.py
+++ b/AppDB/test/unit/test_utils.py
@@ -24,3 +24,9 @@ class TestUtils(unittest.TestCase):
     self.assertEqual(path.element_size(), 1)
     self.assertEqual(path.element(0).type(), 'Greeting')
     self.assertEqual(path.element(0).id(), 2)
+
+    # Test a path that contains the ID separator.
+    path = utils.decode_path('Greeting:Test:1\x01')
+    self.assertEqual(path.element_size(), 1)
+    self.assertEqual(path.element(0).type(), 'Greeting')
+    self.assertEqual(path.element(0).name(), 'Test:1')


### PR DESCRIPTION
This change assumes that everything before the first ':' is the kind name and everything after is the key name (or ID). Although the Cloud Datastore API allows ':' in the kind name, we forbid it during puts so that we can make that assumption during queries.

Resolves #2841.