### PR TITLE
Datastore service index manager zookeeper callback state parameter

### DIFF
--- a/AppDB/appscale/datastore/index_manager.py
+++ b/AppDB/appscale/datastore/index_manager.py
@@ -234,8 +234,12 @@ class IndexManager(object):
       '/appscale/projects', self._update_projects_sync)
     IOLoop.instance().add_callback(persistent_update_projects, project_ids)
 
-  def _handle_connection_change(self):
-    """ Notifies the admin lock holder when the connection changes. """
+  def _handle_connection_change(self, state):
+    """ Notifies the admin lock holder when the connection changes.
+
+    Args:
+      state: The new connection state.
+    """
     IOLoop.current().add_callback(self._wake_event.set)
 
   @gen.coroutine


### PR DESCRIPTION
The datastore server logs currently show errors such as:

```
2019-04-25 18:16:49,610 INFO client.py:480 Zookeeper connection established, state: CONNECTED 
2019-04-25 18:16:49,613 ERROR client.py:459 Error in connection state listener 
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/kazoo/client.py", line 455, in _make_state_change
    remove = listener(state)
TypeError: _handle_connection_change() takes exactly 1 argument (2 given)
```

on Zookeeper connection change. The index manager listener is missing a parameter in the callback function.