### PR TITLE
Configure open file limit for monit

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -161,6 +161,11 @@ EOF
     # On distros with systemd, the open file limit must be adjusted for each
     # service.
     if which systemctl > /dev/null && [ "${IN_DOCKER}" != "yes" ]; then
+        mkdir -p /etc/systemd/system/monit.service.d
+        cat <<EOF > /etc/systemd/system/monit.service.d/override.conf
+[Service]
+LimitNOFILE=200000
+EOF
         mkdir -p /etc/systemd/system/nginx.service.d
         cat <<EOF > /etc/systemd/system/nginx.service.d/override.conf
 [Service]


### PR DESCRIPTION
Configure the open file limit for monit using the same approach we use for nginx.

Fixes #3023