### PR TITLE
Clear monit environment variables before exec

### DIFF
--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -168,7 +168,7 @@ CONFIG
                   '--background',
                   '--make-pidfile',
                   '--pidfile', pidfile,
-                  '--startas', "#{bash} -- -c '#{bash_exec}'"]
+                  '--startas', "#{bash} -- -c 'unset \"${!MONIT_@}\"; #{bash_exec}'"]
 
     stop_cmd = "#{start_stop_daemon} --stop --pidfile #{pidfile} " \
                "--retry=TERM/20/KILL/5 && #{rm} #{pidfile}"

--- a/common/appscale/common/monit_app_configuration.py
+++ b/common/appscale/common/monit_app_configuration.py
@@ -83,7 +83,7 @@ def create_config_file(watch, start_cmd, pidfile, port=None, env_vars=None,
     '--start',
     '--background',
     '--pidfile', pidfile,
-    '--startas', "{} -- -c '{}'".format(bash, bash_exec)
+    '--startas', "{} -- -c 'unset \"${{!MONIT_@}}\"; {}'".format(bash, bash_exec)
   ])
   stop_line = '{} --watch {}'.format(stop_instance, process_name)
 


### PR DESCRIPTION
This cleans up the environment for application instances and for any other services started using bash.

Example monit environment variables for dashboard (to be removed):

```
MONIT_DATE=Tue, 30 Apr 2019 22:39:57
MONIT_DESCRIPTION=Started
MONIT_EVENT=Started
MONIT_HOST=appscale-image0
MONIT_PROCESS_CHILDREN=0
MONIT_PROCESS_CPU_PERCENT=0.0
MONIT_PROCESS_MEMORY=0
MONIT_PROCESS_PID=-1
MONIT_SERVICE=app___appscaledashboard_default_v1_1556663905337-20000
```
non-monit environment variables:

```
APPNAME=appscaledashboard
APPSCALE_HOME=/root/appscale
GOMAXPROCS=4
LANG=en_US.UTF-8
MY_IP_ADDRESS=192.168.100.219
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PWD=/
PYTHON_LIB=/root/appscale/AppServer/
SHLVL=0
_SYSTEMCTL_SKIP_REDIRECT=true
```