### PR TITLE
Perform datastore operations in batches

### DIFF
--- a/AppDB/test/e2e/client.py
+++ b/AppDB/test/e2e/client.py
@@ -87,6 +87,20 @@ class Datastore(object):
     yield self._make_request('Put', request.Encode())
 
   @gen.coroutine
+  def put_multi(self, entities, txid=None):
+    request = datastore_pb.PutRequest()
+    for entity in entities:
+      req_entity = request.add_entity()
+      req_entity.MergeFrom(entity.ToPb())
+
+    if txid is not None:
+      req_tx = request.mutable_transaction()
+      req_tx.set_app(self.project_id)
+      req_tx.set_handle(txid)
+
+    yield self._make_request('Put', request.Encode())
+
+  @gen.coroutine
   def commit(self, txid):
     request = datastore_pb.Transaction()
     request.set_app(self.project_id)

--- a/AppDB/test/e2e/client.py
+++ b/AppDB/test/e2e/client.py
@@ -23,6 +23,7 @@ class BadRequest(DatastoreError):
 
 class Datastore(object):
   SERVICE_NAME = 'datastore_v3'
+  REQUEST_TIMEOUT = 60
 
   def __init__(self, locations, project_id):
     self.project_id = project_id
@@ -118,7 +119,8 @@ class Datastore(object):
     url = 'http://{}'.format(location)
     headers = {'protocolbuffertype': 'Request', 'appdata': self.project_id}
     response = yield self._client.fetch(
-      url, method='POST', body=request.Encode(), headers=headers)
+      url, method='POST', body=request.Encode(), headers=headers,
+      request_timeout=self.REQUEST_TIMEOUT)
     api_response = remote_api_pb.Response(response.body)
 
     if api_response.has_application_error():

--- a/AppDB/test/e2e/test_queries.py
+++ b/AppDB/test/e2e/test_queries.py
@@ -86,7 +86,7 @@ class TestMergeJoinQueries(AsyncTestCase):
 
 class TestQueryLimit(AsyncTestCase):
   CASSANDRA_PAGE_SIZE = 5000
-  BATCH_SIZE = 50
+  BATCH_SIZE = 20
 
   def setUp(self):
     super(TestQueryLimit, self).setUp()

--- a/AppDB/test/e2e/test_queries.py
+++ b/AppDB/test/e2e/test_queries.py
@@ -28,8 +28,7 @@ class TestMergeJoinQueries(AsyncTestCase):
   def tear_down_helper(self):
     query = Query('Greeting', _app=PROJECT_ID)
     results = yield self.datastore.run_query(query)
-    for entity in results:
-      yield self.datastore.delete([entity.key()])
+    yield self.datastore.delete([entity.key() for entity in results])
 
   @gen_test
   def test_merge_query_with_null(self):
@@ -87,6 +86,7 @@ class TestMergeJoinQueries(AsyncTestCase):
 
 class TestQueryLimit(AsyncTestCase):
   CASSANDRA_PAGE_SIZE = 5000
+  BATCH_SIZE = 50
 
   def setUp(self):
     super(TestQueryLimit, self).setUp()
@@ -101,17 +101,26 @@ class TestQueryLimit(AsyncTestCase):
   def tear_down_helper(self):
     query = Query('Greeting', _app=PROJECT_ID)
     results = yield self.datastore.run_query(query)
+    batch = []
     for entity in results:
-      yield self.datastore.delete([entity.key()])
+      batch.append(entity.key())
+      if len(batch) == self.BATCH_SIZE:
+        yield self.datastore.delete(batch)
+        batch = []
+    yield self.datastore.delete(batch)
 
   @gen_test
   def test_cassandra_page_size(self):
     entity_count = self.CASSANDRA_PAGE_SIZE + 1
+    batch = []
     for _ in range(entity_count):
       entity = Entity('Greeting', _app=PROJECT_ID)
-      yield self.datastore.put(entity)
+      batch.append(entity)
+      if len(batch) == self.BATCH_SIZE:
+        yield self.datastore.put_multi(batch)
+        batch = []
+    yield self.datastore.put_multi(batch)
 
     query = Query('Greeting', _app=PROJECT_ID)
     results = yield self.datastore.run_query(query)
     self.assertEqual(len(results), entity_count)
-    self.assertTrue(True)

--- a/AppDB/test/e2e/test_transactions.py
+++ b/AppDB/test/e2e/test_transactions.py
@@ -61,8 +61,7 @@ class TestConcurrentCounter(AsyncTestCase):
   def tear_down_helper(self):
     query = Query('Counter', _app=PROJECT_ID)
     results = yield self.datastore.run_query(query)
-    for entity in results:
-      yield self.datastore.delete([entity.key()])
+    yield self.datastore.delete([entity.key() for entity in results])
 
   @gen_test
   def test_concurrent_counter(self):


### PR DESCRIPTION
 - Added put_multi methods to datastore client.
 - Modified e2e tests to insert and delete entities in batches.