### PR TITLE
Use a patched version of Cassandra

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -346,8 +346,10 @@ installcassandra()
 {
     CASSANDRA_VER=3.11.2
 
-    CASSANDRA_PACKAGE="apache-cassandra-${CASSANDRA_VER}-bin.tar.gz"
-    CASSANDRA_PACKAGE_MD5="1c1bc0b216f308500e219968acbd625e"
+    # The following is a Cassandra package built from source with the inclusion
+    # of https://issues.apache.org/jira/browse/CASSANDRA-12942.
+    CASSANDRA_PACKAGE="apache-cassandra-${CASSANDRA_VER}-w-12942-bin.tar.gz"
+    CASSANDRA_PACKAGE_MD5="25a9039dba8fe7ffe5e5e560e65c1f6f"
     cachepackage ${CASSANDRA_PACKAGE} ${CASSANDRA_PACKAGE_MD5}
 
     # Remove old Cassandra environment directory.


### PR DESCRIPTION
This uses a version of Cassandra that was built from source. The patch from https://issues.apache.org/jira/browse/CASSANDRA-12942 is the only modification.

This fixes an issue with `nodetool status` and `nodetool ring` occasionally not working. The rebalance script, Cassandra monitoring, and service start all rely on those tools.

Resolves #2889.