### PR TITLE
Blobstore application id header and relative success url

### DIFF
--- a/AppController/lib/nginx.rb
+++ b/AppController/lib/nginx.rb
@@ -185,6 +185,12 @@ module Nginx
     if language == 'java'
       java_blobstore_redirection = <<JAVA_BLOBSTORE_REDIRECTION
 location ~ /_ah/upload/.* {
+      proxy_set_header      X-Appengine-Inbound-Appid #{version_key.split('_').first};
+      proxy_set_header      X-Real-IP $remote_addr;
+      proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header      X-Forwarded-Proto $scheme;
+      proxy_set_header      X-Forwarded-Ssl $ssl;
+      proxy_set_header      Host $http_host;
       proxy_pass            http://#{HelperFunctions::GAE_PREFIX}#{version_key}_blobstore;
       proxy_connect_timeout 600;
       proxy_read_timeout    600;

--- a/AppDB/appscale/datastore/scripts/blobstore.py
+++ b/AppDB/appscale/datastore/scripts/blobstore.py
@@ -26,6 +26,7 @@ import tornado.ioloop
 import tornado.web
 import urllib
 import urllib2
+import urlparse
 
 from appscale.appcontroller_client import AppControllerClient
 from appscale.common import appscale_info
@@ -207,7 +208,7 @@ class Application(tornado.web.Application):
   def __init__(self):
     """ Constructor. """
     handlers = [
-      (r"/_ah/upload/(.*)/(.*)", UploadHandler),
+      (r"/_ah/upload/(.*)", UploadHandler),
       (r"/", HealthCheck)
     ]   
     tornado.web.Application.__init__(self, handlers)
@@ -245,13 +246,13 @@ class HealthCheck(tornado.web.RequestHandler):
  
 class UploadHandler(tornado.web.RequestHandler):
   """ Tornado handler for uploads. """
-  def post(self, app_id="blob", session_id = "session"):
+  def post(self, session_id = "session"):
     """ Handler a post request from a user uploading a blob. 
     
     Args:
-      app_id: The application triggering the upload.
       session_id: Authentication token to validate the upload.
     """
+    app_id = self.request.headers.get('X-Appengine-Inbound-Appid', '')
     global datastore_path
     db = datastore_distributed.DatastoreDistributed(
       app_id, datastore_path)
@@ -267,6 +268,8 @@ class UploadHandler(tornado.web.RequestHandler):
       return
 
     success_path = blob_session["success_path"]
+    if success_path.startswith('/'):
+      success_path = urlparse.urljoin(self.request.full_url(), success_path)
 
     server_host = success_path[:success_path.rfind("/", 3)]
     if server_host.startswith("http://"):
@@ -440,7 +443,7 @@ def main():
   setup_env()
 
   http_server = tornado.httpserver.HTTPServer(
-    Application(), max_buffer_size=MAX_REQUEST_BUFF_SIZE)
+    Application(), max_buffer_size=MAX_REQUEST_BUFF_SIZE, xheaders=True)
 
   http_server.listen(args.port)
 

--- a/AppServer_Java/src/com/google/appengine/api/blobstore/dev/LocalBlobstoreService.java
+++ b/AppServer_Java/src/com/google/appengine/api/blobstore/dev/LocalBlobstoreService.java
@@ -105,7 +105,7 @@ public final class LocalBlobstoreService extends AbstractLocalRpcService
          */
         BlobstoreServicePb.CreateUploadURLResponse response = new BlobstoreServicePb.CreateUploadURLResponse();
         String nginxPort = ResourceLoader.getNginxPort();
-        String url = "http://" + System.getProperty("NGINX_ADDR") + ":" + nginxPort + "/" + "_ah/upload/" + System.getProperty("APPLICATION_ID") + "/" + sessionId;
+        String url = "http://" + System.getProperty("NGINX_ADDR") + ":" + nginxPort + "/_ah/upload/" + sessionId;
         logger.fine("UploadURL set to [" + url + "]");
         response.setUrl(url);
 


### PR DESCRIPTION
Update blobstore / java runtime to pass the application id in an HTTP header and to allow use of relative url in the success path for create upload url.

These changes reduce the differences between the java and python runtimes, allowing the java8 runtime to reuse existing functionality.