### PR TITLE
Datastore entity locking resolve deadlock retry syntax

### DIFF
--- a/AppDB/appscale/datastore/zkappscale/entity_lock.py
+++ b/AppDB/appscale/datastore/zkappscale/entity_lock.py
@@ -203,7 +203,7 @@ class EntityLock(object):
         # resolve deadlocks.
         if current_txid > child_txid:
           # TODO: Implement a more graceful deadlock detection.
-          self.client.retry(self._delete_nodes(self.nodes))
+          self.client.retry(self._delete_nodes, self.nodes)
           raise ForceRetryError()
 
   def _inner_acquire(self):


### PR DESCRIPTION
Fix kazoo client retry call which was causing errors such as:

```
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/zkappscale/entity_lock.py", line 269, in _inner_acquire
    self._resolve_deadlocks(children_list)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/zkappscale/entity_lock.py", line 206, in _resolve_deadlocks
    self.client.retry(self._delete_nodes(self.nodes))
  File "/usr/local/lib/python2.7/dist-packages/kazoo/client.py", line 285, in _retry
    return self._retry.copy()(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/kazoo/retry.py", line 120, in __call__
    return func(*args, **kwargs)
TypeError: 'NoneType' object is not callable
```

due to the (`None`) result of the inline invocation being passed to retry rather than the function and argument list.