### PR TITLE
Re-add editing capabilities to datastore viewer

### DIFF
--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -647,13 +647,8 @@ class DatastoreEditRequestHandler(DatastoreViewerPage):
         # property was already empty.
         continue
 
-      if form_value:
-        # TODO: Handle parse exceptions.
-        entity[property_name] = data_type.parse(form_value)
-      elif property_name in entity:
-        # TODO: Treating empty input as deletion is a not a good
-        # interface.
-        del entity[property_name]
+      # TODO: Handle parse exceptions.
+      entity[property_name] = data_type.parse(form_value)
 
     _put_entity(ds_access, entity)
     redirect_url = self.request.get(

--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -610,5 +610,52 @@ class DatastoreEditRequestHandler(DatastoreViewerPage):
       project_id: A string specifying the project ID.
       entity_key_string: A string specifying the entity key.
     """
-    raise NotImplementedError(
-      'Editing entities with the datastore viewer is not supported')
+    self.ensure_user_has_admin(project_id)
+
+    ds_access = DatastoreDistributed(project_id, DATASTORE_LOCATION,
+                                     trusted=True)
+
+    if self.request.get('action:delete'):
+      if entity_key_string:
+        _delete_entities(ds_access, [datastore.Key(entity_key_string)])
+        redirect_url = self.request.get(
+          'next', '/datastore_viewer/{}'.format(project_id))
+        self.redirect(str(redirect_url))
+      else:
+        self.response.set_status(400)
+      return
+
+    if entity_key_string:
+      entity = _get_entity_by_key(ds_access, datastore.Key(entity_key_string))
+    else:
+      kind = self.request.get('kind')
+      namespace = self.request.get('namespace', None)
+      entity = datastore.Entity(kind, _namespace=namespace)
+
+    for arg_name in self.request.arguments():
+      # Arguments are in <property_type>|<property_name>=<value> format.
+      if '|' not in arg_name:
+        continue
+      data_type_name, property_name = arg_name.split('|')
+      form_value = self.request.get(arg_name)
+      data_type = DataType.get_by_name(data_type_name)
+      if (entity and
+          property_name in entity and
+          data_type.format(entity[property_name]) == form_value):
+        # If the property is unchanged then don't update it. This will prevent
+        # empty form values from causing the property to be deleted if the
+        # property was already empty.
+        continue
+
+      if form_value:
+        # TODO: Handle parse exceptions.
+        entity[property_name] = data_type.parse(form_value)
+      elif property_name in entity:
+        # TODO: Treating empty input as deletion is a not a good
+        # interface.
+        del entity[property_name]
+
+    _put_entity(ds_access, entity)
+    redirect_url = self.request.get(
+      'next', '/datastore_viewer/{}'.format(project_id))
+    self.redirect(str(redirect_url))

--- a/AppDashboard/lib/datastore_viewer.py
+++ b/AppDashboard/lib/datastore_viewer.py
@@ -630,7 +630,7 @@ class DatastoreEditRequestHandler(DatastoreViewerPage):
     else:
       kind = self.request.get('kind')
       namespace = self.request.get('namespace', None)
-      entity = datastore.Entity(kind, _namespace=namespace)
+      entity = datastore.Entity(kind, _namespace=namespace, _app=project_id)
 
     for arg_name in self.request.arguments():
       # Arguments are in <property_type>|<property_name>=<value> format.

--- a/AppDashboard/templates/datastore/edit.html
+++ b/AppDashboard/templates/datastore/edit.html
@@ -1,8 +1,8 @@
 <div id="datastore-viewer">
   <div class="page-header">
-    <h1>Datastore Editor - {% if key %}View Entity{% else %}New Entity{% endif %}</h1>
+    <h1>Datastore Editor - {% if key %}Edit Entity{% else %}New Entity{% endif %}</h1>
     <h3>{{ project_id }} >
-      {% if key %}View &quot;{{ kind }}&quot; Entity{% else %}New &quot;{{ kind }}&quot; Entity{% endif %}</h3>
+      {% if key %}Edit &quot;{{ kind }}&quot; Entity{% else %}New &quot;{{ kind }}&quot; Entity{% endif %}</h3>
   </div>
 
   <form action="{{ request.path }}" method="post">
@@ -72,6 +72,14 @@
         <div>{{ field.2|safe }}</div>
       </div>
     {% endfor %}
+    <div class="ae-settings-block">
+      <div>
+        <input class="ae-button ae-button-submit" type="submit" value="Save Changes"/>
+        {% if key %}
+          <input id="delete_button" class="ae-button" type="submit" name="action:delete" value="Delete"/>
+        {% endif %}
+      </div>
+    </div>
   </form>
 </div>
 <script>{% include "datastore/edit.js" %}</script>

--- a/AppDashboard/templates/datastore/viewer.html
+++ b/AppDashboard/templates/datastore/viewer.html
@@ -56,6 +56,7 @@
               </td>
               <td>
                 <input type="submit" class="ae-button" value="List Entities"/>
+                <input type="button" id="create_button" class="ae-button" value="Create New Entity"/>
                 {% if not show_namespace %}
                   <a href="{{ select_namespace_url }}">Select a different namespace</a>
                 {% endif %}

--- a/AppDashboard/templates/datastore/viewer.js
+++ b/AppDashboard/templates/datastore/viewer.js
@@ -29,7 +29,7 @@ $(document).ready(function() {
   $('#allkeys').click(checkAllEntities);
 
   $('#create_button').click(function() {
-    params = {'kind' : $('#kind_input').attr('value'),
+    params = {'kind' : $('#kind_input').find(":selected").val(),
               'next': '{{ request.uri }}'};
 
     if ($('#namespace_input').length) {

--- a/AppServer/google/appengine/tools/devappserver2/admin/datastore_viewer.py
+++ b/AppServer/google/appengine/tools/devappserver2/admin/datastore_viewer.py
@@ -19,6 +19,7 @@
 
 import cgi
 import datetime
+import json
 import math
 import time
 import types
@@ -272,6 +273,26 @@ class BlobType(StringType):
 class EmbeddedEntityType(BlobType):
   def name(self):
     return 'entity:proto'
+
+  def input_field(self, name, value, sample_values, back_uri):
+    if value is None:
+      return '&lt;null&gt;'
+
+    entity = datastore.Entity.FromPb(value)
+    try:
+      return json.dumps(entity)
+    except TypeError:
+      return '&lt;binary&gt;'
+
+  def format(self, value):
+    if value is None:
+      return '<null>'
+
+    entity = datastore.Entity.FromPb(value)
+    try:
+      return json.dumps(entity)
+    except TypeError:
+      return '<binary>'
 
 
 class TimeType(DataType):

--- a/AppServer/google/appengine/tools/devappserver2/admin/datastore_viewer.py
+++ b/AppServer/google/appengine/tools/devappserver2/admin/datastore_viewer.py
@@ -183,7 +183,7 @@ class DataType(object):
   def input_field(self, name, value, sample_values, back_uri):
     string_value = self.format(value) if value else ''
     return (
-        '<input disabled class="%s" name="%s" type="text" size="%d" value="%s" %s/>' % (
+        '<input class="%s" name="%s" type="text" size="%d" value="%s" %s/>' % (
             cgi.escape(self.name()),
             cgi.escape(name),
             self.input_field_size(),

--- a/AppServer/google/appengine/tools/devappserver2/admin/datastore_viewer.py
+++ b/AppServer/google/appengine/tools/devappserver2/admin/datastore_viewer.py
@@ -181,7 +181,7 @@ class DataType(object):
       return format
 
   def input_field(self, name, value, sample_values, back_uri):
-    string_value = self.format(value) if value else ''
+    string_value = self.format(value) if value is not None else ''
     return (
         '<input class="%s" name="%s" type="text" size="%d" value="%s" %s/>' % (
             cgi.escape(self.name()),


### PR DESCRIPTION
Now that the datastore service is responsible for keeping track of composite index definitions, the dashboard can safely mutate entities for other applications.

Resolves #2927.

This also makes a few improvements to the editor interface.

When the user enters an empty string as a value, it stores the empty string instead of removing the property. This does mean that it's not possible to remove a property with the editor, but I think this behavior is less surprising.

When displaying a falsy value like `0`, the editor form will now populate the input with the value instead of an empty string.

Most embedded entities will now display as JSON dictionaries unless they contain unserializable values.

The "Create New Entity" button now works in modern browsers.