### PR TITLE
Remove local_ip helper function

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2261,7 +2261,7 @@ class Djinn
 
       # We create here the needed nodes, with open role and no disk.
       disks = Array.new(new_nodes_roles.length, nil)
-      imc = InfrastructureManagerClient.new(@@secret)
+      imc = InfrastructureManagerClient.new(@@secret, my_node.private_ip)
       begin
         new_nodes_info = imc.run_instances(new_nodes_roles.length, @options,
            new_nodes_roles.values, disks)
@@ -3186,7 +3186,7 @@ class Djinn
           db_master = node.private_ip if node.roles.include?('db_master')
         }
       }
-      setup_db_config_files(db_master)
+      setup_db_config_files(db_master, my_node.private_ip)
 
       threads << Thread.new {
         Djinn.log_info("Starting database services.")
@@ -4192,7 +4192,7 @@ HOSTS
       return
     end
 
-    imc = InfrastructureManagerClient.new(@@secret)
+    imc = InfrastructureManagerClient.new(@@secret, my_node.private_ip)
     begin
       device_name = imc.attach_disk(@options, my_node.disk, my_node.instance_id)
     rescue FailedNodeException
@@ -5021,7 +5021,7 @@ HOSTS
 
     # Terminate instance if we are in cloud.
     if is_cloud?
-      imc = InfrastructureManagerClient.new(@@secret)
+      imc = InfrastructureManagerClient.new(@@secret, my_node.private_ip)
       begin
         imc.terminate_instances(@options, node_to_remove.instance_id)
       rescue FailedNodeException
@@ -5812,7 +5812,7 @@ HOSTS
     return BAD_SECRET_MSG unless valid_secret?(secret)
 
     # Get stats from SystemManager.
-    imc = InfrastructureManagerClient.new(secret)
+    imc = InfrastructureManagerClient.new(secret, my_node.private_ip)
     system_stats = JSON.load(imc.get_system_stats)
     Djinn.log_debug('get_node_stats_json: got system stats.')
 

--- a/AppController/lib/cassandra_helper.rb
+++ b/AppController/lib/cassandra_helper.rb
@@ -37,8 +37,7 @@ CASSANDRA_DATA_DIR = '/opt/appscale/cassandra'.freeze
 # Args:
 #   master_ip: A String corresponding to the private FQDN or IP address of the
 #     machine hosting the Database Master role.
-def setup_db_config_files(master_ip)
-  local_ip = HelperFunctions.local_ip
+def setup_db_config_files(master_ip, local_ip)
   setup_script = "#{SETUP_CONFIG_SCRIPT} --local-ip #{local_ip} "\
                  "--master-ip #{master_ip}"
   until system(setup_script)

--- a/AppController/lib/helperfunctions.rb
+++ b/AppController/lib/helperfunctions.rb
@@ -423,19 +423,6 @@ module HelperFunctions
     bound_addrs
   end
 
-  # Returns the IP address associated with this machine. To get around
-  # issues where a VM may forget its IP address
-  # (https://github.com/AppScale/appscale/issues/84), we locally cache it
-  # to not repeatedly ask the system for this IP (which shouldn't be changing).
-  def self.local_ip
-    bound_addrs = get_all_local_ips
-    raise 'Couldn\'t get our local IP address' if bound_addrs.length.zero?
-
-    addr = bound_addrs[0]
-    Djinn.log_debug("Returning #{addr} as our local IP address")
-    addr
-  end
-
   # In cloudy deployments, the recommended way to determine a machine's true
   # private IP address from its private FQDN is to use dig. This method
   # attempts to resolve IPs in that method, deferring to other methods if that

--- a/AppController/lib/infrastructure_manager_client.rb
+++ b/AppController/lib/infrastructure_manager_client.rb
@@ -27,8 +27,8 @@ class InfrastructureManagerClient
   # or on any AppScale machine.
   attr_accessor :secret
 
-  def initialize(secret)
-    @ip = HelperFunctions.local_ip
+  def initialize(secret, local_ip)
+    @ip = local_ip
     @secret = secret
   end
 


### PR DESCRIPTION
The function could return an IP address that was different than what the controller was given as a private IP. This was problematic for our default Vagrant setup since the Cassandra seed node IP is determined from the node layout, but the local IP was determined from the first entry from `ifconfig`. Cassandra, believing the seed node to be different than itself, would incorrectly try to bootstrap from a different node even though it was the only one in the cluster.