### PR TITLE
Terminate not started AppServers first

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5409,8 +5409,8 @@ HOSTS
       @app_info_map[version_key]['appservers'].each { |location|
         break if num_to_remove == to_delete.length
 
-        _, port = location.split(":")
-        to_delete << location if port < 0
+        host, port = location.split(":")
+        to_delete << location if host == node_ip && port < 0
       }
     }
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5410,7 +5410,7 @@ HOSTS
         break if num_to_remove == to_delete.length
 
         host, port = location.split(":")
-        to_delete << location if host == node_ip && port < 0
+        to_delete << location if host == node_ip && Integer(port) < 0
       }
     }
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5427,10 +5427,18 @@ HOSTS
       }
     }
 
-    # Finally terminates the selected AppServers.
+    # Finally terminates the selected AppServers. Since we can have
+    # multiple same locations (for starting AppServers) we delete the last
+    # occurence of the object only.
     to_delete.each{ |location|
-      @app_info_map[version_key]['appservers'].delete(location)
+      i = @app_info_map[version_key]['appservers'].rindex(location)
+      if i.nil?
+        Djinn.log_warn("Something went wrong removing #{location}.")
+        next
+      end
+      @app_info_map[version_key]['appservers'].delete_at(i)
       @last_decision[version_key] = Time.now.to_i
+      Djinn.log_info("Removing an AppServer for #{version_key} #{location}.")
     }
 
     return !to_delete.empty?


### PR DESCRIPTION
When the autoscaler decides it is time to downscale, the previous logic
would pick AppServers from the newly created machines, in order to
facilitate the removal of instances if not used. We should start
removing first AppServers not started yet, in order to leave a minimum
number of *running* AppServers.