### PR TITLE
Update allocate methods in datastore stubs

### DIFF
--- a/AppServer/google/appengine/api/datastore_file_stub.py
+++ b/AppServer/google/appengine/api/datastore_file_stub.py
@@ -694,7 +694,7 @@ class DatastoreFileStub(datastore_stub_util.BaseDatastore,
     if count >= self._IdCounter(id_space):
       self._SetIdCounter(id_space, count + 1)
 
-  def _AllocateIds(self, reference, size=1, max_id=None):
+  def _AllocateSequentialIds(self, reference, size=1, max_id=None):
     datastore_stub_util.Check(not (size and max_id),
                               'Both size and max cannot be set.')
 
@@ -715,7 +715,7 @@ class DatastoreFileStub(datastore_stub_util.BaseDatastore,
 
     return (start, end)
 
-  def _AllocateScatteredIds(self, keys):
+  def _AllocateIds(self, keys):
     self.__id_lock.acquire()
     full_keys = []
     try:

--- a/AppServer/google/appengine/datastore/datastore_sqlite_stub.py
+++ b/AppServer/google/appengine/datastore/datastore_sqlite_stub.py
@@ -1385,7 +1385,7 @@ class DatastoreSqliteStub(datastore_stub_util.BaseDatastore,
     end = max(max_id, start - 1)
     return start, end
 
-  def _AllocateIds(self, reference, size=1, max_id=None):
+  def _AllocateSequentialIds(self, reference, size=1, max_id=None):
     conn = self._GetConnection()
     try:
       datastore_stub_util.CheckAppId(self._trusted, self._app_id,
@@ -1407,11 +1407,11 @@ class DatastoreSqliteStub(datastore_stub_util.BaseDatastore,
     finally:
       self._ReleaseConnection(conn)
 
-  def _AllocateScatteredIds(self, keys):
+  def _AllocateIds(self, references):
     conn = self._GetConnection()
     try:
       full_keys = []
-      for key in keys:
+      for key in references:
         datastore_stub_util.CheckAppId(self._trusted, self._app_id, key.app())
         prefix = self._GetTablePrefix(key)
         last_element = key.path().element_list()[-1]


### PR DESCRIPTION
Though these stubs are not used during runtime, they may be used during unit tests. Without these changes, the SDK is internally inconsistent.

These changes were introduced in the 1.8.6 SDK.