### PR TITLE
Use security token when making Monit API calls

### DIFF
--- a/AdminServer/setup.py
+++ b/AdminServer/setup.py
@@ -41,6 +41,8 @@ setup(
   entry_points={'console_scripts': [
     'appscale-admin=appscale.admin:main',
     'appscale-stop-instance=appscale.admin.instance_manager.stop_instance:main',
-    'appscale-stop-services=appscale.admin.stop_services:main'
+    'appscale-stop-services=appscale.admin.stop_services:main',
+    'appscale-stop-service=appscale.admin.stop_services:stop_service',
+    'appscale-start-service=appscale.admin.stop_services:start_service'
   ]}
 )

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4467,7 +4467,7 @@ HOSTS
   end
 
   def stop_memcache
-    MonitInterface.stop(:memcached)
+    MonitInterface.stop(:memcached) if MonitInterface.is_running?(:memcached)
   end
 
   def start_ejabberd
@@ -6019,7 +6019,7 @@ HOSTS
   #   app: The application ID whose XMPPReceiver we should shut down.
   def stop_xmpp_for_app(app)
     Djinn.log_info("Shutting down xmpp receiver for app: #{app}")
-    MonitInterface.stop("xmpp-#{app}")
+    MonitInterface.stop("xmpp-#{app}") if MonitInterface.is_running?("xmpp-#{app}")
     Djinn.log_info("Done shutting down xmpp receiver for app: #{app}")
   end
 

--- a/AppController/lib/ejabberd.rb
+++ b/AppController/lib/ejabberd.rb
@@ -33,7 +33,7 @@ module Ejabberd
   end
 
   def self.stop
-    MonitInterface.stop(:ejabberd)
+    MonitInterface.stop(:ejabberd) if MonitInterface.is_running?(:ejabberd)
   end
 
   def self.clear_online_users

--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -113,7 +113,7 @@ CONFIG
     while running
       if stop
         Djinn.log_info("stop_monitoring: stopping service #{watch}.")
-        run_cmd("#{MONIT} stop -g #{watch}")
+        run_cmd("appscale-stop-service #{watch}")
       else
         Djinn.log_info("stop_monitoring: unmonitor service #{watch}.")
         run_cmd("#{MONIT} unmonitor -g #{watch}")

--- a/AppController/lib/search.rb
+++ b/AppController/lib/search.rb
@@ -94,7 +94,7 @@ module Search
   # Stops the AppScale search server.
   def self.stop_search_server
     Djinn.log_debug('Stopping search_server on this node.')
-    MonitInterface.stop(:search)
+    MonitInterface.stop(:search) if MonitInterface.is_running?(:search)
     Djinn.log_debug('Done stopping search_server on this node.')
   end
 

--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -240,9 +240,11 @@ module TaskQueue
 
   # Stops the AppScale TaskQueue server.
   def self.stop_taskqueue_server
-    Djinn.log_debug('Stopping taskqueue_server on this node')
-    MonitInterface.stop(:taskqueue)
-    Djinn.log_debug('Done stopping taskqueue_server on this node')
+    Djinn.log_debug('Stopping taskqueue servers on this node')
+    self.get_server_ports.each do |port|
+      MonitInterface.stop("taskqueue-#{port}")
+    end
+    Djinn.log_debug('Done stopping taskqueue servers on this node')
   end
 
   # Erlang processes use a secret value as a password to authenticate between

--- a/AppDB/appscale/datastore/backup/cassandra_backup.py
+++ b/AppDB/appscale/datastore/backup/cassandra_backup.py
@@ -201,9 +201,10 @@ def restore_data(path, keyname, force=False):
     status = utils.monit_status(summary, CASSANDRA_MONIT_WATCH_NAME)
     retries = SERVICE_RETRIES
     while status != MonitStates.UNMONITORED:
-      appscale_utils.ssh(db_ip, keyname,
-                         'monit stop {}'.format(CASSANDRA_MONIT_WATCH_NAME),
-                         method=subprocess.call)
+      appscale_utils.ssh(
+        db_ip, keyname,
+        'appscale-stop-service {}'.format(CASSANDRA_MONIT_WATCH_NAME),
+        method=subprocess.call)
       time.sleep(3)
       summary = appscale_utils.ssh(db_ip, keyname, 'monit summary',
                                    method=subprocess.check_output)
@@ -229,9 +230,10 @@ def restore_data(path, keyname, force=False):
     retries = SERVICE_RETRIES
     status = MonitStates.UNMONITORED
     while status != MonitStates.RUNNING:
