### PR TITLE
Require attrs>=18.1.0

### DIFF
--- a/Hermes/setup.py
+++ b/Hermes/setup.py
@@ -15,7 +15,7 @@ setup(
     'kazoo',
     'tornado',
     'psutil==5.1.3',
-    'attrs>=16',
+    'attrs>=18.1.0',
     'flexmock',
     'mock',
   ],


### PR DESCRIPTION
The the attrs.fields_dict function (used in e3f4488) was added to the library in 18.1.0.