### PR TITLE
Add B* instance classes

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/constants.py
+++ b/AdminServer/appscale/admin/instance_manager/constants.py
@@ -117,10 +117,17 @@ PYTHON_APPSERVER = os.path.join(APPSCALE_HOME, 'AppServer',
                                 'dev_appserver.py')
 
 # A mapping of instance classes to memory limits in MB.
-INSTANCE_CLASSES = {'F1': 128,
-                    'F2': 256,
-                    'F4': 512,
-                    'F4_1G': 1024}
+INSTANCE_CLASSES = {
+    'F1': 128,
+    'F2': 256,
+    'F4': 512,
+    'F4_1G': 1024,
+    'B1': 128,
+    'B2': 256,
+    'B4': 512,
+    'B4_1G': 1024,
+    'B8': 1024,
+}
 
 # The amount of seconds to wait for an application to start up.
 START_APP_TIMEOUT = 180

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -502,10 +502,17 @@ class Djinn
   ].freeze
 
   # The amount of memory in MB for each instance class.
-  INSTANCE_CLASSES = { F1: 128,
-                       F2: 256,
-                       F4: 512,
-                       F4_1G: 1024 }.freeze
+  INSTANCE_CLASSES = {
+    F1: 128,
+    F2: 256,
+    F4: 512,
+    F4_1G: 1024,
+    B1: 128,
+    B2: 256,
+    B4: 512,
+    B4_1G: 1024,
+    B8: 1024,
+  }.freeze
 
   # Creates a new Djinn, which holds all the information needed to configure
   # and deploy all the services on this node.


### PR DESCRIPTION
This pull request adds memory sizes for the B* instance classes. This memory size metadata is not typically used as tools do not currently propagate the instance class.