### PR TITLE
Fix python detection in taskqueue tests

### DIFF
--- a/AppTaskQueue/test/suites/run-e2e-tests.sh
+++ b/AppTaskQueue/test/suites/run-e2e-tests.sh
@@ -176,16 +176,18 @@ log "=================================================="
 PYTHON=
 for PYTHON_EXECUTABLE in python python3 python3.6 python3.7
 do
-    # Get exact version of python interpreter
+    # Skip python executables that don't exist in PATH
+    if ! which ${PYTHON_EXECUTABLE}; then
+        continue
+    fi
+
     possible_python=$(which ${PYTHON_EXECUTABLE})
-    if [ -n "$possible_python" ]; then
-        HAVE=$(${possible_python} --version 2>&1 | awk '{ print $2 }')
-        # Stop if version is new enough
-        if echo -e "${HAVE}\n3.6" | sort -V | head -1 | grep "^3.6$"
-        then
-            PYTHON=${possible_python}
-            break
-        fi
+    HAVE=$(${possible_python} --version 2>&1 | awk '{ print $2 }')
+    # Stop if version is new enough
+    if echo -e "${HAVE}\n3.6" | sort -V | head -1 | grep "^3.6$"
+    then
+        PYTHON=${possible_python}
+        break
     fi
 done
 if [ -z "${PYTHON}" ]

--- a/AppTaskQueue/test/suites/run-e2e-tests.sh
+++ b/AppTaskQueue/test/suites/run-e2e-tests.sh
@@ -177,14 +177,14 @@ PYTHON=
 for PYTHON_EXECUTABLE in python python3 python3.6 python3.7
 do
     # Skip python executables that don't exist in PATH
-    if ! which ${PYTHON_EXECUTABLE}; then
+    if ! which ${PYTHON_EXECUTABLE} &> /dev/null; then
         continue
     fi
 
     possible_python=$(which ${PYTHON_EXECUTABLE})
     HAVE=$(${possible_python} --version 2>&1 | awk '{ print $2 }')
     # Stop if version is new enough
-    if echo -e "${HAVE}\n3.6" | sort -V | head -1 | grep "^3.6$"
+    if echo -e "${HAVE}\n3.6" | sort -V | head -1 | grep -q "^3.6$"
     then
         PYTHON=${possible_python}
         break

--- a/AppTaskQueue/test/suites/run-e2e-tests.sh
+++ b/AppTaskQueue/test/suites/run-e2e-tests.sh
@@ -193,6 +193,8 @@ then
     log "Python 3.6 or greater was not found." "ERROR"
     log "Please install it and try again."
     exit 1
+else
+    log "Using python: ${PYTHON} version: ${HAVE}"
 fi
 
 cd "${E2E_TEST_DIR}"

--- a/AppTaskQueue/test/suites/run-e2e-tests.sh
+++ b/AppTaskQueue/test/suites/run-e2e-tests.sh
@@ -177,12 +177,15 @@ PYTHON=
 for PYTHON_EXECUTABLE in python python3 python3.6 python3.7
 do
     # Get exact version of python interpreter
-    HAVE=$(${PYTHON_EXECUTABLE} --version 2> null | awk '{ print $2 }')
-    # Stop if version is new enough
-    if echo -e "${HAVE}\n3.6" | sort -V | head -1 | grep "^3.6$"
-    then
-        PYTHON=$(which ${PYTHON_EXECUTABLE})
-        break
+    possible_python=$(which ${PYTHON_EXECUTABLE})
+    if [ -n "$possible_python" ]; then
+        HAVE=$(${possible_python} --version 2>&1 | awk '{ print $2 }')
+        # Stop if version is new enough
+        if echo -e "${HAVE}\n3.6" | sort -V | head -1 | grep "^3.6$"
+        then
+            PYTHON=${possible_python}
+            break
+        fi
     fi
 done
 if [ -z "${PYTHON}" ]

--- a/AppTaskQueue/test/suites/run-load-test.sh
+++ b/AppTaskQueue/test/suites/run-load-test.sh
@@ -319,12 +319,17 @@ log "=============================================="
 PYTHON=
 for PYTHON_EXECUTABLE in python python3 python3.6 python3.7
 do
-    # Get exact version of python interpreter
-    HAVE=$(${PYTHON_EXECUTABLE} --version 2> null | awk '{ print $2 }')
+    # Skip python executables that don't exist in PATH
+    if ! which ${PYTHON_EXECUTABLE} &> /dev/null; then
+        continue
+    fi
+
+    possible_python=$(which ${PYTHON_EXECUTABLE})
+    HAVE=$(${possible_python} --version 2>&1 | awk '{ print $2 }')
     # Stop if version is new enough
-    if echo -e "${HAVE}\n3.6" | sort -V | head -1 | grep "^3.6$"
+    if echo -e "${HAVE}\n3.6" | sort -V | head -1 | grep -q "^3.6$"
     then
-        PYTHON=$(which ${PYTHON_EXECUTABLE})
+        PYTHON=${possible_python}
         break
     fi
 done
@@ -333,6 +338,8 @@ then
     log "Python 3.6 or greater was not found." "ERROR"
     log "Please install it and try again."
     exit 1
+else
+    log "Using python: ${PYTHON} version: ${HAVE}"
 fi
 
 cd "${LOAD_TEST_DIR}"


### PR DESCRIPTION
**Technical Problem Description**
This line was writing output to the **file** null for stderr.
Python 2.x --version writes **only** to stderr.
Python 3.x --version writes **only** to stdout. 
```
HAVE=$(${PYTHON_EXECUTABLE} --version 2> null | awk '{ print $2 }')
```
This caused any python 2 versions to make the $HAVE variable an empty string. Which technically works...but is not correct.

**Summary of changes**
- dups stderr to stdout and pipe to awk and does not create the 'null' file.
- Skips executables that don't exist on the system. Previously $HAVE would contain unexpected output if the executable (python3.7 at the time) didn't exist.
- Added log message indicating which python version we picked up from the system.

**Demo**
```
2019-04-03 22:35:33: INFO 
2019-04-03 22:35:33: INFO ==================================================
2019-04-03 22:35:33: INFO === Prepare virtualenv for running test script ===
2019-04-03 22:35:33: INFO ==================================================
2019-04-03 22:35:33: INFO Using python: /home/jenkins/.local/bin//python3.7 version: 3.7.3
```