### PR TITLE
Use login property as ejabberd host

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4379,9 +4379,8 @@ HOSTS
 
   def start_ejabberd
     @state = "Starting up XMPP server"
-    my_public = my_node.public_ip
     Djinn.log_run("rm -f /var/lib/ejabberd/*")
-    Ejabberd.write_config_file(my_public, my_node.private_ip)
+    Ejabberd.write_config_file(@options['login'], my_node.private_ip)
     Ejabberd.update_ctl_config
 
     # Monit does not have an entry for ejabberd yet. This allows a restart


### PR DESCRIPTION
For the host portion of the JID, clients specify the login property instead of the public IP address of whatever machine the request gets routed to.