### PR TITLE
Do not modify /root file mode on install

### DIFF
--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -312,7 +312,6 @@ installgems()
 postinstallnginx()
 {
     rm -fv /etc/nginx/sites-enabled/default
-    chmod +x /root
 }
 
 installsolr()


### PR DESCRIPTION
Remove  `/root` file mode change from nginx post install step. This is not needed as nginx no longer uses files under `/root`.