### PR TITLE
Ensure application instances logger tag is 32 characters or less

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/instance_manager.py
+++ b/AdminServer/appscale/admin/instance_manager/instance_manager.py
@@ -1,4 +1,5 @@
 """ Fulfills AppServer instance assignments from the scheduler. """
+import hashlib
 import logging
 import math
 import json
@@ -210,6 +211,9 @@ class InstanceManager(object):
     logger.info("Start command: " + str(start_cmd))
     logger.info("Environment variables: " + str(env_vars))
 
+    base_version = version.revision_key.rsplit(VERSION_PATH_SEPARATOR, 1)[0]
+    log_tag = "app_{}".format(hashlib.sha1(base_version).hexdigest()[:28])
+
     monit_app_configuration.create_config_file(
       watch,
       start_cmd,
@@ -219,7 +223,9 @@ class InstanceManager(object):
       max_memory,
       self._syslog_server,
       check_port=True,
-      kill_exceeded_memory=True)
+      kill_exceeded_memory=True,
+      log_tag=log_tag,
+    )
 
     full_watch = '{}-{}'.format(watch, port)
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4764,9 +4764,11 @@ HOSTS
     rsyslog_prop = ':syslogtag'
     rsyslog_version = Gem::Version.new(`rsyslogd -v`.split[1].chomp(','))
     rsyslog_prop = ':programname' if rsyslog_version < Gem::Version.new('8.12')
+    rsyslog_propval = "app_#{Digest::SHA1.hexdigest(version_key)[0...28]}"
 
     app_log_template = HelperFunctions.read_file(RSYSLOG_TEMPLATE_LOCATION)
     app_log_config = app_log_template.gsub('{property}', rsyslog_prop)
+    app_log_config = app_log_config.gsub('{property_value}', rsyslog_propval)
     app_log_config = app_log_config.gsub('{version}', version_key)
     unless existing_app_log_config == app_log_config
       Djinn.log_info("Installing log configuration for #{version_key}.")

--- a/common/appscale/common/templates/rsyslog-app.conf
+++ b/common/appscale/common/templates/rsyslog-app.conf
@@ -1,5 +1,5 @@
 # Log application output to its own file.
-{property}, isequal, "app___{version}" /var/log/appscale/app___{version}.log;APPSCALE
+{property}, isequal, "{property_value}" /var/log/appscale/app___{version}.log;APPSCALE
 
 # The following is to prevent further processing.
-& ~
+& stop


### PR DESCRIPTION
The logger tag is updated to use a truncated sha-1 hash derived from the application, service and version.

The `logger` command would exit with an error if the tag was too long, causing application errors. The hash is used when logging (as per monit config in the `start program` line) and then in the rsyslogd configuration that routes the log messages to the version specific log file.