### PR TITLE
Only list unique items in project list

### DIFF
--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -177,7 +177,8 @@ class DatastoreViewerPage(AppDashboard):
     """
     if self.helper.is_user_cloud_admin():
       version_keys = self.helper.get_version_info().keys()
-      owned_projects = [version.split('_')[0] for version in version_keys]
+      owned_projects = list({version.split('_')[0]
+                             for version in version_keys})
     else:
       owned_projects = self.helper.get_owned_apps()
 
@@ -195,8 +196,8 @@ class DatastoreViewerSelector(AppDashboard):
     """ Presents a list of projects to view data for. """
     if self.helper.is_user_cloud_admin():
       version_keys = self.helper.get_version_info().keys()
-      owned_projects = [version.split('_')[0] for version in version_keys
-                        if version.split('_')[0] != self.PROJECT_ID]
+      owned_projects = list({version.split('_')[0] for version in version_keys
+                             if version.split('_')[0] != self.PROJECT_ID})
     else:
       owned_projects = self.helper.get_owned_apps()
 

--- a/AppDashboard/lib/pull_queue_viewer.py
+++ b/AppDashboard/lib/pull_queue_viewer.py
@@ -68,7 +68,8 @@ class PQViewerPage(AppDashboard):
     """
     if self.helper.is_user_cloud_admin():
       version_keys = self.helper.get_version_info().keys()
-      owned_projects = [version.split('_')[0] for version in version_keys]
+      owned_projects = list({version.split('_')[0]
+                             for version in version_keys})
     else:
       owned_projects = self.helper.get_owned_apps()
 
@@ -86,8 +87,8 @@ class PQProjectSelector(AppDashboard):
     """ Presents a list of projects to view queue info for. """
     if self.helper.is_user_cloud_admin():
       version_keys = self.helper.get_version_info().keys()
-      owned_projects = [version.split('_')[0] for version in version_keys
-                        if version.split('_')[0] != self.PROJECT_ID]
+      owned_projects = list({version.split('_')[0] for version in version_keys
+                             if version.split('_')[0] != self.PROJECT_ID})
     else:
       owned_projects = self.helper.get_owned_apps()
 


### PR DESCRIPTION
This prevents the dashboard from showing duplicate project entries when multiple services are deployed.