### PR TITLE
Add a timeout to the health check request

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/constants.py
+++ b/AdminServer/appscale/admin/instance_manager/constants.py
@@ -89,6 +89,9 @@ PIDFILE_TEMPLATE = os.path.join('/', 'var', 'run', 'appscale',
 REPACKED_LIB_DIR = os.path.join(
   APPSCALE_HOME, 'AppServer_Java', 'appengine-java-sdk-repacked', 'lib')
 
+# The number of seconds to wait for a health check response.
+HEALTH_CHECK_TIMEOUT = 2
+
 # The highest available port to assign to an API server.
 MAX_API_SERVER_PORT = 19999
 

--- a/AdminServer/appscale/admin/instance_manager/instance_manager.py
+++ b/AdminServer/appscale/admin/instance_manager/instance_manager.py
@@ -15,10 +15,11 @@ from appscale.admin.constants import CONTROLLER_STATE_NODE, UNPACK_ROOT
 from appscale.admin.instance_manager.constants import (
   API_SERVER_LOCATION, API_SERVER_PREFIX, APP_LOG_SIZE, BACKOFF_TIME,
   BadConfigurationException, DASHBOARD_LOG_SIZE, DASHBOARD_PROJECT_ID,
-  DEFAULT_MAX_APPSERVER_MEMORY, FETCH_PATH, GO_SDK, INSTANCE_CLASSES,
-  JAVA_APPSERVER_CLASS, MAX_API_SERVER_PORT, MAX_INSTANCE_RESPONSE_TIME,
-  MONIT_INSTANCE_PREFIX, NoRedirection, PIDFILE_TEMPLATE, PYTHON_APPSERVER,
-  START_APP_TIMEOUT, STARTING_INSTANCE_PORT, VERSION_REGISTRATION_NODE)
+  DEFAULT_MAX_APPSERVER_MEMORY, FETCH_PATH, GO_SDK, HEALTH_CHECK_TIMEOUT,
+  INSTANCE_CLASSES, JAVA_APPSERVER_CLASS, MAX_API_SERVER_PORT,
+  MAX_INSTANCE_RESPONSE_TIME, MONIT_INSTANCE_PREFIX, NoRedirection,
+  PIDFILE_TEMPLATE, PYTHON_APPSERVER, START_APP_TIMEOUT,
+  STARTING_INSTANCE_PORT, VERSION_REGISTRATION_NODE)
 from appscale.admin.instance_manager.instance import (
   create_java_app_env, create_java_start_cmd, create_python_app_env,
   create_python27_start_cmd, get_login_server, Instance)
@@ -385,7 +386,7 @@ class InstanceManager(object):
     while retries > 0:
       try:
         opener = urllib2.build_opener(NoRedirection)
-        response = opener.open(url)
+        response = opener.open(url, timeout=HEALTH_CHECK_TIMEOUT)
         if response.code != HTTPCodes.OK:
           logger.warning('{} returned {}. Headers: {}'.
                           format(url, response.code, response.headers.headers))

--- a/AdminServer/tests/test_instance_manager.py
+++ b/AdminServer/tests/test_instance_manager.py
@@ -311,7 +311,8 @@ class TestInstanceManager(AsyncTestCase):
     ip = '127.0.0.1'
     testing.disable_logging()
     fake_opener = flexmock(
-      open=lambda opener: flexmock(code=200, headers=flexmock(headers=[])))
+      open=lambda url, timeout: flexmock(code=200,
+                                         headers=flexmock(headers=[])))
     flexmock(urllib2).should_receive('build_opener').and_return(fake_opener)
     flexmock(appscale_info).should_receive('get_private_ip').and_return(ip)
 


### PR DESCRIPTION
If the instance gets stuck coming up, this prevents the instance manager from also getting stuck.

Resolves #3008.