### PR TITLE
Don't upgrade dependencies when testing TQ server

### DIFF
--- a/AppTaskQueue/test/helpers/restart-taskqueue.sh
+++ b/AppTaskQueue/test/helpers/restart-taskqueue.sh
@@ -85,7 +85,8 @@ fi
 
 if [ ! -z ${TQ_SOURCE_DIR} ]; then
     log "Installing TaskQueue from specified sources"
-    pip install --upgrade "${TQ_SOURCE_DIR}"
+    pip install --upgrade --no-deps "${TQ_SOURCE_DIR}"
+    pip install "${TQ_SOURCE_DIR}"
 fi
 
 log "Filling /etc/appscale/* files with addresses of required services"


### PR DESCRIPTION
Fixes the taskqueue e2e tests