### PR TITLE
Accept multiple values per field in SearchService

### DIFF
--- a/AppServer/google/appengine/api/search/appscale_search_stub.py
+++ b/AppServer/google/appengine/api/search/appscale_search_stub.py
@@ -141,7 +141,7 @@ class SearchServiceStub(apiproxy_stub.APIProxyStub):
     return
 
   def _RemoteSend(self, request, response, method):
-    """ Sends a request remotely to the datstore server. 
+    """ Sends a request remotely to the search server.
 
     Args:
       request: A request object.
@@ -165,10 +165,6 @@ class SearchServiceStub(apiproxy_stub.APIProxyStub):
       KEY_LOCATION,
       CERT_LOCATION)
 
-    if not api_response or not api_response.has_response():
-      raise search.InternalError(
-          'No response from db server on %s requests.' % method)
-
     if api_response.has_application_error():
       error_pb = api_response.application_error()
       logging.error(error_pb.detail())
@@ -177,5 +173,9 @@ class SearchServiceStub(apiproxy_stub.APIProxyStub):
 
     if api_response.has_exception():
       raise api_response.exception()
+
+    if not api_response or not api_response.has_response():
+      raise search.InternalError(
+          'No response from search server on %s requests.' % method)
 
     response.ParseFromString(api_response.response())

--- a/SearchService/search_api.py
+++ b/SearchService/search_api.py
@@ -74,7 +74,7 @@ class SearchService():
     elif method == "Search":
       response, errcode, errdetail = self.search(http_request_data)
 
-    if response:
+    if response is not None:
       apiresponse.set_response(response)
 
     # If there was an error add it to the response.
@@ -94,7 +94,7 @@ class SearchService():
       A tuple of an encoded response, error code, and error detail.
     """
     request = search_service_pb.IndexDocumentRequest(data)
-    logging.debug("APP ID: {0}".format(request.app_id())) 
+    logging.debug("APP ID: {0}".format(request.app_id()))
     response = search_service_pb.IndexDocumentResponse()
     params = request.params()
 
@@ -152,9 +152,11 @@ class SearchService():
     Returns:
       A tuple of an encoded response, error code, and error detail.
     """
-    request = search_service_pb.ListIndexesRequest(data)
-    response = search_service_pb.ListIndexesResponse()
-    return response, 0, ""
+    return (
+      '',
+      search_service_pb.SearchServiceError.INTERNAL_ERROR,
+      "List indexes method is not implemented in AppScale SearchService yet"
+    )
   
   def list_documents(self, data):
     """ List all documents for an application.
@@ -164,12 +166,11 @@ class SearchService():
     Returns:
       A tuple of an encoded response, error code, and error detail.
     """
-    request = search_service_pb.ListDocumentsRequest(data)
-    response = search_service_pb.ListDocumentsResponse()
-    status = response.mutable_status()
-    status.set_code(
-      search_service_pb.SearchServiceError.OK)
-    return response, 0, ""
+    return (
+      '',
+      search_service_pb.SearchServiceError.INTERNAL_ERROR,
+      "List documents method is not implemented in AppScale SearchService yet"
+    )
 
   def search(self, data):
     """ Search within a document.

--- a/SearchService/search_server.py
+++ b/SearchService/search_server.py
@@ -20,7 +20,6 @@ class MainHandler(tornado.web.RequestHandler):
     """ Class for initializing search service web handler. """
     self.search_service = search_service
 
-  @tornado.web.asynchronous
   def post(self):
     """ A POST handler for request to this server. """
     request = self.request
@@ -35,7 +34,6 @@ class MainHandler(tornado.web.RequestHandler):
       tornado.httputil.ResponseStartLine('HTTP/1.1', 200, 'OK'),
       tornado.httputil.HTTPHeaders({"Content-Length": str(len(response))}))
     request.connection.write(response)
-    request.connection.finish()
 
 
 if __name__ == "__main__":

--- a/SearchService/solr_interface.py
+++ b/SearchService/solr_interface.py
@@ -296,18 +296,17 @@ class Solr():
     Returns:
       A list of dictionaries with SOLR field names that require updates.
     """
+    known_fields = {current_field['name'] for current_field in current_fields}
     fields_to_update = []
     for doc_field in doc_fields:
-      doc_name = doc_field.name
-      found = False
-      for current_field in current_fields:
-        current_name = current_field['name']
-        if current_name == index_name + "_" + doc_name:
-          found = True
-      if not found:
-        new_field = {'name': index_name + "_" + doc_name, 'type':
-          doc_field.field_type}
-        fields_to_update.append(new_field)
+      full_field_name = index_name + '_' + doc_field.name
+      if full_field_name in known_fields:
+        continue
+      fields_to_update.append({
+        'name': full_field_name,
+        'type': doc_field.field_type
+      })
+      known_fields.add(full_field_name)
     #TODO add fields to delete also.
     return fields_to_update
 


### PR DESCRIPTION
The PR contains two commits: the first is related to ability to debug the problem when the second is about actual fix.
solr_interface was building a list of fields to update in index schema by just looping through document fields and ignoring fields which are already in schema. But it didn't take in account that document can contain multiple values for the field, so it was sending duplicated fields in update_schema request.
https://ocd.appscale.com:8080/job/Daily%20Build/5623