### PR TITLE
Add initial implementation of datastore-backed sessions

### DIFF
--- a/AppServer_Java/build.xml
+++ b/AppServer_Java/build.xml
@@ -118,6 +118,7 @@
       <include name="com/google/apphosting/utils/config/*" />
       <include name="com/google/appengine/tools/development/*" />
       <include name="com/google/appengine/tools/resources/*" />
+      <include name="org/mortbay/jetty/servlet/DatastoreSessionManager*" />
     </jar>
     <copy file="src/com/google/appengine/tools/development/webdefault.xml" tofile="${gae_dist}/com/google/appengine/tools/development/" />
   </target>

--- a/AppServer_Java/src/com/google/appengine/tools/development/JettyContainerService.java
+++ b/AppServer_Java/src/com/google/appengine/tools/development/JettyContainerService.java
@@ -1,5 +1,6 @@
 package com.google.appengine.tools.development;
 
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.log.dev.DevLogHandler;
 import com.google.appengine.api.log.dev.LocalLogService;
 import com.google.appengine.repackaged.com.google.common.collect.ImmutableList;
@@ -40,6 +41,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.handler.HandlerWrapper;
 import org.mortbay.jetty.nio.SelectChannelConnector;
+import org.mortbay.jetty.servlet.DatastoreSessionManager;
 import org.mortbay.jetty.servlet.ServletHolder;
 import org.mortbay.jetty.servlet.SessionHandler;
 import org.mortbay.jetty.webapp.WebAppContext;
