### PR TITLE
Don't add tag data to task if the task has none

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/queue.py
+++ b/AppTaskQueue/appscale/taskqueue/queue.py
@@ -1217,8 +1217,10 @@ class PullQueue(Queue):
     for result in results:
       task_info = {'id': result.id,
                    'enqueueTimestamp': result.enqueued,
-                   'leaseTimestamp': result.lease_expires,
-                   'tag': result.tag}
+                   'leaseTimestamp': result.lease_expires}
+      if result.tag:
+        task_info['tag'] = result.tag
+
       self._delete_task_and_index(Task(task_info))
 
   def to_json(self, include_stats=False, fields=None):


### PR DESCRIPTION
This fixes the purge_queue method.