### PR TITLE
Store hints within the persistent state directory

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/templates/cassandra.yaml
+++ b/AppDB/appscale/datastore/cassandra_env/templates/cassandra.yaml
@@ -70,7 +70,7 @@ max_hints_delivery_threads: 2
 
 # Directory where Cassandra should store hints.
 # If not set, the default directory is $CASSANDRA_HOME/data/hints.
-# hints_directory: /var/lib/cassandra/hints
+hints_directory: /opt/appscale/cassandra/hints
 
 # How often hints should be flushed from the internal buffers to disk.
 # Will *not* trigger fsync.


### PR DESCRIPTION
If the cluster is heavily loaded, the size of Cassandra hint data could be problematic for the OS disk.