### PR TITLE
Pass app identity calls to the external API server

### DIFF
--- a/AppServer/google/appengine/api/app_identity/app_identity_external_stub.py
+++ b/AppServer/google/appengine/api/app_identity/app_identity_external_stub.py
@@ -1,0 +1,71 @@
+""" App identity stub service implementation.
+
+This just forwards calls to an external server.
+"""
+
+import random
+import urllib2
+
+from google.appengine.api import apiproxy_stub
+from google.appengine.runtime import apiproxy_errors
+from google.appengine.ext.remote_api import remote_api_pb
+
+
+class AppIdentityExternalStub(apiproxy_stub.APIProxyStub):
+  """ A proxy for the AppIdentityService API. """
+  THREADSAFE = True
+
+  def __init__(self, location, service_name='app_identity_service'):
+    """ Constructor.
+
+    Args:
+      location: The location of a server that handles App Identity requests.
+    """
+    super(AppIdentityExternalStub, self).__init__(service_name)
+    self._location = location
+    self._max_request_size = apiproxy_stub.MAX_REQUEST_SIZE
+    self._service_name = service_name
+
+  def MakeSyncCall(self, service, call, request, response, request_id=None):
+    """ The main RPC entry point.
+
+    Args:
+      service: Must be name as provided to service_name of constructor.
+      call: A string representing the rpc to make.  Must be part of
+        the underlying services methods and impemented by _Dynamic_<call>.
+      request: A protocol buffer of the type corresponding to 'call'.
+      response: A protocol buffer of the type corresponding to 'call'.
+      request_id: A unique string identifying the request associated with the
+          API call.
+    """
+    assert service == self._service_name, ('Expected "%s" service name, '
+                                           'was "%s"' % (self._service_name,
+                                                         service))
+
+    if request.ByteSize() > self._max_request_size:
+      raise apiproxy_errors.RequestTooLargeError(
+          'The request to API call %s.%s() was too large.' % (service, call))
+
+    messages = []
+    assert request.IsInitialized(messages), messages
+
+    remote_api_request = remote_api_pb.Request()
+    remote_api_request.set_service_name(service)
+    remote_api_request.set_method(call)
+    remote_api_request.set_request(request.Encode())
+    if request_id is not None:
+      remote_api_request.set_request_id(request_id)
+
+    url = 'http://{}'.format(self._location)
+    request_handle = urllib2.Request(url, remote_api_request.Encode())
+    response_handle = urllib2.urlopen(request_handle)
+    remote_api_response = remote_api_pb.Response(response_handle.read())
+    if remote_api_response.has_application_error():
+      error_pb = remote_api_response.application_error()
+      raise apiproxy_errors.ApplicationError(error_pb.code(),
+                                             error_pb.detail())
+
+    if remote_api_response.has_exception():
+      raise remote_api_response.exception()
+
+    response.ParseFromString(remote_api_response.response())

--- a/AppServer/google/appengine/ext/remote_api/remote_api_stub.py
+++ b/AppServer/google/appengine/ext/remote_api/remote_api_stub.py
@@ -588,12 +588,10 @@ def GetRemoteAppIdFromServer(server, path, remote_token=None):
   return app_info['app_id']
 
 
-# AppScale: Add support for an async RPCs and an external API server.
 def ConfigureRemoteApiFromServer(server, path, app_id, services=None,
                                  default_auth_domain=None,
                                  use_remote_datastore=True,
-                                 use_async_rpc=False,
-                                 external_server=None):
+                                 use_async_rpc=False):
   """Does necessary setup to allow easy remote access to App Engine APIs.
 
   Args:
@@ -610,8 +608,6 @@ def ConfigureRemoteApiFromServer(server, path, app_id, services=None,
       a single request.
     use_async_rpc: A boolean indicating whether or not to make RPC calls in a
       separate thread.
-    external_server: An AbstractRpcServer specifying the location of an
-      external API server.
 
   Raises:
     urllib2.HTTPError: if app_id is not provided and there is an error while
@@ -639,20 +635,12 @@ def ConfigureRemoteApiFromServer(server, path, app_id, services=None,
     apiproxy_stub_map.apiproxy.RegisterStub('datastore_v3', datastore_stub)
 
   if use_async_rpc:
-    stub_type = RuntimeRemoteStub
+    stub = RuntimeRemoteStub(server, path)
   else:
-    stub_type = RemoteStub
-
-  stub = stub_type(server, path)
-  external_stub = None
-  if external_server is not None:
-    external_stub = stub_type(external_server, path)
+    stub = RemoteStub(server, path)
 
   for service in services:
-    if service == 'app_identity_service' and external_stub is not None:
-      apiproxy_stub_map.apiproxy.RegisterStub(service, external_stub)
-    else:
-      apiproxy_stub_map.apiproxy.RegisterStub(service, stub)
+    apiproxy_stub_map.apiproxy.RegisterStub(service, stub)
 
 
 def GetRemoteAppId(servername,
@@ -692,7 +680,7 @@ def GetRemoteAppId(servername,
   return app_id, server
 
 
-# AppScale: Add support for an async RPCs and an external API server.
+# AppScale: Add support for async RPCs.
 def ConfigureRemoteApi(app_id,
                        path,
                        auth_func,
@@ -704,8 +692,7 @@ def ConfigureRemoteApi(app_id,
                        default_auth_domain=None,
                        save_cookies=False,
                        use_remote_datastore=True,
-                       use_async_rpc=False,
-                       external_api_server=None):
+                       use_async_rpc=False):
   """Does necessary setup to allow easy remote access to App Engine APIs.
 
   Either servername must be provided or app_id must not be None.  If app_id