-      appscale_utils.ssh(db_ip, keyname,
-                         'monit start {}'.format(CASSANDRA_MONIT_WATCH_NAME),
-                         method=subprocess.call)
+      appscale_utils.ssh(
+        db_ip, keyname,
+        'appscale-start-service {}'.format(CASSANDRA_MONIT_WATCH_NAME),
+        method=subprocess.call)
       time.sleep(3)
       summary = appscale_utils.ssh(db_ip, keyname, 'monit summary',
                                    method=subprocess.check_output)
@@ -240,8 +242,9 @@ def restore_data(path, keyname, force=False):
       if retries < 0:
         raise BRException('Unable to start Cassandra')
 
-    appscale_utils.ssh(db_ip, keyname,
-                       'monit start {}'.format(CASSANDRA_MONIT_WATCH_NAME))
+    appscale_utils.ssh(
+      db_ip, keyname,
+      'appscale-start-service {}'.format(CASSANDRA_MONIT_WATCH_NAME))
 
   logging.info('Waiting for Cassandra cluster to be ready')
   db_ip = db_ips[0]

--- a/AppDB/test/unit/test_cassandra_backup.py
+++ b/AppDB/test/unit/test_cassandra_backup.py
@@ -100,10 +100,10 @@ class TestCassandraBackup(unittest.TestCase):
     flexmock(appscale_utils).should_receive('ssh').with_args(
       re.compile('^192.*'), keyname, re.compile('^tar xf .*'))
     flexmock(appscale_utils).should_receive('ssh').with_args(
-      re.compile('^192.*'), keyname, re.compile('^monit start .*'),
+      re.compile('^192.*'), keyname, re.compile('^appscale-start-service .*'),
       subprocess.call)
     flexmock(appscale_utils).should_receive('ssh').with_args(
-      re.compile('^192.*'), keyname, re.compile('^monit start .*'))
+      re.compile('^192.*'), keyname, re.compile('^appscale-start-service .*'))
     flexmock(appscale_utils).should_receive('ssh').with_args(
       re.compile('^192.*'), keyname, re.compile('^chown -R cassandra /opt/.*'))
     flexmock(rebalance).should_receive('get_status').and_return(

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -8,7 +8,6 @@ import os
 import random
 import re
 import signal
-import urllib
 import urllib2
 
 import psutil
@@ -19,7 +18,6 @@ from kazoo.exceptions import NodeExistsError, NoNodeError
 from tornado import gen
 from tornado.escape import json_decode
 from tornado.httpclient import AsyncHTTPClient
-from tornado.httpclient import HTTPClient
 from tornado.httpclient import HTTPError
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.options import options
@@ -48,7 +46,6 @@ from appscale.common import (
   constants,
   file_io,
   monit_app_configuration,
-  monit_interface,
   misc
 )
 from appscale.common.constants import HTTPCodes, MonitStates, VAR_DIR
@@ -56,7 +53,9 @@ from appscale.common.constants import VERSION_PATH_SEPARATOR
 from appscale.common.deployment_config import ConfigInaccessible
 from appscale.common.deployment_config import DeploymentConfig
 from appscale.common.monit_interface import MonitOperator
+from appscale.common.monit_interface import MonitUnavailable
 from appscale.common.monit_interface import ProcessNotFound
+from appscale.common.retrying import retry
 from appscale.hermes.constants import HERMES_PORT
 
 
@@ -240,8 +239,12 @@ def ensure_api_server(project_id):
     max_memory=DEFAULT_MAX_APPSERVER_MEMORY,
     check_port=True)
 
-  assert monit_interface.start(full_watch, is_group=False), (
-    'Monit was unable to start {}'.format(watch))
+  monit_operator = MonitOperator()
+  monit_operator.reload_sync()
+
+  monit_retry = retry(max_retries=5, retry_on_exception=MonitUnavailable)
+  send_w_retries = monit_retry(monit_operator.send_command_sync)
+  send_w_retries(full_watch, 'start')
 
   api_servers[project_id] = server_port
   return server_port
@@ -386,12 +389,11 @@ def start_app(version_key, config):
     check_port=True,
     kill_exceeded_memory=True)
 
-  # We want to tell monit to start the single process instead of the
-  # group, since monit can get slow if there are quite a few processes in
-  # the same group.
   full_watch = '{}-{}'.format(watch, config['app_port'])
-  assert monit_interface.start(full_watch, is_group=False), (
-    'Monit was unable to start {}:{}'.format(project_id, config['app_port']))
+
+  monit_operator = MonitOperator()
+  yield monit_operator.reload()
+  yield monit_operator.send_command(full_watch, 'start')
 
   # Make sure the version node exists.
   zk_client.ensure_path('/'.join([VERSION_REGISTRATION_NODE, version_key]))
