### PR TITLE
Add hmac.compare_digest fallback

### DIFF
--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -2,6 +2,7 @@
 
 import errno
 import json
+import hmac
 import logging
 import os
 import shutil
@@ -551,3 +552,30 @@ def queues_from_dict(payload):
     queues[name] = queue
 
   return {'queue': queues}
+
+
+def _constant_time_compare(val_a, val_b):
+  """ Compares the two input values in a way that prevents timing analysis.
+
+  Args:
+    val_a: A string.
+    val_b: A string.
+  Returns:
+    A boolean indicating whether or not the given strings are equal.
+  """
+  if len(val_a) != len(val_b):
+    return False
+
+  values_equal = True
+  for char_a, char_b in zip(val_a, val_b):
+    if char_a != char_b:
+      # Do not break early here in order to keep the compare constant time.
+      values_equal = False
+
+  return values_equal
+
+
+if hasattr(hmac, 'compare_digest'):
+  constant_time_compare = hmac.compare_digest
+else:
+  constant_time_compare = _constant_time_compare


### PR DESCRIPTION
The function was introduced in Python 2.7.7, so it is not available on Trusty.