### PR TITLE
Use gossip to find live Cassandra nodes

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1534,7 +1534,7 @@ class Djinn
       }
       return "#{ready}"
     ensure
-      NODETOOL_LOCK.unlock
+      NODETOOL_LOCK.unlock if lock_obtained
     end
   end
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1527,11 +1527,7 @@ class Djinn
     lock_obtained = NODETOOL_LOCK.try_lock
     begin
       return NOT_READY unless lock_obtained
-      output = `"#{NODETOOL}" status`
-      ready = false
-      output.split("\n").each { |line|
-        ready = true if line.start_with?('UN') && line.include?(primary_ip)
-      }
+      ready = nodes_ready.include?(primary_ip)
       return "#{ready}"
     ensure
       NODETOOL_LOCK.unlock if lock_obtained

--- a/AppController/lib/cassandra_helper.rb
+++ b/AppController/lib/cassandra_helper.rb
@@ -177,6 +177,14 @@ end
 
 # Returns an array of nodes in 'Up Normal' state.
 def nodes_ready
+  # Example output of `nodetool gossipinfo`:
+  # /192.168.33.10
+  #   ...
+  #   STATUS:15272:NORMAL,f02dd17...
+  #   LOAD:263359:1.29168682182E11
+  #   ...
+  # /192.168.33.11
+  # ...
   output = `"#{NODETOOL}" gossipinfo`
   return [] unless $?.exitstatus == 0
 


### PR DESCRIPTION
This is more efficient than using `nodetool status` because it is able to skip the ownership calculation, which takes an unreasonable amount of time on a BOP cluster that contains a lot of data.

This also fixes a ThreadError that can occur if the lock was not obtained.

Resolves #2948.