### PR TITLE
Remove HAProxy stats URL

### DIFF
--- a/AdminServer/appscale/admin/routing/templates/base.cfg
+++ b/AdminServer/appscale/admin/routing/templates/base.cfg
@@ -46,15 +46,6 @@ defaults
   # The maximum inactivity time allowed for a server.
   timeout server {server_timeout}ms
 
-  # Enable the statistics page
-  stats enable
-  stats uri     /haproxy?stats
-  stats realm   Haproxy\ Statistics
-  stats auth    haproxy:stats
-
-  # Create a monitorable URI which returns a 200 if haproxy is up
-  # monitor-uri /haproxy?monitor
-
   # Amount of time after which a health check is considered to have timed out
   timeout check 5000
 


### PR DESCRIPTION
The stats are already accessible via the unix socket, and we don't need a public interface for them.