### PR TITLE
Increase the monit safety sleep time

### DIFF
--- a/AdminServer/appscale/admin/instance_manager/instance_manager.py
+++ b/AdminServer/appscale/admin/instance_manager/instance_manager.py
@@ -238,7 +238,7 @@ class InstanceManager(object):
     # where it never starts the process. As a temporary workaround, this
     # small period allows it to finish reloading. This can be removed if
     # instances are started inside a cgroup.
-    yield gen.sleep(0.5)
+    yield gen.sleep(1)
     yield self._monit_operator.send_command_retry_process(full_watch, 'start')
 
     # Make sure the version registration node exists.


### PR DESCRIPTION
There are times where it takes monit longer than 500ms to finish reloading. The monit xml interface does not differentiate between the "stopped" and "starting" states, and moving to cgroup-based management will take a lot more effort. This is a temporary hack to mitigate the issue given those limitations.