### PR TITLE
Remove --force-private from fast-start.sh

### DIFF
--- a/scripts/fast-start.sh
+++ b/scripts/fast-start.sh
@@ -273,9 +273,6 @@ fi
 # Start AppScale.
 ${APPSCALE_CMD} up
 
-# We need to set the login after AppScale is up for marketplace.
-${APPSCALE_CMD} set login ${LOGIN}
-
 # If we don't need to deploy the demo app, we are done.
 if [ "${USE_DEMO_APP}" != "Y" ]; then
     exit 0

--- a/scripts/fast-start.sh
+++ b/scripts/fast-start.sh
@@ -28,7 +28,6 @@ GUESTBOOK_URL="https://www.appscale.com/wp-content/uploads/2017/09/guestbook.tar
 GUESTBOOK_APP="${HOME}/guestbook.tar.gz"
 MD5_SUMS="${HOME}/appscale/md5sums.txt"
 USE_DEMO_APP="Y"
-FORCE_PRIVATE="N"
 AZURE_METADATA="http://169.254.169.254/metadata/v1/InstanceInfo"
 
 # Print help screen.
@@ -39,7 +38,6 @@ usage() {
     echo "  --user <email>          administrator's email"
     echo "  --passwd <password>     administrator's password"
     echo "  --no-demo-app           don't start the demo application"
-    echo "  --force-private         don't use public IP (needed for marketplace)"
     echo "  --no-metadata-server    don't try to contact metadata servers"
     echo
 }
@@ -89,11 +87,6 @@ while [ $# -gt 0 ]; do
     if [ "$1" = "--no-demo-app" ]; then
         shift
         USE_DEMO_APP="N"
-        continue
-    fi
-    if [ "$1" = "--force-private" ]; then
-        shift
-        FORCE_PRIVATE="Y"
         continue
     fi
     if [ "$1" = "--no-metadata-server" ]; then


### PR DESCRIPTION
Remove --force-private from fast-start.sh since it was added to fix an Ec2 issue that can be resolved by using the dns.

Changing to the dns for aws/euca means we can put the login property in the AppScalefile rather than use `appscale set login` which could make it more transparent for fast-start users.

http://ocd.appscale.net:8080/job/Daily%20Build/6225/
http://ocd.appscale.net:8080/job/EC2-Testing/72/
- http://ocd.appscale.net:8080/job/Hawkeye-Test-EC2-Image/358/

http://ocd.appscale.net:8080/job/GCE-Testing/40/
- http://ocd.appscale.net:8080/job/Hawkeye-Test-GCE-Image/331/

http://ocd.appscale.net:8080/job/Azure-Testing/73/

AppScale/appscale-testing#385