### PR TITLE
Avoid using slots dunder method

### DIFF
--- a/Hermes/appscale/hermes/stats/producers/proxy_stats.py
+++ b/Hermes/appscale/hermes/stats/producers/proxy_stats.py
@@ -209,8 +209,10 @@ class HAProxyServerStats(object):
 
 
 ALL_HAPROXY_FIELDS = set(
-  HAProxyListenerStats.__slots__ + HAProxyFrontendStats.__slots__
-  + HAProxyBackendStats.__slots__ + HAProxyServerStats.__slots__
+  attr.fields_dict(HAProxyListenerStats).keys() +
+  attr.fields_dict(HAProxyFrontendStats).keys() +
+  attr.fields_dict(HAProxyBackendStats).keys() +
+  attr.fields_dict(HAProxyServerStats).keys()
 ) - {'private_ip', 'port'}    # HAProxy stats doesn't include IP/Port columns
                               # But we add these values by ourselves
 
@@ -331,7 +333,7 @@ def get_stats_from_one_haproxy(socket_path, configs_dir):
 
     stats_values = {
       field: _get_field_value(row, field)
-      for field in stats_type.__slots__
+      for field in attr.fields_dict(stats_type).keys()
     }
     stats_values.update(**extra_values)
 

--- a/Hermes/appscale/hermes/stats/producers/tests/test_proxy.py
+++ b/Hermes/appscale/hermes/stats/producers/tests/test_proxy.py
@@ -2,6 +2,7 @@ import os
 from os import path
 import unittest
 
+import attr
 from mock import patch, MagicMock
 
 from appscale.hermes.stats.constants import MISSED
@@ -50,12 +51,12 @@ class TestCurrentProxiesStats(unittest.TestCase):
 
     # Frontend stats shouldn't have Nones
     frontend = dashboard.frontend
-    for field in proxy_stats.HAProxyFrontendStats.__slots__:
+    for field in attr.fields_dict(proxy_stats.HAProxyFrontendStats).keys():
       self.assertIsNotNone(getattr(frontend, field))
 
     # Backend stats shouldn't have Nones
     backend = dashboard.backend
-    for field in proxy_stats.HAProxyBackendStats.__slots__:
+    for field in attr.fields_dict(proxy_stats.HAProxyBackendStats).keys():
       self.assertIsNotNone(getattr(backend, field))
 
     # Backend stats can have Nones only in some fields
@@ -63,7 +64,7 @@ class TestCurrentProxiesStats(unittest.TestCase):
     self.assertIsInstance(servers, list)
     self.assertEqual(len(servers), 3)
     for server in servers:
-      for field in proxy_stats.HAProxyServerStats.__slots__:
+      for field in attr.fields_dict(proxy_stats.HAProxyServerStats).keys():
         if field in {'qlimit', 'throttle', 'tracked', 'check_code',
                      'last_chk', 'last_agt'}:
           continue
@@ -108,7 +109,7 @@ class TestCurrentProxiesStats(unittest.TestCase):
 
     # Frontend stats shouldn't have Nones
     frontend = dashboard.frontend
-    for field in proxy_stats.HAProxyFrontendStats.__slots__:
+    for field in attr.fields_dict(proxy_stats.HAProxyFrontendStats).keys():
       self.assertIsNotNone(getattr(frontend, field))
     # New columns should be highlighted
     for new_in_v1_5 in ('comp_byp', 'comp_rsp', 'comp_out', 'comp_in'):
@@ -116,7 +117,7 @@ class TestCurrentProxiesStats(unittest.TestCase):
 
     # Backend stats shouldn't have Nones
     backend = dashboard.backend
-    for field in proxy_stats.HAProxyBackendStats.__slots__:
+    for field in attr.fields_dict(proxy_stats.HAProxyBackendStats).keys():
       self.assertIsNotNone(getattr(backend, field))
     # New columns should be highlighted
     for new_in_v1_5 in ('comp_byp', 'lastsess', 'comp_rsp', 'comp_out',
@@ -128,7 +129,7 @@ class TestCurrentProxiesStats(unittest.TestCase):
     self.assertIsInstance(servers, list)
     self.assertEqual(len(servers), 3)
     for server in servers:
-      for field in proxy_stats.HAProxyServerStats.__slots__:
+      for field in attr.fields_dict(proxy_stats.HAProxyServerStats).keys():
         if field in {'qlimit', 'throttle', 'tracked', 'check_code',
                      'last_chk', 'last_agt'}:
           continue


### PR DESCRIPTION
The attrs 18.2.0 package adds an additional item to \_\_slots\_\_ that is not present in the defined attributes.