### PR TITLE
Datastore statistics timestamp second resolution

### DIFF
--- a/AppDB/appscale/datastore/groomer.py
+++ b/AppDB/appscale/datastore/groomer.py
@@ -1129,7 +1129,7 @@ class DatastoreGroomer(threading.Thread):
 
     self.update_groomer_state([])
 
-    timestamp = datetime.datetime.utcnow()
+    timestamp = datetime.datetime.utcnow().replace(microsecond=0)
 
     self.update_statistics(timestamp)
     self.update_namespaces(timestamp)


### PR DESCRIPTION
Clear the sub-second components of the timestamp for datastore statistics.

This is as-per GAE and expected by some clients, e.g.:

https://github.com/apache/beam/blob/247e93ef7fbe87dbb1cd82a0ce6b2e6aa5254f7c/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java#L368