@@ -741,8 +728,6 @@ def ConfigureRemoteApi(app_id,
       a single request.
     use_async_rpc: A boolean indicating whether or not to make RPC calls in a
       separate thread.
-    external_api_server: A string specifying the location of an external API
-      server.
 
   Returns:
     server, the server created by rpc_server_factory, which may be useful for
@@ -760,20 +745,12 @@ def ConfigureRemoteApi(app_id,
   server = rpc_server_factory(servername, auth_func, GetUserAgent(),
                               GetSourceName(), save_cookies=save_cookies,
                               debug_data=False, secure=secure)
-
-  if external_api_server is None:
-    external_server = server
-  else:
-    external_server = rpc_server_factory(
-      external_api_server, auth_func, GetUserAgent(), GetSourceName(),
-      save_cookies=save_cookies, debug_data=False, secure=secure)
-
   if not app_id:
     app_id = GetRemoteAppIdFromServer(server, path, rtok)
 
   ConfigureRemoteApiFromServer(server, path, app_id, services,
                                default_auth_domain, use_remote_datastore,
-                               use_async_rpc, external_server)
+                               use_async_rpc)
   return server
 
 

--- a/AppServer/google/appengine/tools/devappserver2/api_server.py
+++ b/AppServer/google/appengine/tools/devappserver2/api_server.py
@@ -45,7 +45,8 @@ from google.appengine.api import mail_stub
 from google.appengine.api import request_info as request_info_lib
 from google.appengine.api import urlfetch_stub
 from google.appengine.api import user_service_stub
-from google.appengine.api.app_identity import app_identity_stub
+from google.appengine.api.app_identity import (app_identity_stub,
+                                               app_identity_external_stub)
 from google.appengine.api.blobstore import blobstore_stub
 from google.appengine.api.capabilities import capability_stub
 from google.appengine.api.channel import channel_service_stub
@@ -280,6 +281,11 @@ def create_api_server(request_info, storage_path, options, app_id, app_root):
     assert 0, ('unknown consistency policy: %r' %
                options.datastore_consistency_policy)
 
+  app_identity_location = None
+  if options.external_api_port:
+    app_identity_location = ':'.join(['localhost',
+                                      str(options.external_api_port)])
+
   maybe_convert_datastore_file_stub_data_to_sqlite(app_id, datastore_path)
   setup_stubs(
       request_data=request_info,
@@ -310,7 +316,8 @@ def create_api_server(request_info, storage_path, options, app_id, app_root):
       default_gcs_bucket_name=options.default_gcs_bucket_name,
       uaserver_path=options.uaserver_path,
       xmpp_path=options.xmpp_path,
-      xmpp_domain=options.login_server)
+      xmpp_domain=options.login_server,
+      app_identity_location=app_identity_location)
 
   # The APIServer must bind to localhost because that is what the runtime
   # instances talk to.
@@ -431,7 +438,8 @@ def setup_stubs(
     default_gcs_bucket_name,
     uaserver_path,
     xmpp_path,
-    xmpp_domain):
+    xmpp_domain,
+    app_identity_location):
   """Configures the APIs hosted by this server.
 
   Args:
@@ -489,11 +497,17 @@ def setup_stubs(
     xmpp_path: (AppScale-specific) A str containing the FQDN or IP address of
         the machine that runs ejabberd, where XMPP clients should connect to.
     xmpp_domain: A string specifying the domain portion of the XMPP user.
+    app_identity_location: The location of a server that handles App Identity
+        requests.
   """
 