@@ -448,46 +450,6 @@ def setup_logrotate(app_name, log_size):
   return True
 
 
-def unmonitor(process_name, retries=5, csrf_token=None):
-  """ Unmonitors a process.
-
-  Args:
-    process_name: A string specifying the process to stop monitoring.
-    retries: An integer specifying the number of times to retry the operation.
-    csrf_token: A string specifying a security token for making API calls.
-  """
-  client = HTTPClient()
-  process_url = '{}/{}'.format(monit_operator.LOCATION, process_name)
-  params = {'action': 'unmonitor'}
-
-  headers = {}
-  if csrf_token is not None:
-    headers['Cookie'] = 'securitytoken={}'.format(csrf_token)
-    params['securitytoken'] = csrf_token
-
-  try:
-    client.fetch(process_url, method='POST', body=urllib.urlencode(params),
-                 headers=headers)
-  except HTTPError as error:
-    if error.code == httplib.NOT_FOUND:
-      raise ProcessNotFound('{} not listed by Monit'.format(process_name))
-
-    if error.code == httplib.FORBIDDEN:
-      # Retrieve CSRF token (introduced in Monit 5.20).
-      response = client.fetch(process_url)
-      csrf_token = re.search('securitytoken=([a-zA-Z0-9]+);',
-                             response.headers['Set-Cookie']).group(1)
-
-    if error.code in (httplib.FORBIDDEN, httplib.SERVICE_UNAVAILABLE):
-      retries -= 1
-      if retries < 0:
-        raise
-
-      return unmonitor(process_name, retries, csrf_token)
-
-    raise
-
-
 @gen.coroutine
 def clean_old_sources():
   """ Removes source code for obsolete revisions. """
