### PR TITLE
Smooth current sessions

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5134,7 +5134,7 @@ HOSTS
     @curr_sessions_list.delete_at(0)  if @curr_sessions_list.length >= 10
     @curr_sessions_list << current_sessions
     scale_sessions = @curr_sessions_list.max
-    Djinn.log_debug("Using #{scale_sessions} as current_sessions value "
+    Djinn.log_debug("Using #{scale_sessions} as current_sessions value " \
                     "for scaling #{version_key}.")
 
     allow_concurrency = version_details.fetch('threadsafe', true)


### PR DESCRIPTION
This PR is to smooth the values we use to autoscale, since the straight read from haproxy can actually be quite jumpy in a short amount of time.