### PR TITLE
Replacing zookeeper_locations.json with zookeeper_locations

### DIFF
--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -70,8 +70,9 @@ module TerminateHelper
     FileUtils.rm_f("#{APPSCALE_CONFIG_DIR}/slaves")
     FileUtils.rm_f("#{APPSCALE_CONFIG_DIR}/taskqueue_nodes")
 
-    # TODO: Use the constant in djinn.rb (ZK_LOCATIONS_FILE)
+    # TODO: Use the constant in djinn.rb (ZK_LOCATIONS_JSON_FILE)
     `rm -rf #{APPSCALE_CONFIG_DIR}/zookeeper_locations.json`
+    `rm -rf #{APPSCALE_CONFIG_DIR}/zookeeper_locations`
     `rm -f /opt/appscale/appcontroller-state.json`
     `rm -f /opt/appscale/appserver-state.json`
     print "OK"

--- a/AppDB/README.rst
+++ b/AppDB/README.rst
@@ -32,12 +32,17 @@ How to set up
      remaining machines in the cluster. Each address should be on a different
      line.
 
-5. Create a file called /etc/appscale/zookeeper_locations.json with the content
-   ``{"locations":["zk-ip-1", "zk-ip-2"]}`` (where zk-ip-1 and zk-ip-2 are the
-   locations of the machines in the ZooKeeper cluster).
-5. Run ``appscale-prime-cassandra --replication x`` where "x" is the
+5. Create a file called /etc/appscale/zookeeper_locations with the content
+   ::
+
+      zk-ip-1
+      zk-ip-2
+
+   (where zk-ip-1 and zk-ip-2 are the locations of the machines
+   in the ZooKeeper cluster).
+6. Run ``appscale-prime-cassandra --replication x`` where "x" is the
    replication factor you want for the datastore's keyspace.
-6. Start the datastore server with ``appscale-datastore -p x`` where "x" is the
+7. Start the datastore server with ``appscale-datastore -p x`` where "x" is the
    port you would like to start the server on. You probably want to start more
    than one since each can currently only handle one request at a time.
    AppScale starts 2x the number of cores on the machine.

--- a/AppTaskQueue/test/helpers/prepare-cassandra.sh
+++ b/AppTaskQueue/test/helpers/prepare-cassandra.sh
@@ -53,7 +53,7 @@ fi
 
 echo ${PRIVATE_IP} > /etc/appscale/masters
 echo ${PRIVATE_IP} > /etc/appscale/slaves
-echo "{\"locations\":[\"${ZK_IP}\"]}" > /etc/appscale/zookeeper_locations.json
+echo ${ZK_IP} > /etc/appscale/zookeeper_locations
 
 
 log "Configuring Cassandra"

--- a/AppTaskQueue/test/helpers/restart-taskqueue.sh
+++ b/AppTaskQueue/test/helpers/restart-taskqueue.sh
@@ -91,7 +91,7 @@ fi
 log "Filling /etc/appscale/* files with addresses of required services"
 echo ${DB_IP} > /etc/appscale/masters
 echo ${DB_IP} > /etc/appscale/slaves
-echo "{\"locations\":[\"${ZK_IP}\"]}" > /etc/appscale/zookeeper_locations.json
+echo ${ZK_IP} > /etc/appscale/zookeeper_locations
 echo ${LB_IP} > /etc/appscale/load_balancer_ips
 
 

--- a/common/appscale/common/appscale_info.py
+++ b/common/appscale/common/appscale_info.py
@@ -1,5 +1,5 @@
-""" 
-This file contains functions for getting and setting information related 
+"""
+This file contains functions for getting and setting information related
 to AppScale and the current node/machine.
 """
 import json
@@ -101,7 +101,7 @@ def get_tq_proxy():
 
 def get_private_ip():
   """ Get the private IP of the current machine.
-  
+
   Returns:
     String containing the private IP of the current machine.
   """
@@ -109,7 +109,7 @@ def get_private_ip():
 
 def get_public_ip():
   """ Get the public IP of the current machine.
-  
+
   Returns:
     String containing the public IP of the current machine.
   """
@@ -117,31 +117,31 @@ def get_public_ip():
 
 def get_secret():
   """ Get AppScale shared security key for authentication.
-    
+
   Returns:
     String containing the secret key.
   """
   return file_io.read(constants.SECRET_LOC).rstrip()
- 
+
 def get_num_cpus():
   """ Get the number of CPU processes on the current machine.
-  
+
   Returns:
     Integer of the number of CPUs on the current machine
   """
-  return multiprocessing.cpu_count() 
+  return multiprocessing.cpu_count()
 
 def get_db_info():
   """ Get information on the database being used.
-  
+
   Returns:
     A dictionary with database info
   """
-  info = file_io.read(constants.DB_INFO_LOC) 
+  info = file_io.read(constants.DB_INFO_LOC)
   return yaml.safe_load(info)
 
 def get_taskqueue_nodes():
-  """ Returns a list of all the taskqueue nodes (including the master). 
+  """ Returns a list of all the taskqueue nodes (including the master).
       Strips off any empty lines
 
   Returns:
@@ -155,7 +155,7 @@ def get_taskqueue_nodes():
 
 def get_app_path(app_id):
   """ Returns the application path.
-  
+
   Args:
     app_id: The application id.
   Returns:
@@ -164,16 +164,16 @@ def get_app_path(app_id):
   return constants.APPS_PATH + app_id + '/app/'
 
 def get_zk_locations_string():
-  """ Returns the ZooKeeper connection host string. 
+  """ Returns the ZooKeeper connection host string.
 
   Returns:
-    A string containing one or more host:port listings, separated by commas. 
+    A string containing one or more host:port listings, separated by commas.
     None is returned if there was a problem getting the location string.
   """
   try:
-    info = file_io.read(constants.ZK_LOCATIONS_JSON_FILE) 
-    zk_json = json.loads(info) 
-    return ":2181,".join(zk_json['locations']) + ":2181"
+    with open(constants.ZK_LOCATIONS_FILE) as locations_file:
+      return ''.join('{}:2181'.format(line.strip())
+                     for line in locations_file if line.strip())
   except IOError, io_error:
     logger.exception(io_error)
     return constants.ZK_DEFAULT_CONNECTION_STR
@@ -195,9 +195,8 @@ def get_zk_node_ips():
     AppScale deployment.
   """
   try:
-    info = file_io.read(constants.ZK_LOCATIONS_JSON_FILE)
-    zk_json = json.loads(info)
-    return zk_json['locations']
+    with open(constants.ZK_LOCATIONS_FILE) as locations_file:
+      return [line.strip() for line in locations_file if line.strip()]
   except IOError, io_error:
     logger.exception(io_error)
     return []

--- a/common/appscale/common/constants.py
+++ b/common/appscale/common/constants.py
@@ -112,8 +112,8 @@ PHP = "php"
 # Location where applications are stored.
 APPS_PATH = "/var/apps/"
 
-# Locations of ZooKeeper in json format.
-ZK_LOCATIONS_JSON_FILE = "/etc/appscale/zookeeper_locations.json"
+# Locations of ZooKeeper.
+ZK_LOCATIONS_FILE = "/etc/appscale/zookeeper_locations"
 
 # Default location for connecting to ZooKeeper.
 ZK_DEFAULT_CONNECTION_STR = "localhost:2181"


### PR DESCRIPTION
It's much easier to work with a simple text file containing
zookeeper locations written as lines instead of json formatted file.