### PR TITLE
Rescue rescue Errno::EHOSTUNREACH

### DIFF
--- a/AppController/lib/hermes_client.rb
+++ b/AppController/lib/hermes_client.rb
@@ -29,6 +29,8 @@ module HermesClient
       return JSON.load(response.body)
     rescue Errno::ETIMEDOUT, Timeout::Error
       raise FailedNodeException.new("Failed to call Hermes: timed out")
+    rescue Errno::EHOSTUNREACH
+      raise FailedNodeException.new("Failed to call Hermes: host unreachable")
     rescue Errno::ECONNREFUSED
       raise FailedNodeException.new("Failed to call Hermes: connection refused")
     end


### PR DESCRIPTION
Make sure the AC won't crash if a host in unreachable when calling
herems. This is to prevent failures with 

/usr/lib/ruby/2.3.0/net/http.rb:882:in `rescue in block in connect': Failed to open TCP connection to 10.10.1.191:4378 (No route to host - connect(2) for "10.10.1.191" port 4378) (Errno::EHOSTUNREACH)
        from /usr/lib/ruby/2.3.0/net/http.rb:879:in `block in connect'
        from /usr/lib/ruby/2.3.0/timeout.rb:91:in `block in timeout'
        from /usr/lib/ruby/2.3.0/timeout.rb:101:in `timeout'
        from /usr/lib/ruby/2.3.0/net/http.rb:878:in `connect'
        from /usr/lib/ruby/2.3.0/net/http.rb:863:in `do_start'
        from /usr/lib/ruby/2.3.0/net/http.rb:852:in `start'
        from /usr/lib/ruby/2.3.0/net/http.rb:584:in `start'
        from /root/appscale/AppController/lib/hermes_client.rb:21:in `make_call'
        from /root/appscale/AppController/lib/hermes_client.rb:66:in `get_proxies_stats'
        from /root/appscale/AppController/lib/hermes_client.rb:84:in `get_proxy_stats'
        from /root/appscale/AppController/lib/hermes_client.rb:101:in `get_proxy_load_stats'
        from /root/appscale/AppController/djinn.rb:5851:in `block in get_application_load_stats'
        from /root/appscale/AppController/djinn.rb:5848:in `each'
        from /root/appscale/AppController/djinn.rb:5848:in `get_application_load_stats'
        from /root/appscale/AppController/djinn.rb:5113:in `get_scaling_info_for_version'
        from /root/appscale/AppController/djinn.rb:4825:in `block in scale_deployment'
        from /root/appscale/AppController/djinn.rb:4818:in `each'
        from /root/appscale/AppController/djinn.rb:4818:in `scale_deployment'
        from /root/appscale/AppController/djinn.rb:1868:in `block in job_start'
        from /usr/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
        from /root/appscale/AppController/djinn.rb:1868:in `job_start'
        from /root/appscale/AppController/djinnServer.rb:157:in `<main>'
