### PR TITLE
Handle datastore connection errors with TQ server

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/constants.py
+++ b/AppTaskQueue/appscale/taskqueue/constants.py
@@ -1,4 +1,12 @@
 import re
+import socket
+import sys
+
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.ext import db
+from google.appengine.runtime import apiproxy_errors
 
 
 class EmptyQueue(Exception):
@@ -66,3 +74,7 @@ SUPPORTED_PUSH_QUEUE_FIELDS = {
 }
 
 SHUTTING_DOWN_TIMEOUT = 10  # Limit time for finishing request
+
+# Exceptions that the datastore client might raise.
+TRANSIENT_DS_ERRORS = (db.InternalError, db.Timeout, socket.error,
+                       apiproxy_errors.ApplicationError)

--- a/AppTaskQueue/appscale/taskqueue/push_worker.py
+++ b/AppTaskQueue/appscale/taskqueue/push_worker.py
@@ -77,7 +77,7 @@ def update_task(task_name, new_state, retries=3):
   Args:
     task_name: A string specifying the TaskName key.
     new_state: A string specifying the new task state.
-    retries: An integer specifying how many times to retry the delete.
+    retries: An integer specifying how many times to retry the update.
   """
   try:
     task_name_entity = TaskName.get_by_key_name(task_name)

--- a/AppTaskQueue/appscale/taskqueue/push_worker.py
+++ b/AppTaskQueue/appscale/taskqueue/push_worker.py
@@ -14,6 +14,7 @@ from eventlet.green.httplib import BadStatusLine
 from eventlet.timeout import Timeout as EventletTimeout
 from socket import error as SocketError
 from urlparse import urlparse
+from .constants import TRANSIENT_DS_ERRORS
 from .task_name import TaskName
 from .tq_lib import TASK_STATES
 from .utils import (
@@ -81,7 +82,7 @@ def update_task(task_name, new_state, retries=3):
   """
   try:
     task_name_entity = TaskName.get_by_key_name(task_name)
-  except Exception as error:
+  except TRANSIENT_DS_ERRORS as error:
     retries -= 1
     if retries >= 0:
       logger.warning('Error fetching task name: {}. Retrying'.format(error))
@@ -97,7 +98,7 @@ def update_task(task_name, new_state, retries=3):
 
     try:
       db.put(task_name_entity)
-    except Exception as error:
+    except TRANSIENT_DS_ERRORS as error:
       retries -= 1
       if retries >= 0:
         logger.warning('Error updating task name: {}. Retrying'.format(error))


### PR DESCRIPTION
The TaskQueue server does not use an API Proxy like application runtimes do, so it cannot expect the usual errors from using the client libraries.