-  identity_stub = app_identity_stub.AppIdentityServiceStub()
-  if default_gcs_bucket_name is not None:
-    identity_stub.SetDefaultGcsBucketName(default_gcs_bucket_name)
+  if app_identity_location is None:
+    identity_stub = app_identity_stub.AppIdentityServiceStub()
+    if default_gcs_bucket_name is not None:
+      identity_stub.SetDefaultGcsBucketName(default_gcs_bucket_name)
+  else:
+    identity_stub = app_identity_external_stub.AppIdentityExternalStub(
+        app_identity_location)
   apiproxy_stub_map.apiproxy.RegisterStub('app_identity_service', identity_stub)
 
   blob_storage = datastore_blob_storage.DatastoreBlobStorage(app_id)
@@ -686,7 +700,8 @@ def test_setup_stubs(
     default_gcs_bucket_name=None,
     uaserver_path='localhost',
     xmpp_path='localhost',
-    xmpp_domain='localhost'):
+    xmpp_domain='localhost',
+    app_identity_location=None):
   """Similar to setup_stubs with reasonable test defaults and recallable."""
 
   # Reset the stub map between requests because a stub map only allows a
@@ -723,7 +738,8 @@ def test_setup_stubs(
               default_gcs_bucket_name,
               uaserver_path,
               xmpp_path,
-              xmpp_domain)
+              xmpp_domain,
+              app_identity_location)
 
 
 def cleanup_stubs():

--- a/AppServer/google/appengine/tools/devappserver2/devappserver2.py
+++ b/AppServer/google/appengine/tools/devappserver2/devappserver2.py
@@ -163,8 +163,7 @@ class DevelopmentServer(object):
         options.use_mtime_file_watcher,
         options.automatic_restart,
         options.allow_skipped_files,
-        module_to_threadsafe_override,
-        options.external_api_port)
+        module_to_threadsafe_override)
 
     request_data = wsgi_request_info.WSGIRequestInfo(self._dispatcher)
     storage_path = api_server.get_storage_path(

--- a/AppServer/google/appengine/tools/devappserver2/module.py
+++ b/AppServer/google/appengine/tools/devappserver2/module.py
@@ -28,7 +28,6 @@ import os.path
 import random
 import re
 import string
-import struct
 import threading
 import time
 import urllib
@@ -267,15 +266,7 @@ class Module(object):
       runtime_config.skip_files = str(self._module_configuration.skip_files)
       runtime_config.static_files = _static_files_regex_from_handlers(
           self._module_configuration.handlers)
-
-    # AppScale: Pack both API ports into the same field.
-    if (self._external_api_port is not None and
-        self._module_configuration.runtime in ('python27', 'go', 'php')):
-      port_bytes = struct.pack('HH', self._api_port, self._external_api_port)
-      runtime_config.api_port = struct.unpack('I', port_bytes)[0]
-    else:
-      runtime_config.api_port = self._api_port
-
+    runtime_config.api_port = self._api_port
     runtime_config.stderr_log_level = self._runtime_stderr_loglevel
     runtime_config.datacenter = 'us1'
     runtime_config.auth_domain = self._auth_domain
@@ -369,8 +360,7 @@ class Module(object):
                use_mtime_file_watcher,
                automatic_restarts,
                allow_skipped_files,
-               threadsafe_override,
-               external_api_port=None):
+               threadsafe_override):
     """Initializer for Module.
 
     Args:
@@ -414,14 +404,11 @@ class Module(object):
           directive.
       threadsafe_override: If not None, ignore the YAML file value of threadsafe
           and use this value instead.
-      external_api_port: An integer specifying the location of an external API
-          server.
     """
     self._module_configuration = module_configuration
     self._name = module_configuration.module_name
     self._host = host
     self._api_port = api_port
-    self._external_api_port = external_api_port
     self._auth_domain = auth_domain
     self._runtime_stderr_loglevel = runtime_stderr_loglevel
     self._balanced_port = balanced_port
@@ -920,8 +907,7 @@ class AutoScalingModule(Module):
                use_mtime_file_watcher,
                automatic_restarts,
                allow_skipped_files,
