### PR TITLE
Use output of appscale-admin summary

### DIFF
--- a/AppDB/appscale/datastore/backup/cassandra_backup.py
+++ b/AppDB/appscale/datastore/backup/cassandra_backup.py
@@ -12,6 +12,7 @@ from appscale.common import appscale_info
 from appscale.common import appscale_utils
 from appscale.common import monit_interface
 from appscale.common.constants import APPSCALE_DATA_DIR
+from appscale.common.constants import MonitStates
 from appscale.common.constants import SCHEMA_CHANGE_TIMEOUT
 from subprocess import CalledProcessError
 from . import backup_recovery_helper
@@ -192,19 +193,21 @@ def restore_data(path, keyname, force=False):
 
   for db_ip in db_ips:
     logger.info('Stopping Cassandra on {}'.format(db_ip))
-    summary = appscale_utils.ssh(db_ip, keyname, 'monit summary',
+    summary = appscale_utils.ssh(db_ip, keyname, 'appscale-admin summary',
                                  method=subprocess.check_output)
-    status = utils.monit_status(summary, CASSANDRA_MONIT_WATCH_NAME)
+    status_line = next((line for line in summary.split('\n')
+                        if line.startswith(CASSANDRA_MONIT_WATCH_NAME)), '')
     retries = SERVICE_RETRIES
-    while status != utils.MonitStates.UNMONITORED:
+    while MonitStates.UNMONITORED not in status_line:
       appscale_utils.ssh(
         db_ip, keyname,
         'appscale-stop-service {}'.format(CASSANDRA_MONIT_WATCH_NAME),
         method=subprocess.call)
       time.sleep(3)
-      summary = appscale_utils.ssh(db_ip, keyname, 'monit summary',
+      summary = appscale_utils.ssh(db_ip, keyname, 'appscale-admin summary',
                                    method=subprocess.check_output)
-      status = utils.monit_status(summary, CASSANDRA_MONIT_WATCH_NAME)
+      status_line = next((line for line in summary.split('\n')
+                          if line.startswith(CASSANDRA_MONIT_WATCH_NAME)), '')
       retries -= 1
       if retries < 0:
         raise BRException('Unable to stop Cassandra')
@@ -224,16 +227,17 @@ def restore_data(path, keyname, force=False):
 
     logger.info('Starting Cassandra on {}'.format(db_ip))
     retries = SERVICE_RETRIES
-    status = utils.MonitStates.UNMONITORED
-    while status != utils.MonitStates.RUNNING:
+    status_line = MonitStates.UNMONITORED
+    while MonitStates.RUNNING not in status_line:
       appscale_utils.ssh(
         db_ip, keyname,
         'appscale-start-service {}'.format(CASSANDRA_MONIT_WATCH_NAME),
         method=subprocess.call)
       time.sleep(3)
-      summary = appscale_utils.ssh(db_ip, keyname, 'monit summary',
+      summary = appscale_utils.ssh(db_ip, keyname, 'appscale-admin summary',
                                    method=subprocess.check_output)
-      status = utils.monit_status(summary, CASSANDRA_MONIT_WATCH_NAME)
+      status_line = next((line for line in summary.split('\n')
+                          if line.startswith(CASSANDRA_MONIT_WATCH_NAME)), '')
       retries -= 1
       if retries < 0:
         raise BRException('Unable to start Cassandra')

--- a/AppDB/appscale/datastore/backup/utils.py
+++ b/AppDB/appscale/datastore/backup/utils.py
@@ -8,25 +8,5 @@ class ExitCodes(object):
   SUCCESS = 0
 
 
-class MonitStates(object):
-  RUNNING = 'Running'
-  UNMONITORED = 'Not monitored'
-
-
 class ServiceException(Exception):
   pass
-
-
-def monit_status(summary, service):
-  """ Retrieves the status of a Monit service.
-
-  Args:
-    summary: A string containing the output of 'monit summary'.
-    service: A string containing the name of a service.
-  Raises:
-    ServiceException if summary does not include service.
-  """
-  for line in summary.split('\n'):
-    if service in line:
-      return ' '.join(line.split()[2:])
-  raise ServiceException('Unable to find Monit entry for {}'.format(service))

--- a/AppDB/test/unit/test_cassandra_backup.py
+++ b/AppDB/test/unit/test_cassandra_backup.py
@@ -85,12 +85,10 @@ class TestCassandraBackup(unittest.TestCase):
       method=subprocess.call).and_return(0)
 
     flexmock(appscale_utils).should_receive('ssh').with_args(
-      re.compile('^192.*'), keyname, 'monit summary',
-      method=subprocess.check_output).and_return('summary output')
-    status_outputs = (['Not monitored'] * len(db_ips)) +\
-                     (['Running'] * len(db_ips))
-    flexmock(utils).should_receive('monit_status').\
-      and_return(*status_outputs).one_by_one()
+      re.compile('^192.*'), keyname, 'appscale-admin summary',
+      method=subprocess.check_output).and_return(
+      ['cassandra unmonitored'] * len(db_ips) +
+      ['cassandra running'] * len(db_ips)).one_by_one()
 
     flexmock(appscale_utils).should_receive('ssh').with_args(
       re.compile('^192.*'), keyname, re.compile('^find.* -exec rm .*'))


### PR DESCRIPTION
The output format of `monit summary` changed between xenial and bionic. The output of `appscale-admin summary` is a consistent alternative.