### PR TITLE
Allow push queue bucket size and max concurrent requests parameters

### DIFF
--- a/AppTaskQueue/appscale/taskqueue/constants.py
+++ b/AppTaskQueue/appscale/taskqueue/constants.py
@@ -70,7 +70,9 @@ SUPPORTED_PUSH_QUEUE_FIELDS = {
     'min_backoff_seconds': non_negative_int,
     'max_backoff_seconds': non_negative_int,
     'max_doublings': non_negative_int
-  }
+  },
+  'bucket_size': non_negative_int,
+  'max_concurrent_requests': non_negative_int,
 }
 
 SHUTTING_DOWN_TIMEOUT = 10  # Limit time for finishing request


### PR DESCRIPTION
With this change we will allow, but ignore, the queue rate options for bucket size and maximum concurrent requests. 

These options are expected to be commonly used and we should not require users remove them in order to deploy their application.

A related change will be made to appscale tools to warn users about the unsupported options.