@@ -112,7 +114,7 @@ public class JettyContainerService extends AbstractContainerService {
          this.server.setHandler(apiHandler);
          SessionHandler handler = this.context.getSessionHandler();
          if(this.isSessionsEnabled()) {
-            handler.setSessionManager(new SerializableObjectsOnlyHashSessionManager());
+            handler.setSessionManager(new DatastoreSessionManager(DatastoreServiceFactory.getDatastoreService()));
          } else {
             handler.setSessionManager(new StubSessionManager());
          }

--- a/AppServer_Java/src/org/mortbay/jetty/servlet/DatastoreSessionManager.java
+++ b/AppServer_Java/src/org/mortbay/jetty/servlet/DatastoreSessionManager.java
@@ -74,14 +74,16 @@ public class DatastoreSessionManager extends AbstractSessionManager {
         session._invalid = (boolean)entity.getProperty("_invalid");
 
         Blob blob = (Blob)entity.getProperty("_values");
-        try {
-            ByteArrayInputStream bais = new ByteArrayInputStream(blob.getBytes());
-            ObjectInputStream ois = new ObjectInputStream(bais);
-            session._values = (HashMap<String, Object>)ois.readObject();
-            ois.close();
-            bais.close();
-        } catch (ClassNotFoundException | IOException error) {
-            throw new RuntimeException(error);
+        if (blob != null) {
+            try {
+                ByteArrayInputStream bais = new ByteArrayInputStream(blob.getBytes());
+                ObjectInputStream ois = new ObjectInputStream(bais);
+                session._values = (HashMap<String, Object>)ois.readObject();
+                ois.close();
+                bais.close();
+            } catch (ClassNotFoundException | IOException error) {
+                throw new RuntimeException(error);
+            }
         }
 
         return session;

--- a/AppServer_Java/src/org/mortbay/jetty/servlet/DatastoreSessionManager.java
+++ b/AppServer_Java/src/org/mortbay/jetty/servlet/DatastoreSessionManager.java
@@ -1,0 +1,145 @@
+package org.mortbay.jetty.servlet;
+
+import java.io.*;
+import java.util.*;
+import javax.servlet.http.*;
+
+import com.google.appengine.api.NamespaceManager;
+import com.google.appengine.api.datastore.*;
+import org.mortbay.util.LazyList;
+
+
+// AppScale: This is a naive implementation of datastore-backed sessions. There is a much more sophisticated
+// implementation in the 1.9.66 SDK.
+public class DatastoreSessionManager extends AbstractSessionManager {
+    private final DatastoreService datastore;
+    private static String kind = "_ah_SESSION";
+
+    public DatastoreSessionManager(DatastoreService datastore) {
+        this.datastore = datastore;
+    }
+
+    public Map getSessionMap() {
+        throw new RuntimeException("Not supported.");
+    }
+
+    public int getSessions() {
+        throw new RuntimeException("Not supported.");
+    }
+
+    protected void addSession(AbstractSessionManager.Session session) {
+        this.datastore.put(encodeSessionAsEntity(session));
+    }
+
+    protected void addSession(AbstractSessionManager.Session session, boolean created) {
+        synchronized(this._sessionIdManager) {
+            this._sessionIdManager.addSession(session);
+        }
+
+        if (!created) {
+            session.didActivate();
+        } else if (this._sessionListeners != null) {
+            HttpSessionEvent event = new HttpSessionEvent(session);
+
+            for(int i = 0; i < LazyList.size(this._sessionListeners); ++i) {
+                ((HttpSessionListener)LazyList.get(this._sessionListeners, i)).sessionCreated(event);
+            }
+        }
+    }
+
+    public AbstractSessionManager.Session getSession(String idInCluster) {
+        Entity entity;
+        try {
+            entity = this.datastore.get(getSessionDatastoreKey(idInCluster));
+        } catch (EntityNotFoundException error) {
+            return null;
+        }
+        return decodeEntityAsSession(entity);
+    }
+
+    protected void invalidateSessions() {}
+
+    protected AbstractSessionManager.Session newSession(HttpServletRequest request) {
+        return new DatastoreSessionManager.Session(request);
+    }
+
+    protected void removeSession(String clusterId) {
+        this.datastore.delete(getSessionDatastoreKey(clusterId));
+    }
+
+    private AbstractSessionManager.Session decodeEntityAsSession(Entity entity) {
+        String clusterId = (String)entity.getProperty("_clusterId");
+        long created = (long)entity.getProperty("_created");
+        DatastoreSessionManager.Session session = new DatastoreSessionManager.Session(created, clusterId);
+        session._invalid = (boolean)entity.getProperty("_invalid");
+
+        Blob blob = (Blob)entity.getProperty("_values");
+        try {
+            ByteArrayInputStream bais = new ByteArrayInputStream(blob.getBytes());
+            ObjectInputStream ois = new ObjectInputStream(bais);
+            session._values = (HashMap<String, Object>)ois.readObject();
+            ois.close();
+            bais.close();
+        } catch (ClassNotFoundException | IOException error) {
+            throw new RuntimeException(error);
+        }
+
+        return session;
+    }
+
+    private Entity encodeSessionAsEntity(AbstractSessionManager.Session session) {
+        Entity entity = new Entity(getSessionDatastoreKey(session._clusterId));
+        entity.setProperty("_clusterId", session._clusterId);
+        entity.setProperty("_created", session._created);
+        entity.setProperty("_invalid", session._invalid);
+        if (session._values != null) {
+            Blob blob;
+            try {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos);
+                oos.writeObject(session._values);
+                oos.close();
+                blob = new Blob(baos.toByteArray());
+                baos.close();
+            } catch (IOException error) {
+                throw new RuntimeException(error);
+            }
+            entity.setProperty("_values", blob);
+        }
+        return entity;
+    }
+
+    private Key getSessionDatastoreKey(String clusterId) {
+        String originalNamespace = NamespaceManager.get();
+        try {
+            NamespaceManager.set("");
+            return KeyFactory.createKey(DatastoreSessionManager.kind, clusterId);
+        } finally {
+            NamespaceManager.set(originalNamespace);
+        }
+    }
+
+    protected class Session extends AbstractSessionManager.Session {
+        Session(HttpServletRequest request) {
+            super(request);
+        }
+
+        Session(long created, String clusterId) {
+            super(created, clusterId);
+        }
+
+        protected Map newAttributeMap() {
+            return new HashMap(3);
+        }
+
+        public synchronized void removeAttribute(String name) {
+            super.removeAttribute(name);
+            DatastoreSessionManager.this.addSession(this);
+        }
+
+        public synchronized void setAttribute(String name, Object value) {
+            super.setAttribute(name, value);
+            DatastoreSessionManager.this.addSession(this);
+        }
+    }
+}


### PR DESCRIPTION
Though a much more robust implementation is available in the 1.9.66 SDK, it would require too much effort to backport it to the current SDK right now. This particular implementation is inefficient,
but I think anything is an improvement over the in-memory implementation that it replaces.

Resolves #3014.