### PR TITLE
Add support for the target field for cron jobs

### DIFF
--- a/AdminServer/appscale/admin/utils.py
+++ b/AdminServer/appscale/admin/utils.py
@@ -431,7 +431,7 @@ def validate_job(job):
     InvalidConfiguration if configuration is invalid.
   """
   required_fields = ('schedule', 'url')
-  supported_fields = ('description', 'schedule', 'url')
+  supported_fields = ('description', 'schedule', 'url', 'target')
 
   for field in required_fields:
     if field not in job:


### PR DESCRIPTION
If the specified service does not exist, use the default one.

Resolves #2957.