### PR TITLE
Avoid using localhost when waiting for service

### DIFF
--- a/AdminServer/appscale/admin/service_manager.py
+++ b/AdminServer/appscale/admin/service_manager.py
@@ -282,7 +282,7 @@ class DatastoreServer(Server):
     Raises:
       StartTimeout if start time exceeds given timeout.
     """
-    server_url = 'http://localhost:{}'.format(self.port)
+    server_url = 'http://{}:{}'.format(options.private_ip, self.port)
     start_time = time.time()
     try:
       while True:


### PR DESCRIPTION
This avoids an extra lookup and works around an issue where an HTTP client in our docker container is unable to make a request to `localhost`.