@@ -516,7 +478,9 @@ def unmonitor_and_terminate(watch):
     watch: A string specifying the Monit entry.
   """
   try:
-    unmonitor(watch)
+    monit_retry = retry(max_retries=5, retry_on_exception=MonitUnavailable)
+    send_w_retries = monit_retry(monit_operator.send_command_sync)
+    send_w_retries(watch, 'unmonitor')
   except ProcessNotFound:
     # If Monit does not know about a process, assume it is already stopped.
     return

--- a/AppManager/app_manager_server.py
+++ b/AppManager/app_manager_server.py
@@ -1,6 +1,5 @@
 """ This service starts and stops application servers of a given application. """
 
-import httplib
 import json
 import logging
 import math

--- a/AppManager/test/unit/test_app_manager_server.py
+++ b/AppManager/test/unit/test_app_manager_server.py
@@ -47,7 +47,7 @@ class TestAppManager(AsyncTestCase):
   @gen_test
   def test_start_app_bad_appname(self):
     configuration = {
-      'app_port': 2000,
+      'app_port': 20000,
       'service_id': 'default',
       'version_id': 'v1',
       'env_vars': {}
@@ -64,7 +64,7 @@ class TestAppManager(AsyncTestCase):
   @gen_test
   def test_start_app_goodconfig_python(self):
     configuration = {
-      'app_port': 2000,
+      'app_port': 20000,
       'login_server': 'public1',
       'service_id': 'default',
       'version_id': 'v1',
@@ -90,8 +90,20 @@ class TestAppManager(AsyncTestCase):
 
     flexmock(monit_app_configuration).should_receive('create_config_file').\
       and_return('fakeconfig')
-    flexmock(monit_interface).should_receive('start').\
-      and_return(True)
+
+    flexmock(app_manager_server).should_receive('ensure_api_server')
+
+    response = Future()
+    response.set_result(None)
+    flexmock(MonitOperator).should_receive('send_command').\
+      with_args('app___test_default_v1_1-20000', 'start').\
+      and_return(response)
+
+    response = Future()
+    response.set_result(None)
+    flexmock(app_manager_server).should_receive('add_routing').\
+      and_return(response)
+
     flexmock(app_manager_server).should_receive('wait_on_app').\
       and_return(True)
     flexmock(os).should_receive('popen').\
@@ -140,8 +152,20 @@ class TestAppManager(AsyncTestCase):
 
     flexmock(monit_app_configuration).should_receive('create_config_file').\
       and_return('fakeconfig')
-    flexmock(monit_interface).should_receive('start').\
-      and_return(True)
+
+    flexmock(app_manager_server).should_receive('ensure_api_server')
+
+    response = Future()
+    response.set_result(None)
+    flexmock(MonitOperator).should_receive('send_command').\
+      with_args('app___test_default_v1_1-20000', 'start').\
+      and_return(response)
+
+    response = Future()
+    response.set_result(None)
+    flexmock(app_manager_server).should_receive('add_routing').\
+      and_return(response)
+
     flexmock(app_manager_server).should_receive('create_java_app_env').\
       and_return({})
     flexmock(app_manager_server).should_receive('wait_on_app').\
@@ -164,7 +188,7 @@ class TestAppManager(AsyncTestCase):
   @gen_test
   def test_start_app_failed_copy_java(self):
     configuration = {
-      'app_port': 2000,
+      'app_port': 20000,
       'login_server': 'public1',
       'service_id': 'default',
       'version_id': 'v1',
@@ -231,7 +255,8 @@ class TestAppManager(AsyncTestCase):
 
     flexmock(misc).should_receive('is_app_name_valid').and_return(True)
     flexmock(app_manager_server).should_receive('unregister_instance')
-    flexmock(app_manager_server).should_receive('unmonitor').\
+    flexmock(MonitOperator).should_receive('send_command_sync').\
+      with_args('app___test_default_v1-20000', 'unmonitor').\
       and_raise(HTTPError)
 
     unmonitor_future = Future()
@@ -247,7 +272,8 @@ class TestAppManager(AsyncTestCase):
     with self.assertRaises(HTTPError):
       yield app_manager_server.stop_app_instance(version_key, port)
 
-    flexmock(app_manager_server).should_receive('unmonitor')
+    flexmock(MonitOperator).should_receive('send_command_sync').\
+      with_args('app___test_default_v1-20000', 'unmonitor')
     flexmock(os).should_receive('remove')
     flexmock(monit_interface).should_receive('safe_monit_run')
 

--- a/common/appscale/common/monit_interface.py
+++ b/common/appscale/common/monit_interface.py
@@ -2,13 +2,17 @@ import errno
 import httplib
 import logging
 import os
-import re
 import socket
 import subprocess
 import time
 import urllib
 from datetime import timedelta
 from xml.etree import ElementTree
+
+try:
+  from http.cookies import SimpleCookie
+except ImportError:
+  from Cookie import SimpleCookie
 
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient
@@ -272,8 +276,7 @@ class MonitOperator(object):
       if error.code == httplib.FORBIDDEN:
         # Retrieve CSRF token (introduced in Monit 5.20).
         response = yield self._async_client.fetch(process_url)
-        self._csrf_token = re.search('securitytoken=([a-zA-Z0-9]+);',
-                                     response.headers['Set-Cookie']).group(1)
+        self._csrf_token = self._parse_security_token(response)
 
       if error.code == httplib.NOT_FOUND:
         raise ProcessNotFound('{} is not monitored'.format(process_name))
@@ -311,8 +314,7 @@ class MonitOperator(object):
 
         # Retrieve CSRF token (introduced in Monit 5.20).
         response = self._client.fetch(process_url)
-        self._csrf_token = re.search('securitytoken=([a-zA-Z0-9]+);',
-                                     response.headers['Set-Cookie']).group(1)
+        self._csrf_token = self._parse_security_token(response)
         return self.send_command_sync(process_name, command, new_token=True)
 
       if error.code == httplib.NOT_FOUND:
@@ -408,3 +410,15 @@ class MonitOperator(object):
     yield gen.sleep(wait_time)
     self.last_reload = time.time()
     subprocess.check_call(['monit', 'reload'])
+
+  @staticmethod
+  def _parse_security_token(http_response):
+    """ Extracts the security token from an HTTP response.
+
+    Args:
+      A tornado.httpclient.HTTPResponse object.
+    Returns:
+      A string containing the security token.
+    """
+    cookie = SimpleCookie(http_response['Set-Cookie'])
+    return cookie['securitytoken'].value

--- a/common/appscale/common/monit_interface.py
+++ b/common/appscale/common/monit_interface.py
@@ -420,5 +420,5 @@ class MonitOperator(object):
     Returns:
       A string containing the security token.
     """
-    cookie = SimpleCookie(http_response['Set-Cookie'])
+    cookie = SimpleCookie(http_response.headers['Set-Cookie'])
     return cookie['securitytoken'].value


### PR DESCRIPTION
The cookie field was introduced in Monit 5.20.

This also reduces the number of Monit CLI calls. Monit was recently patched in Ubuntu to address https://security-tracker.debian.org/tracker/CVE-2016-7067. However, the CLI client was not modified to match the new restrictions on the HTTP interface.

https://bugs.launchpad.net/ubuntu/+source/monit/+bug/1786910

These changes are not exhaustive. There are probably more invocations of the monit script that are ineffectual. This just changes enough to pass most of the tests.