### PR TITLE
Decrease Cassandra heap size when sharing roles

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3238,10 +3238,11 @@ class Djinn
         # If this machine is running other services, decrease Cassandra's max
         # heap size.
         heap_reduction = 0
-        heap_reduction += 0.2 if my_node.is_compute?
+        heap_reduction += 0.25 if my_node.is_compute?
         if my_node.is_taskqueue_master? || my_node.is_taskqueue_slave?
-          heap_reduction += 0.1
+          heap_reduction += 0.15
         end
+        heap_reduction = heap_reduction.round(2)
 
         if my_node.is_db_master?
           start_db_master(false, needed_nodes, db_nodes, heap_reduction)


### PR DESCRIPTION
With the previous heap reduction, memory is still a bit tight on 4GB single-node deployments.