### PR TITLE
Convert number to string before writing string_value of it

### DIFF
--- a/SearchService/solr_interface.py
+++ b/SearchService/solr_interface.py
@@ -440,7 +440,7 @@ class Solr():
       new_value.set_string_value(value)
       new_value.set_type(FieldValue.ATOM)
     elif ftype == Field.NUMBER:
-      new_value.set_string_value(value)
+      new_value.set_string_value(str(value))
       new_value.set_type(FieldValue.NUMBER)
     elif ftype == Field.GEO:
       geo = new_value.mutable_geo()


### PR DESCRIPTION
SearchService couldn't return documents with numeric fields before this change.