### PR TITLE
Pin SOAPpy to version 0.12.22

### DIFF
--- a/debian/appscale_install.sh
+++ b/debian/appscale_install.sh
@@ -42,6 +42,7 @@ case "$1" in
         installpycrypto 
         installpycapnp
         installpyyaml
+        installsoappy
         installzookeeper
         postinstallzookeeper
         installcassandra

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -575,6 +575,14 @@ installpyyaml()
     fi
 }
 
+installsoappy()
+{
+    # This particular version is needed for
+    # google.appengine.api.xmpp.unverified_transport, which imports
+    # SOAPpy.HTTPWithTimeout.
+    pipwrapper SOAPpy==0.12.22
+}
+
 preplogserver()
 {
     LOGSERVER_DIR="/opt/appscale/logserver"


### PR DESCRIPTION
This fixes the build on Trusty, which was broken by 5be8d13.