### PR TITLE
Fix list_tasks method in TaskQueue

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/queue.py
+++ b/AppTaskQueue/appscale/taskqueue/queue.py
@@ -1073,7 +1073,7 @@ class PullQueue(Queue):
     task_id = ''
     while True:
       query_tasks = """
-        SELECT eta, id FROM pull_queue_eta_index
+        SELECT eta, id, tag FROM pull_queue_eta_index
         WHERE token(app, queue, eta, id) > token(%(app)s, %(queue)s, %(eta)s, %(id)s)
         AND token(app, queue, eta, id) < token(%(app)s, %(next_queue)s, 0, '')
         LIMIT {limit}


### PR DESCRIPTION
Selecting tag column was missing.

When listing tasks in queue, we also clean missing tasks from index,
To remove index entry we need to know task tag.

### Demo
#### On master:
https://ocd.appscale.com:8080/view/All/job/Taskqueue-e2e-Test/39/console
https://ocd.appscale.com:8080/view/All/job/Taskqueue-e2e-Test/39/artifact/logs/taskqueue-50002.log :
```
2018-10-29 12:25:35,897 ERROR web.py:1496 Uncaught exception GET /taskqueue/v1beta2/projects/cassandra-test-project/taskqueues/pull-queue-b/tasks (192.168.111.9)
HTTPServerRequest(protocol='http', host='euca-192-168-100-201.eucalyptus.eucalyptus.appscale.net:50002', method='GET', uri='/taskqueue/v1beta2/projects/cassandra-test-project/taskqueues/pull-queue-b/tasks', version='HTTP/1.1', remote_ip='192.168.111.9', headers={'Host': 'euca-192-168-100-201.eucalyptus.eucalyptus.appscale.net:50002', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'User-Agent': 'Python/3.6 aiohttp/3.4.4'}) 
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 1413, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/appscale/taskqueue/rest_api.py", line 146, in get
    tasks = queue.list_tasks()
  File "/usr/local/lib/python2.7/dist-packages/appscale/taskqueue/queue.py", line 1092, in list_tasks
    self._delete_index(result.eta, result.id, result.tag)
AttributeError: 'Row' object has no attribute 'tag'
2018-10-29 12:25:35,900 ERROR web.py:1908 500 GET /taskqueue/v1beta2/projects/cassandra-test-project/taskqueues/pull-queue-b/tasks (192.168.111.9) 12.45ms 
```

#### On branch:
https://ocd.appscale.com:8080/view/All/job/Taskqueue-e2e-Test/40/console
https://ocd.appscale.com:8080/view/All/job/Taskqueue-e2e-Test/40/artifact/logs/taskqueue-50002.log
```
2018-10-29 13:30:48,876 INFO web.py:1908 200 GET /taskqueue/v1beta2/projects/cassandra-test-project/taskqueues/pull-queue-b/tasks (192.168.111.9) 68.19ms 
```