### PR TITLE
Merge release notes from release-3.5 branch into master

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -5,6 +5,29 @@
 /_/  |_/ .___/ .___//____/\___/\__,_/_/ \___/
       /_/   /_/
 
+AppScale version 3.5.3, released June 2018
+Highlights of features/bugs in this release:
+ - Issue-2813 - Controller won't start with latest version of soap4r-ng (2.0.4) 
+
+Known Issues:
+
+
+AppScale version 3.5.2, released May 2018
+Highlights of features/bugs in this release:
+
+ - Issue-2770 - Groups are not locked during commit
+
+Known Issues:
+
+
+AppScale version 3.5.1, released April 2018
+Highlights of features/bugs in this release:
+ - Upgrade to Cassandra 3.11.2
+ - Handle Docker as a provider
+
+Known Issues:
+
+
 AppScale version 3.5.0, released March 2018
 Highlights of features/bugs in this release:
 


### PR DESCRIPTION
This is to get the RELEASE file up to date on master since we haven't (won't) merge from release-3.5 into master. 