### PR TITLE
Monit random csrf token and switch to appscale start/stop scripts

### DIFF
--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -52,8 +52,11 @@ module MonitInterface
       Djinn.log_info("Starting #{process_name} with command #{full_start_cmd}")
     }
 
-    run_cmd('monit reload', true) if reload_monit
-    run_cmd("#{MONIT} start -g #{watch}")
+    run_cmd("#{MONIT} reload", true) if reload_monit
+    ports.each { |port|
+      process_name = if port.nil? then watch.to_s else "#{watch.to_s}-#{port}" end
+      run_cmd("appscale-start-service #{process_name}")
+    }
   end
 
   # Starts a daemonized service. The start_cmd should be designed to start a
@@ -70,8 +73,8 @@ CONFIG
 
     monit_file = "#{MONIT_CONFIG}/appscale-#{watch}.cfg"
     reload_required = update_config(monit_file, config)
-    run_cmd('monit reload', true) if reload_required
-    run_cmd("#{MONIT} start #{watch}")
+    run_cmd("#{MONIT} reload", true) if reload_required
+    run_cmd("appscale-start-service #{watch}")
   end
 
   # Starts a custom service. The start_cmd should be designed to start a
@@ -86,8 +89,8 @@ CONFIG
 
     monit_file = "#{MONIT_CONFIG}/appscale-#{watch}.cfg"
     reload_required = update_config(monit_file, config)
-    run_cmd('monit reload', true) if reload_required
-    run_cmd("#{MONIT} start #{watch}")
+    run_cmd("#{MONIT} reload", true) if reload_required
+    run_cmd("appscale-start-service #{watch}")
   end
 
   def self.update_config(monit_file, config)
@@ -136,7 +139,7 @@ CONFIG
                      " #{config}.")
     end
     FileUtils.rm_rf(config)
-    run_cmd('monit reload', true)
+    run_cmd("#{MONIT} reload", true)
   end
 
   def self.service_config(process_name, group, start_cmd, env_vars, mem)

--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -50,7 +50,6 @@ module TerminateHelper
     # Let's make sure we restart any non-appscale service.
     `service monit restart`
     `service appscale-controller stop`
-    `monit start all`
     `rm -f #{APPSCALE_CONFIG_DIR}/port-*.txt`
 
     # Remove location files.

--- a/AppManager/test/unit/test_app_manager_server.py
+++ b/AppManager/test/unit/test_app_manager_server.py
@@ -63,6 +63,8 @@ class TestAppManager(AsyncTestCase):
 
   @gen_test
   def test_start_app_goodconfig_python(self):
+    testing.disable_logging()
+
     configuration = {
       'app_port': 20000,
       'login_server': 'public1',
@@ -83,19 +85,27 @@ class TestAppManager(AsyncTestCase):
     source_manager = flexmock()
     response = Future()
     response.set_result(None)
-    source_manager.should_receive('ensure_source'). \
-      with_args('test_default_v1_1', 'source.tar.gz', 'python27'). \
+    source_manager.should_receive('ensure_source').\
+      with_args('test_default_v1_1', 'source.tar.gz', 'python27').\
       and_return(response)
     app_manager_server.source_manager = source_manager
 
     flexmock(monit_app_configuration).should_receive('create_config_file').\
       and_return('fakeconfig')
 
-    flexmock(app_manager_server).should_receive('ensure_api_server')
+    response = Future()
+    response.set_result(None)
+    flexmock(app_manager_server).should_receive('ensure_api_server').\
+      and_return(response)
 
     response = Future()
     response.set_result(None)
-    flexmock(MonitOperator).should_receive('send_command').\
+    flexmock(MonitOperator).should_receive('reload').\
+      and_return(response)
+
+    response = Future()
+    response.set_result(None)
+    flexmock(MonitOperator).should_receive('send_command_retry_process').\
       with_args('app___test_default_v1_1-20000', 'start').\
       and_return(response)
 
@@ -120,6 +130,8 @@ class TestAppManager(AsyncTestCase):
 
   @gen_test
   def test_start_app_goodconfig_java(self):
+    testing.disable_logging()
+
     configuration = {
       'app_port': 20000,
       'login_server': 'public1',
@@ -153,11 +165,19 @@ class TestAppManager(AsyncTestCase):
     flexmock(monit_app_configuration).should_receive('create_config_file').\
       and_return('fakeconfig')
 
-    flexmock(app_manager_server).should_receive('ensure_api_server')
+    response = Future()
+    response.set_result(None)
+    flexmock(app_manager_server).should_receive('ensure_api_server').\
+        and_return(response)
 
     response = Future()
     response.set_result(None)
-    flexmock(MonitOperator).should_receive('send_command').\
+    flexmock(MonitOperator).should_receive('reload').\
+        and_return(response)
+
+    response = Future()
+    response.set_result(None)
+    flexmock(MonitOperator).should_receive('send_command_retry_process').\
       with_args('app___test_default_v1_1-20000', 'start').\
       and_return(response)
 
@@ -276,6 +296,11 @@ class TestAppManager(AsyncTestCase):
       with_args('app___test_default_v1-20000', 'unmonitor')
     flexmock(os).should_receive('remove')
     flexmock(monit_interface).should_receive('safe_monit_run')
+
+    response = Future()
+    response.set_result(None)
+    flexmock(MonitOperator).should_receive('reload').\
+      and_return(response)
 
     response = Future()
     response.set_result(None)


### PR DESCRIPTION
The common monit interface now uses a random CSRF token rather than one obtained from monit.

Retries for monit commands are updated, we now retry for all cases other than `ProcessNotFound` by default and will retry on that failure for `start` actions when there may be a short period before a previous `reload` completes and the process is recognized.

Start/stop commands are updated to not output error traces for some expected failures.

Monit reloading can now be performed on a separate thread.