### PR TITLE
Remove haproxy statistics page

### DIFF
--- a/AppController/lib/haproxy.rb
+++ b/AppController/lib/haproxy.rb
@@ -313,15 +313,6 @@ defaults
   # The maximum inactivity time allowed for a server.
   timeout server #{HAPROXY_SERVER_TIMEOUT}s
 
-  # Enable the statistics page
-  stats enable
-  stats uri     /haproxy?stats
-  stats realm   Haproxy\ Statistics
-  stats auth    haproxy:stats
-
-  # Create a monitorable URI which returns a 200 if haproxy is up
-  # monitor-uri /haproxy?monitor
-
   # Amount of time after which a health check is considered to have timed out
   timeout check 5000
 

--- a/AppDashboard/setup/haproxy.cfg
+++ b/AppDashboard/setup/haproxy.cfg
@@ -64,15 +64,6 @@ defaults
   # a 404. This is useful for rolling restarts.
 #  http-check disable-on-404
 
-  # Enable the statistics page 
-  stats enable
-  stats uri     /haproxy?stats
-  stats realm   Haproxy\ Statistics
-  stats auth    haproxy:stats
-
-  # Create a monitorable URI which returns a 200 if haproxy is up
-  monitor-uri /haproxy?monitor
-
   # Specify the HTTP method and URI to check to ensure the server is alive.
   # see http://github.com/jnewland/pulse
   #option httpchk GET /pulse


### PR DESCRIPTION
Remove remaining unused haproxy statistics pages with hard-coded credentials.