### PR TITLE
Move protobuffer handling to different level

### DIFF
--- a/AppDB/appscale/datastore/datastore_distributed.py
+++ b/AppDB/appscale/datastore/datastore_distributed.py
@@ -3137,38 +3137,6 @@ class DatastoreDistributed():
       IOLoop.current().spawn_callback(self.enqueue_transactional_tasks, app,
                                       metadata['tasks'])
 
-  @gen.coroutine
-  def commit_transaction(self, app_id, http_request_data):
-    """ Handles the commit phase of a transaction.
-
-    Args:
-      app_id: The application ID requesting the transaction commit.
-      http_request_data: The encoded request of datastore_pb.Transaction.
-    Returns:
-      An encoded protocol buffer commit response.
-    """
-    transaction_pb = datastore_pb.Transaction(http_request_data)
-    txn_id = transaction_pb.handle()
-
-    try:
-      yield self.apply_txn_changes(app_id, txn_id)
-    except (dbconstants.TxTimeoutException, dbconstants.Timeout) as timeout:
-      raise gen.Return(('', datastore_pb.Error.TIMEOUT, str(timeout)))
-    except dbconstants.AppScaleDBConnectionError:
-      self.logger.exception('DB connection error during commit')
-      raise gen.Return(
-        ('', datastore_pb.Error.INTERNAL_ERROR,
-         'Datastore connection error on Commit request.'))
-    except dbconstants.ConcurrentModificationException as error:
-      raise gen.Return(
-        ('', datastore_pb.Error.CONCURRENT_TRANSACTION, str(error)))
-    except (dbconstants.TooManyGroupsException,
-            dbconstants.BadRequest) as error:
-      raise gen.Return(('', datastore_pb.Error.BAD_REQUEST, str(error)))
-
-    commitres_pb = datastore_pb.CommitResponse()
-    raise gen.Return((commitres_pb.Encode(), 0, ''))
-
   def rollback_transaction(self, app_id, txid):
     """ Handles the rollback phase of a transaction.
 

--- a/AppDB/test/unit/test_datastore_server.py
+++ b/AppDB/test/unit/test_datastore_server.py
@@ -281,26 +281,6 @@ class TestDatastoreServer(testing.AsyncTestCase):
     })
     self.assertEqual(fetched[1], ['test\x00blah\x00test_kind:bob\x01'])
 
-  @testing.gen_test
-  def test_commit_transaction(self):
-    db_batch = flexmock()
-    db_batch.should_receive('valid_data_version_sync').and_return(True)
-
-    zk_client = flexmock()
-    zk_client.should_receive('add_listener')
-
-    zookeeper = flexmock(handle=zk_client)
-    transaction_manager = flexmock(
-      delete_transaction_id=lambda project, txid: None)
-    dd = DatastoreDistributed(db_batch, transaction_manager, zookeeper)
-    flexmock(dd).should_receive('apply_txn_changes').and_return(ASYNC_NONE)
-    commit_request = datastore_pb.Transaction()
-    commit_request.set_handle(123)
-    commit_request.set_app("aaa")
-    http_request = commit_request.Encode()
-    result = yield dd.commit_transaction("app_id", http_request)
-    self.assertEquals(result, (datastore_pb.CommitResponse().Encode(), 0, ""))
-
   def test_rollback_transcation(self):
     db_batch = flexmock()
     db_batch.should_receive('valid_data_version_sync').and_return(True)


### PR DESCRIPTION
Parsing the commit request and populating the response should happen at the protobuffer interface level rather than in DatastoreDistributed.