-               threadsafe_override,
-               external_api_port=None):
+               threadsafe_override):
     """Initializer for AutoScalingModule.
 
     Args:
@@ -965,8 +951,6 @@ class AutoScalingModule(Module):
           directive.
       threadsafe_override: If not None, ignore the YAML file value of threadsafe
           and use this value instead.
-      external_api_port: An integer specifying the location of an external API
-          server.
     """
     super(AutoScalingModule, self).__init__(module_configuration,
                                             host,
@@ -986,8 +970,7 @@ class AutoScalingModule(Module):
                                             use_mtime_file_watcher,
                                             automatic_restarts,
                                             allow_skipped_files,
-                                            threadsafe_override,
-                                            external_api_port)
+                                            threadsafe_override)
 
     self._process_automatic_scaling(
         self._module_configuration.automatic_scaling)
@@ -1360,8 +1343,7 @@ class ManualScalingModule(Module):
                use_mtime_file_watcher,
                automatic_restarts,
                allow_skipped_files,
-               threadsafe_override,
-               external_api_port=None):
+               threadsafe_override):
     """Initializer for ManualScalingModule.
 
     Args:
@@ -1405,8 +1387,6 @@ class ManualScalingModule(Module):
           directive.
       threadsafe_override: If not None, ignore the YAML file value of threadsafe
           and use this value instead.
-      external_api_port: An integer specifying the location of an external API
-          server.
     """
     super(ManualScalingModule, self).__init__(module_configuration,
                                               host,
@@ -1426,8 +1406,7 @@ class ManualScalingModule(Module):
                                               use_mtime_file_watcher,
                                               automatic_restarts,
                                               allow_skipped_files,
-                                              threadsafe_override,
-                                              external_api_port)
+                                              threadsafe_override)
 
     self._process_manual_scaling(module_configuration.manual_scaling)
 
@@ -1864,8 +1843,7 @@ class BasicScalingModule(Module):
                use_mtime_file_watcher,
                automatic_restarts,
                allow_skipped_files,
-               threadsafe_override,
-               external_api_port=None):
+               threadsafe_override):
     """Initializer for BasicScalingModule.
 
     Args:
@@ -1909,8 +1887,6 @@ class BasicScalingModule(Module):
           directive.
       threadsafe_override: If not None, ignore the YAML file value of threadsafe
           and use this value instead.
-      external_api_port: An integer specifying the location of an external API
-          server.
     """
     super(BasicScalingModule, self).__init__(module_configuration,
                                              host,
@@ -1930,8 +1906,7 @@ class BasicScalingModule(Module):
                                              use_mtime_file_watcher,
                                              automatic_restarts,
                                              allow_skipped_files,
-                                             threadsafe_override,
-                                             external_api_port)
+                                             threadsafe_override)
     self._process_basic_scaling(module_configuration.basic_scaling)
 
     self._instances = []  # Protected by self._condition.

--- a/AppServer/google/appengine/tools/devappserver2/php/runtime.py
+++ b/AppServer/google/appengine/tools/devappserver2/php/runtime.py
@@ -22,7 +22,6 @@ import cStringIO
 import httplib
 import logging
 import os
-import struct
 import subprocess
 import sys
 import time
@@ -49,11 +48,6 @@ class PHPRuntime(object):
     logging.debug('Initializing runtime with %s', config)
     self.config = config
 
-    external_api_port = 0
-    if config.api_port > 65535:
-        port_bytes = struct.pack('I', config.api_port)
-        config.api_port, external_api_port = struct.unpack('HH', port_bytes)
-
     if appinfo.MODULE_SEPARATOR not in config.version_id:
       module_id = appinfo.DEFAULT_MODULE
       version_id = config.version_id
@@ -73,7 +67,6 @@ class PHPRuntime(object):
         # http://php.net/manual/en/security.cgi-bin.force-redirect.php
         'REDIRECT_STATUS': '1',
         'REMOTE_API_PORT': str(config.api_port),
-        'EXTERNAL_API_PORT': str(external_api_port),
         'SERVER_SOFTWARE': http_runtime_constants.SERVER_SOFTWARE,
         'TZ': 'UTC',
         }

--- a/AppServer/google/appengine/tools/devappserver2/php/setup.php
+++ b/AppServer/google/appengine/tools/devappserver2/php/setup.php
@@ -52,16 +52,12 @@ $setup = function() {
     require_once 'google/appengine/runtime/RemoteApiProxy.php';
     \google\appengine\runtime\ApiProxy::setApiProxy(
       new \google\appengine\runtime\RemoteApiProxy(
-        getenv('REMOTE_API_PORT'), getenv('EXTERNAL_API_PORT'),
-        getenv('REMOTE_REQUEST_ID')));
+        getenv('REMOTE_API_PORT'), getenv('REMOTE_REQUEST_ID')));
     putenv('REMOTE_API_PORT');
