### PR TITLE
Remove "for_cas" field requirement on set

### DIFF
--- a/AppServer/google/appengine/api/memcache/memcache_distributed.py
+++ b/AppServer/google/appengine/api/memcache/memcache_distributed.py
@@ -127,8 +127,7 @@ class MemcacheService(apiproxy_stub.APIProxyStub):
         if (old_entry is None or set_policy == MemcacheSetRequest.SET):
           set_status = MemcacheSetResponse.STORED
 
-      elif (set_policy == MemcacheSetRequest.CAS and item.for_cas() and
-        item.has_cas_id()):
+      elif (set_policy == MemcacheSetRequest.CAS and item.has_cas_id()):
         if old_entry is None:
           set_status = MemcacheSetResponse.NOT_STORED
         elif cas_id != item.cas_id():


### PR DESCRIPTION
When making a compare-and-set update, the client does not need to set "for_cas" on each item.