### PR TITLE
Async coroutine retry for datastore large batches

### DIFF
--- a/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
+++ b/AppDB/appscale/datastore/cassandra_env/cassandra_interface.py
@@ -11,7 +11,7 @@ import time
 import uuid
 
 from appscale.common import appscale_info
-from appscale.common.async_retrying import retry_coroutine
+from appscale.common.async_retrying import retry_raw_coroutine
 from appscale.common.constants import SCHEMA_CHANGE_TIMEOUT
 from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
 import cassandra
@@ -492,7 +492,7 @@ class DatastoreProxy(AppDBInterface):
 
     # Since failing after this point is expensive and time consuming, retry
     # operations to make a failure less likely.
-    custom_retry_coroutine = retry_coroutine(
+    custom_retry_coroutine = retry_raw_coroutine(
       backoff_threshold=5, retrying_timeout=10,
       retry_on_exception=dbconstants.TRANSIENT_CASSANDRA_ERRORS)
 

--- a/common/appscale/common/async_retrying.py
+++ b/common/appscale/common/async_retrying.py
@@ -18,22 +18,23 @@ from appscale.common.retrying import (
 logger = logging.getLogger(__name__)
 
 
-class _RetryCoroutine(_Retry):
+class _RetryRawCoroutine(_Retry):
 
-  def wrap(self, generator):
-    """ Wraps python generator with tornado coroutine and retry mechanism
-    which runs up to max_retries attempts with exponential backoff
+  def wrap(self, coroutine):
+    """ Wraps a tornado coroutine with a retry mechanism which runs up to
+    max_retries attempts with exponential backoff
     (sleep = backoff_multiplier * backoff_base**X).
 
     Args:
-      generator: python generator to wrap.
+      coroutine: tornado coroutine to wrap.
     Returns:
       A wrapped coroutine.
     """
+    return self._wrap(coroutine, coroutine)
 
-    coroutine = gen.coroutine(generator)
+  def _wrap(self, coroutine, wrapped):
 
-    @functools.wraps(generator)
+    @functools.wraps(wrapped)
     @gen.coroutine
     def wrapped(*args, **kwargs):
       check_exception = self.retry_on_exception
@@ -93,6 +94,32 @@ class _RetryCoroutine(_Retry):
       raise gen.Return(result)
 
     return wrapped
+
+
+class _RetryCoroutine(_RetryRawCoroutine):
+
+  def wrap(self, generator):
+    """ Wraps python generator with tornado coroutine and retry mechanism
+    which runs up to max_retries attempts with exponential backoff
+    (sleep = backoff_multiplier * backoff_base**X).
+
+    Args:
+      generator: python generator to wrap.
+    Returns:
+      A wrapped coroutine.
+    """
+    coroutine = gen.coroutine(generator)
+    return _RetryRawCoroutine._wrap(self, coroutine, generator)
+
+
+retry_raw_coroutine = _RetryRawCoroutine(
+    backoff_base=DEFAULT_BACKOFF_BASE,
+    backoff_multiplier=DEFAULT_BACKOFF_MULTIPLIER,
+    backoff_threshold=DEFAULT_BACKOFF_THRESHOLD,
+    max_retries=DEFAULT_MAX_RETRIES,
+    retrying_timeout=DEFAULT_RETRYING_TIMEOUT,
+    retry_on_exception=DEFAULT_RETRY_ON_EXCEPTION
+)
 
 retry_coroutine = _RetryCoroutine(
   backoff_base=DEFAULT_BACKOFF_BASE,


### PR DESCRIPTION
Add a `retry_raw_coroutine` for retries where there is already a coroutine available. This is used by the cassandra interface for large batches. Without this change errors such as:

```
2019-03-30 01:01:17,185 ERROR concurrent.py:124 Future exception was never retrieved: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/cassandra_env/large_batch.py", line 183, in set_applied
    raise FailedBatch(str(error))
FailedBatch: Batch for appscaledashboard:22497 not found
```
could occur due to the original coroutine not being yielded and completed before processing continued.