-    putenv('EXTERNAL_API_PORT');
     putenv('REMOTE_REQUEST_ID');
     unset($_SERVER['REMOTE_API_PORT']);
-    unset($_SERVER['EXTERNAL_API_PORT']);
     unset($_SERVER['REMOTE_REQUEST_ID']);
     unset($_ENV['REMOTE_API_PORT']);
-    unset($_ENV['EXTERNAL_API_PORT']);
     unset($_ENV['REMOTE_REQUEST_ID']);
   };
 

--- a/AppServer/php/sdk/google/appengine/runtime/RemoteApiProxy.php
+++ b/AppServer/php/sdk/google/appengine/runtime/RemoteApiProxy.php
@@ -43,12 +43,10 @@ class RemoteApiProxy extends ApiProxyBase{
   /**
    * Constructs an instance of RemoteApiProxy.
    * @param int $apiPort Port to use
-   * @param int $externalApiPort Port of external API server
    * @param string $requestId ID of the request
    */
-  function __construct($apiPort, $externalApiPort, $requestId) {
+  function __construct($apiPort, $requestId) {
     $this->apiPort = $apiPort;
-    $this->externalApiPort = $externalApiPort;
     $this->requestId = $requestId;
   }
 
@@ -89,14 +87,9 @@ class RemoteApiProxy extends ApiProxyBase{
       )
     );
 
-    $port_to_use = $this->apiPort;
-    if ($package == 'app_identity_service' && $this->externalApiPort != '0') {
-      $port_to_use = $this->externalApiPort;
-    }
-
     $context = stream_context_create($opts);
     $serialized_remote_respone = file_get_contents(
-        'http://localhost:' . $port_to_use, false, $context);
+        'http://localhost:' . $this->apiPort, false, $context);
     $remote_response = new Response();
     $remote_response->parseFromString($serialized_remote_respone);
 

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -538,24 +538,28 @@ installapiclient()
 
 installgosdk()
 {
+    EXTRAS_DIR="/opt"
+    GO_RUNTIME_DIR="${EXTRAS_DIR}/go_appengine"
     if [ ${UNAME_MACHINE} = "x86_64" ]; then
-        GO_SDK_PACKAGE="appscale-go-runtime-1.9.48.zip"
-        GO_SDK_PACKAGE_MD5="3af8c4f6b3a147f99590862d2815025b"
-
-        GO_RUNTIME_DIR="/opt/go_appengine"
-        cachepackage ${GO_SDK_PACKAGE} ${GO_SDK_PACKAGE_MD5}
-
-        echo "Extracting Go SDK"
-        # Remove existing SDK directory in case it's old.
-        rm -rf ${GO_RUNTIME_DIR}
-        mkdir -p ${GO_RUNTIME_DIR}/gopath
-        unzip -q ${PACKAGE_CACHE}/${GO_SDK_PACKAGE} -d ${GO_RUNTIME_DIR}
+        GO_SDK_PACKAGE="go_appengine_sdk_linux_amd64-1.9.48.zip"
+        GO_SDK_PACKAGE_MD5="b5c1a3eab1ba69993c3a35661ec3043d"
+    elif [ ${UNAME_MACHINE} = "i386" ]; then
+        GO_SDK_PACKAGE="go_appengine_sdk_linux_386-1.9.48.zip"
+        GO_SDK_PACKAGE_MD5="b6aad6a3cb2506dfe1067e06fb93f9fb"
     else
         echo "Warning: There is no binary appscale-go-runtime package"
         echo "available for ${UNAME_MACHINE}. If you need support for Go"
         echo "applications, compile github.com/AppScale/appscale-go-runtime"
         echo "and install in ${GO_RUNTIME_DIR}/goroot."
+        return 0
     fi
+
+    cachepackage ${GO_SDK_PACKAGE} ${GO_SDK_PACKAGE_MD5}
+
+    echo "Extracting Go SDK"
+    # Remove existing SDK directory in case it's old.
+    rm -rf ${GO_RUNTIME_DIR}
+    unzip -q ${PACKAGE_CACHE}/${GO_SDK_PACKAGE} -d ${EXTRAS_DIR}
 }
 
 installpycapnp()


### PR DESCRIPTION
This simplifies runtime instance configuration by routing all calls through one API server. This will make it easier for the java runtime to use the Python SDK's API server.