### PR TITLE
Support for autoscaling  idle instances

### DIFF
--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -1028,10 +1028,10 @@ class VersionHandler(BaseVersionHandler):
       scheduler_fields['maxInstances'] = max_instances
 
     if min_idle_instances is not None:
-      scheduler_fields['minIdleInstances'] = min_idle_instances
+      new_fields['automaticScaling']['minIdleInstances'] = min_idle_instances
 
     if max_idle_instances is not None:
-      scheduler_fields['maxIdleInstances'] = max_idle_instances
+      new_fields['automaticScaling']['maxIdleInstances'] = max_idle_instances
 
     yield self.thread_pool.submit(self.version_update_lock.acquire)
     try:
@@ -1149,16 +1149,14 @@ class VersionHandler(BaseVersionHandler):
         project_id, service_id, version_id, new_http_port, new_https_port)
 
     automatic_scaling = version.get('automaticScaling', {})
+    new_min_idle_instances = automatic_scaling.get('minIdleInstances', None)
+    new_max_idle_instances = automatic_scaling.get('maxIdleInstances', None)
     standard_settings = automatic_scaling.get(
       'standardSchedulerSettings', {})
     if ('minInstances' in standard_settings or
-        'maxInstances' in standard_settings or
-        'minIdleInstances' in standard_settings or
-        'maxIdleInstances' in standard_settings):
+        'maxInstances' in standard_settings)
       new_min_instances = standard_settings.get('minInstances', None)
       new_max_instances = standard_settings.get('maxInstances', None)
-      new_min_idle_instances = standard_settings.get('minIdleInstances', None)
-      new_max_idle_instances = standard_settings.get('maxIdleInstances', None)
       version = yield self.update_scaling_for_version(
         project_id, service_id, version_id, new_min_instances,
         new_max_instances,new_min_idle_instances, new_max_idle_instances)

--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -1015,7 +1015,7 @@ class VersionHandler(BaseVersionHandler):
       min_instances: An integer specifying minimum instances.
       max_instances: An integer specifying maximum instances.
       min_idle_instances: An integer specifying minimum idle instances.
-      max__idle_instances: An integer specifying maximum idle instances.
+      max_idle_instances: An integer specifying maximum idle instances.
     Returns:
       A dictionary containing completed version details.
     """
@@ -1154,7 +1154,7 @@ class VersionHandler(BaseVersionHandler):
     standard_settings = automatic_scaling.get(
       'standardSchedulerSettings', {})
     if ('minInstances' in standard_settings or
-        'maxInstances' in standard_settings)
+        'maxInstances' in standard_settings):
       new_min_instances = standard_settings.get('minInstances', None)
       new_max_instances = standard_settings.get('maxInstances', None)
       version = yield self.update_scaling_for_version(

--- a/AdminServer/appscale/admin/instance_manager/instance_manager.py
+++ b/AdminServer/appscale/admin/instance_manager/instance_manager.py
@@ -660,7 +660,8 @@ class InstanceManager(object):
       controller_state: A dictionary containing controller state.
     """
     def version_assignments(data):
-      return [int(server.split(':')[1]) for server in data['appservers']
+      active_list = data['appservers'] + data['idle']
+      return [int(server.split(':')[1]) for server in active_list
               if server.split(':')[0] == self._private_ip]
 
     return {

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -5221,12 +5221,12 @@ HOSTS
     # running AppServers, its max allowed threaded connections and current
     # handled sessions.
     # Formula: Load = Current Sessions / (No of AppServers * Max conn)
-    current_load = scale_session.to_f / (num_appservers * concurrency)
+    current_load = scale_sessions.to_f / (num_appservers * concurrency)
 
     # Calculates the additional number of AppServers needed to be scaled up in
     # order achieve the desired load.
     # Formula: No of AppServers = Current sessions / (Load * Max conn)
-    desired_appservers = scale_session.to_f / (DESIRED_LOAD * concurrency)
+    desired_appservers = scale_sessioasn.to_f / (DESIRED_LOAD * concurrency)
 
     if current_load >= MAX_LOAD_THRESHOLD
       if num_appservers == max
@@ -5498,8 +5498,8 @@ HOSTS
 
     # Now let's make sure we have enough idle instances as per the
     # application request.
-    if  min_idle > @app_info_map[vesion_key]['idle'].length
-      min_idle - @app_info_map[vesion_key]['idle'].length.downto(1) { |delta|
+    if  min_idle > @app_info_map[version_key]['idle'].length
+      min_idle - @app_info_map[version_key]['idle'].length.downto(1) { |delta|
         if available_hosts.empty?
           Djinn.log_info("No compute node is available to host idle " \
                          "instances for #{version_key}.")

--- a/AppController/lib/haproxy.rb
+++ b/AppController/lib/haproxy.rb
@@ -38,9 +38,6 @@ module HAProxy
   BASE_CONFIG_FILE = File.join(HAPROXY_PATH, "app-base.#{CONFIG_EXTENSION}")
   PIDFILE = '/var/run/app-haproxy.pid'.freeze
 
-  # Maximum AppServer threaded connections
-  MAX_APPSERVER_CONN = 7
-
   # The first port that haproxy will bind to for App Engine apps.
   START_PORT = 10000
 


### PR DESCRIPTION
Added support for min_idle_instances. The parameters max_idle_instances and max_concurrent_requets are recognized, but not acted upon yet.