### PR TITLE
Serving status modification for application versions with manual scaling

### DIFF
--- a/AdminServer/appscale/admin/version.schema.json
+++ b/AdminServer/appscale/admin/version.schema.json
@@ -192,6 +192,10 @@
                     "maximum": 10000
                 }
             }
+        },
+        "servingStatus": {
+          "type": "string",
+          "pattern": "^(SERVING|STOPPED)$"
         }
     }
 }


### PR DESCRIPTION
Updates the `AdminServer` and `AppController` to allow the serving status to be modified for an application version. When `STOPPED` the application version will not be running and manual update is required to restart.

https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.services.versions#Version.FIELDS.serving_status