### PR TITLE
Add initial FDB datastore backend implementation

### DIFF
--- a/AppDB/appscale/datastore/dbconstants.py
+++ b/AppDB/appscale/datastore/dbconstants.py
@@ -58,7 +58,7 @@ TRANSIENT_CASSANDRA_ERRORS = (
   cassandra.OperationTimedOut, cassandra.cluster.NoHostAvailable)
 
 # The database backends supported by the AppScale datastore.
-VALID_DATASTORES = ['cassandra']
+VALID_DATASTORES = ['cassandra', 'fdb']
 
 # Table names
 USERS_TABLE = "USERS__"

--- a/AppDB/appscale/datastore/fdb/__init__.py
+++ b/AppDB/appscale/datastore/fdb/__init__.py
@@ -1,1 +1,0 @@
-from appscale.datastore.fdb.fdb_datastore import FDBDatastore

--- a/AppDB/appscale/datastore/fdb/__init__.py
+++ b/AppDB/appscale/datastore/fdb/__init__.py
@@ -1,0 +1,1 @@
+from appscale.datastore.fdb.fdb_datastore import FDBDatastore

--- a/AppDB/appscale/datastore/fdb/cache.py
+++ b/AppDB/appscale/datastore/fdb/cache.py
@@ -1,0 +1,248 @@
+"""
+This module allows FDB clients to cache directory mappings and invalidate
+them when the schema changes.
+"""
+from collections import deque
+
+from fdb.directory_impl import DirectorySubspace
+from tornado import gen
+
+from appscale.datastore.dbconstants import InternalError
+from appscale.datastore.fdb.codecs import decode_str
+from appscale.datastore.fdb.utils import KVIterator
+
+
+class DirectoryCache(object):
+  """ A simple directory cache that more specialized caches can extend. """
+
+  # The location of the metadata version key.
+  METADATA_KEY = b'\xff/metadataVersion'
+
+  def __init__(self, tornado_fdb, root_dir, cache_size):
+    self.root_dir = root_dir
+    self._cache_size = cache_size
+    self._directory_dict = {}
+    self._directory_keys = deque()
+    self._metadata_version = None
+    self._tornado_fdb = tornado_fdb
+
+  def __setitem__(self, key, value):
+    if key not in self._directory_dict:
+      self._directory_keys.append(key)
+      if len(self._directory_keys) > self._cache_size:
+        oldest_key = self._directory_keys.popleft()
+        del self._directory_dict[oldest_key]
+
+    self._directory_dict[key] = value
+
+  def __getitem__(self, key):
+    return self._directory_dict[key]
+
+  def __contains__(self, item):
+    return item in self._directory_dict
+
+  @gen.coroutine
+  def validate_cache(self, tr):
+    """ Clears the cache if the metadata key has been updated. """
+    current_version = yield self._tornado_fdb.get(tr, self.METADATA_KEY)
+    if not current_version.present():
+      raise InternalError(u'The FDB cluster metadata key is missing')
+
+    if current_version.value != self._metadata_version:
+      self._metadata_version = current_version.value
+      self._directory_dict.clear()
+      self._directory_keys.clear()
+
+  @staticmethod
+  def subdirs_subspace(directory):
+    """
+    Returns the subspace used by the directory layer to keep track of
+    subdirectories.
+    """
+    dir_layer = directory._directory_layer
+    parent_subspace = dir_layer._node_with_prefix(directory.rawPrefix)
+    return parent_subspace.subspace((dir_layer.SUBDIRS,))
+
+
+class ProjectCache(DirectoryCache):
+  """ A directory cache that keeps track of projects. """
+
+  # The number of items the cache can hold.
+  SIZE = 256
+
+  def __init__(self, tornado_fdb, root_dir):
+    super(ProjectCache, self).__init__(tornado_fdb, root_dir, self.SIZE)
+
+  @gen.coroutine
+  def get(self, tr, project_id):
+    """ Gets a project's directory.
+
+    Args:
+      tr: An FDB transaction.
+      project_id: A string specifying a project ID.
+    Returns:
+      A DirectorySubspace object.
+    """
+    yield self.validate_cache(tr)
+    if project_id not in self:
+      # TODO: Check new projects instead of assuming they are valid.
+      # This can also be made async.
+      self[project_id] = self.root_dir.create_or_open(tr, (project_id,))
+
+    raise gen.Return(self[project_id])
+
+  @gen.coroutine
+  def list(self, tr):
+    """ Gets a project's subdirectories.
+
+    Args:
+      tr: An FDB transaction.
+    Returns:
+      A list of DirectorySubspace objects.
+    """
+    yield self.validate_cache(tr)
+    subdirs_subspace = self.subdirs_subspace(self.root_dir)
+    kvs = yield KVIterator(tr, self._tornado_fdb,
+                           subdirs_subspace.range()).list()
+    directories = []
+    for kv in kvs:
+      project_id = subdirs_subspace.unpack(kv.key)[0]
+      directory = DirectorySubspace(
+        self.root_dir.get_path() + (project_id,), kv.value)
+      if project_id not in self:
+        self[project_id] = directory
+
+      directories.append(self[project_id])
+
+    raise gen.Return(directories)
+
+
+class SectionCache(DirectoryCache):
+  """ Caches non-namespaced section directories within a project. """
+
+  # The number of items the cache can hold.
+  SIZE = 256
+
+  def __init__(self, tornado_fdb, project_cache, dir_type):
+    super(SectionCache, self).__init__(
+      tornado_fdb, project_cache.root_dir, self.SIZE)
+    self._project_cache = project_cache
+    self._dir_type = dir_type
+
+  @gen.coroutine
+  def get(self, tr, project_id):
+    """ Gets a section directory for the given project.
+
+    Args:
+      tr: An FDB transaction.
+      project_id: A string specifying the project ID.
+    Returns:
+      A namespace directory object of the directory type.
+    """
+    yield self.validate_cache(tr)
+    if project_id not in self:
+      project_dir = yield self._project_cache.get(project_id)
+      # TODO: Make async.
+      section_dir = project_dir.create_or_open(tr, (self._dir_type.DIR_NAME,))
+      self[project_id] = self._dir_type(section_dir)
+
+    raise gen.Return(self[project_id])
+
+
+class NSCache(DirectoryCache):
+  """ Caches namespaced sections to keep track of directory prefixes. """
+
+  # The number of items the cache can hold.
+  SIZE = 512
+
+  def __init__(self, tornado_fdb, project_cache, dir_type):
+    super(NSCache, self).__init__(
+      tornado_fdb, project_cache.root_dir, self.SIZE)
+    self._project_cache = project_cache
+    self._dir_type = dir_type
+
+  # TODO: This interface is really clumsy. Rethink arguments.
+  @gen.coroutine
+  def get(self, tr, project_id, namespace, *args, **kwargs):
+    """ Gets a namespace directory for the given project and namespace.
+
+    Args:
+      tr: An FDB transaction.
+      project_id: A string specifying the project ID.
+      namespace: A string specifying the namespace.
+    Returns:
+      A namespace directory object of the directory type.
+    """
+    yield self.validate_cache(tr)
+    key = (project_id, namespace)
+    if key not in self:
+      project_dir = yield self._project_cache.get(project_id)
+      section_dir = yield self.get_section(tr, project_dir)
+      # TODO: Make async.
+      ns_dir = section_dir.create_or_open(tr, (namespace,) + tuple(args))
+      self[key] = self._dir_type(ns_dir, **kwargs)
+
+    raise gen.Return(self[key])
+
+  @gen.coroutine
+  def get_from_key(self, tr, key):
+    """ Gets a namespace directory for a protobuf reference object.
+
+    Args:
+      tr: An FDB transaction.
+      key: A protobuf reference object.
+    Returns:
+      A namespace directory object of the directory type.
+    """
+    project_id = decode_str(key.app())
+    namespace = decode_str(key.name_space())
+    ns_dir = yield self.get(tr, project_id, namespace)
+    raise gen.Return(ns_dir)
+
+  @gen.coroutine
+  def get_section(self, tr, project_dir):
+    """ Gets a project's directory type section.
+
+    Args:
+      tr: An FDB transaction.
+      project_dir: The project's DirectorySubspace.
+    Returns:
+      A DirectorySubpace object with the path of
+      (<ds-root>, <project-id>, <section>).
+    """
+    project_id = project_dir.get_path()[-1]
+    if project_id not in self:
+      # TODO: Make async.
+      section_dir = project_dir.create_or_open(tr, (self._dir_type.DIR_NAME,))
+      self[project_id] = section_dir
+
+    raise gen.Return(self[project_id])
+
+  @gen.coroutine
+  def list(self, tr, project_dir):
+    """ Gets the namepsace directories from the project's relevant section.
+
+    Args:
+      tr: An FDB transaction.
+      project_dir: The project's DirectorySubspace.
+    Returns:
+      A list of DirectorySubspace objects with the path of
+      (<ds-root>, <project-id>, <section>, <namespace>).
+    """
+    project_id = project_dir.get_path()[-1]
+    section_dir = yield self.get_section(tr, project_dir)
+    subdirs_subspace = self.subdirs_subspace(section_dir)
+    kvs = yield KVIterator(tr, self._tornado_fdb,
+                           subdirs_subspace.range()).list()
+    ns_directories = []
+    for kv in kvs:
+      namespace = subdirs_subspace.unpack(kv.key)[0]
+      ns_directory = DirectorySubspace(
+        section_dir.get_path() + (namespace,), kv.value)
+      key = (project_id, namespace)
+      if key not in self:
+        self[key] = self._dir_type(ns_directory)
+
+      ns_directories.append(self[key])
+
+    raise gen.Return(ns_directories)

--- a/AppDB/appscale/datastore/fdb/codecs.py
+++ b/AppDB/appscale/datastore/fdb/codecs.py
@@ -15,8 +15,9 @@ from appscale.datastore.dbconstants import BadRequest, InternalError
 sys.path.append(APPSCALE_PYTHON_APPSERVER)
 from google.appengine.datastore import entity_pb
 
-# The number of bytes used to encode a read versionstamp.
-READ_VS_SIZE = 8
+# The number of bytes used to encode a read version in a way that is comparable
+# to commit versionstamps.
+READ_VERSION_SIZE = 8
 
 # Byte values that signify a data type. A couple values are left between each
 # one just in case they need adjustment.
@@ -494,9 +495,9 @@ class TransactionID(object):
   BATCH_ORDER_BITS = 8
 
   @classmethod
-  def encode(cls, scatter_val, commit_vs):
-    commit_version = struct.unpack('>Q', commit_vs[:8])[0]
-    batch_order = struct.unpack('>H', commit_vs[8:])[0]
+  def encode(cls, scatter_val, commit_versionstamp):
+    commit_version = struct.unpack('>Q', commit_versionstamp[:8])[0]
+    batch_order = struct.unpack('>H', commit_versionstamp[8:])[0]
     if not 0 <= scatter_val <= 15:
       raise InternalError(u'Invalid scatter value')
 
@@ -516,10 +517,10 @@ class TransactionID(object):
     return scatter_val, commit_version_bytes + batch_order_bytes
 
 
-encode_read_vs = lambda read_version: Int64.encode_bare(
-  read_version, READ_VS_SIZE)
+encode_read_version = lambda read_version: Int64.encode_bare(
+  read_version, READ_VERSION_SIZE)
 
 
-def encode_vs_index(vs_position):
+def encode_versionstamp_index(versionstamp_position):
   """ Encodes an FDB key index position. """
-  return struct.pack(u'<L', vs_position)
+  return struct.pack(u'<L', versionstamp_position)

--- a/AppDB/appscale/datastore/fdb/codecs.py
+++ b/AppDB/appscale/datastore/fdb/codecs.py
@@ -2,6 +2,7 @@
 This module contains shared encoding and decoding utilities for translating
 datastore types to bytestrings and vice versa.
 """
+import bisect
 import struct
 import sys
 
@@ -9,7 +10,6 @@ import six
 
 from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
 from appscale.datastore.dbconstants import BadRequest, InternalError
-from appscale.datastore.fdb.utils import fdb
 
 sys.path.append(APPSCALE_PYTHON_APPSERVER)
 from google.appengine.datastore import entity_pb
@@ -17,46 +17,31 @@ from google.appengine.datastore import entity_pb
 # The number of bytes used to encode a read versionstamp.
 READ_VS_SIZE = 8
 
+# Byte values that signify a data type. A couple values are left between each
+# one just in case they need adjustment.
+NULL_CODE = 0x01
+# 17 values are reserved for integers in order to allow variable size in both a
+# negative and positive direction.
+INT64_ZERO_CODE = 0x0C
+FALSE_CODE = 0x17
+TRUE_CODE = 0x18
+BYTES_CODE = 0x1B
+DOUBLE_CODE = 0x1E
+POINT_CODE = 0x21
+USER_CODE = 0x24
+REFERENCE_CODE = 0x27
 
-class V3Types(object):
-  NULL = b'\x00'
-  INT64 = b'\x01'
-  BOOLEAN = b'\x02'
-  STRING = b'\x03'
-  DOUBLE = b'\x04'
-  POINT = b'\x05'
-  USER = b'\x06'
-  REFERENCE = b'\x07'
+# Ensures the shorter of two variable-length values (with identical prefixes)
+# is placed before the longer one.
+TERMINATOR = 0x00
 
-  accessible = (
-    ('int64', INT64), ('boolean', BOOLEAN), ('string', STRING),
-    ('double', DOUBLE), ('point', POINT), ('user', USER),
-    ('reference', REFERENCE))
 
-  @classmethod
-  def null(cls, encoded_type):
-    return encoded_type == cls.NULL or cls.reverse(encoded_type) == cls.NULL
+def reverse_bits(blob):
+  return b''.join(map(lambda x: six.int2byte(x ^ 0xFF), six.iterbytes(blob)))
 
-  @classmethod
-  def scalar(cls, encoded_type):
-    scalar_types = (cls.INT64, cls.BOOLEAN, cls.STRING, cls.DOUBLE)
-    return (encoded_type in scalar_types or
-            cls.reverse(encoded_type) in scalar_types)
 
-  @classmethod
-  def compound(cls, encoded_type):
-    compound_types = (cls.POINT, cls.USER, cls.REFERENCE)
-    return (encoded_type in compound_types or
-            cls.reverse(encoded_type) in compound_types)
-
-  @classmethod
-  def name(cls, encoded_type):
-    return next(key for key, val in V3Types.__dict__.items()
-                if val == encoded_type or val == cls.reverse(encoded_type))
-
-  @staticmethod
-  def reverse(encoded_type):
-    return bytes(bytearray([255 - ord(encoded_type)]))
+def encode_marker(marker, reverse):
+  return six.int2byte(marker ^ 0xFF) if reverse else six.int2byte(marker)
 
 
 def decode_str(string):
@@ -67,251 +52,420 @@ def decode_str(string):
   return string.decode('utf-8')
 
 
-def encode_element(element):
-  """ Converts a path element protobuf object to a tuple. """
-  if element.has_id():
-    id_or_name = element.id()
-  elif element.has_name():
-    id_or_name = decode_str(element.name())
-  else:
-    raise BadRequest('All path elements must either have a name or ID')
+class Int64(object):
+  LIMITS = tuple((1 << (i * 8)) - 1 for i in range(9))
 
-  return decode_str(element.type()), id_or_name
-
-
-def decode_element(element_tuple):
-  """ Converts a tuple to a path element protobuf object. """
-  path_element = entity_pb.Path_Element()
-  path_element.set_type(element_tuple[0])
-  if isinstance(element_tuple[1], int):
-    path_element.set_id(element_tuple[1])
-  else:
-    path_element.set_name(element_tuple[1])
-
-  return path_element
-
-
-def encode_ancestor_range(subspace, path):
-  """ Determines the start and stop key selectors for an ancestor range. """
-  embedded_value = fdb.tuple.pack(path)
-  # In order to exclude the ancestor itself, the range is manually selected
-  # using the potential values for the next element in the key path. It's
-  # normally a unicode string specifying the kind of the next element, but it
-  # can also be an integer if it's the last element and the index directory
-  # includes the kind.
-  embedded_start = embedded_value + six.int2byte(fdb.tuple.STRING_CODE)
-  embedded_stop = embedded_value + six.int2byte(fdb.tuple.POS_INT_END + 1)
-  prefix = subspace.rawPrefix + six.int2byte(fdb.tuple.NESTED_CODE)
-  start = fdb.KeySelector.first_greater_than(prefix + embedded_start)
-  stop = fdb.KeySelector.first_greater_or_equal(prefix + embedded_stop)
-  return start, stop
-
-
-def encode_path(path):
-  """ Converts a key path protobuf object to a tuple. """
-  if isinstance(path, entity_pb.PropertyValue):
-    element_list = path.referencevalue().pathelement_list()
-  elif isinstance(path, entity_pb.PropertyValue_ReferenceValue):
-    element_list = path.pathelement_list()
-  else:
-    element_list = path.element_list()
-
-  return tuple(item for element in element_list
-               for item in encode_element(element))
-
-
-def decode_path(encoded_path, reference_value=False):
-  """ Converts a tuple to a key path protobuf object. """
-  if reference_value:
-    path = entity_pb.PropertyValue_ReferenceValue()
-  else:
-    path = entity_pb.Path()
-
-  for index in range(0, len(encoded_path), 2):
-    element = path.add_element()
-    element.set_type(encoded_path[index])
-    id_or_name = encoded_path[index + 1]
-    if isinstance(id_or_name, int):
-      element.set_id(id_or_name)
+  @classmethod
+  def encode(cls, value, reverse=False):
+    if value == 0:
+      code = INT64_ZERO_CODE
+      packed = b''
+    elif value > 0:
+      encoded_size = bisect.bisect_left(cls.LIMITS, value)
+      adjusted_value = cls.LIMITS[encoded_size] - value if reverse else value
+      code = INT64_ZERO_CODE + encoded_size
+      packed = struct.pack('>Q', adjusted_value)[-encoded_size:]
     else:
-      element.set_name(id_or_name)
+      encoded_size = bisect.bisect_left(cls.LIMITS, -value)
+      # Shift negative values to an unsigned space.
+      adjusted_value = -value if reverse else cls.LIMITS[encoded_size] + value
+      code = INT64_ZERO_CODE - encoded_size
+      packed = struct.pack('>Q', adjusted_value)[-encoded_size:]
 
-  return path
+    return encode_marker(code, reverse) + packed
 
+  @classmethod
+  def decode(cls, marker, blob, pos, reverse=False):
+    code = ord(marker) ^ 0xFF if reverse else ord(marker)
+    if code == INT64_ZERO_CODE:
+      return 0, pos
 
-def reverse_encode_string(unicode_string):
-  """ Encodes strings so that they will be sorted in reverse order. """
-  byte_array = bytearray(unicode_string, encoding='utf-8')
-  # In order to place smaller byte values before larger ones, each byte is
-  # inverted. In order to ensure that the shorter of two strings with otherwise
-  # identical prefixes will be placed after the longer string, the largest byte
-  # value (255) is used to terminate the string.
-  # Since b'\x00' would normally be encoded as the terminator with this
-  # conversion, each value is first shifted up a value before being inverted.
-  # For example, b'\x00' -> b'\x01' -> b'\xfe'. Luckily, b'\xff' is not used
-  # by UTF-8, so every encoded UTF-8 byte can be incremented without exceeding
-  # the largest byte value.
-  for index, byte_value in enumerate(byte_array):
-    byte_array[index] = 255 - (byte_value + 1)
+    encoded_size = abs(code - INT64_ZERO_CODE)
+    packed = b'\x00' * (8 - encoded_size) + blob[pos:pos + encoded_size]
+    pos += encoded_size
+    value = struct.unpack('>Q', packed)[0]
+    if code > INT64_ZERO_CODE:
+      value = cls.LIMITS[encoded_size] - value if reverse else value
+    else:
+      # Shift values back to their original, negative state.
+      value = -value if reverse else value - cls.LIMITS[encoded_size]
 
-  return bytes(byte_array) + b'\xff'
+    return value, pos
 
+  @classmethod
+  def encode_bare(cls, value, byte_count):
+    """
+    Encodes an integer without a prefix using the specified number of bytes.
+    """
+    encoded = struct.pack('>Q', value)
+    if any(byte != b'\x00' for byte in encoded[:-byte_count]):
+      raise InternalError(u'Value exceeds maximum size')
 
-def reverse_decode_string(byte_string):
-  """ Recovers the original unicode string from a reverse-encoded one. """
-  byte_array = bytearray(byte_string[:-1])
-  for index, byte_value in enumerate(byte_array):
-    byte_array[index] = (255 - byte_value) - 1
+    return encoded[-byte_count:]
 
-  return byte_array.decode('utf-8')
-
-
-def decode_point(val):
-  """ Converts a tuple to a PointValue property value object. """
-  point_val = entity_pb.PropertyValue_PointValue()
-  point_val.set_x(val[0])
-  point_val.set_y(val[1])
-  return point_val
-
-
-def decode_user(val):
-  """ Converts a tuple to a UserValue property value object. """
-  user_val = entity_pb.PropertyValue_UserValue()
-  user_val.set_email(val[0])
-  user_val.set_auth_domain(val[1])
-  return user_val
+  @classmethod
+  def decode_bare(cls, encoded_value):
+    """ Decodes a byte string back to an integer. """
+    encoded_value = b'\x00' * (8 - len(encoded_value)) + encoded_value
+    return struct.unpack('>Q', encoded_value)[0]
 
 
-def encode_reference(val):
-  """ Converts an entity key protobuf object to a tuple. """
-  project_id = decode_str(val.app())
-  namespace = decode_str(val.name_space())
-  return (project_id, namespace) + encode_path(val)
+class Bytes(object):
+  @classmethod
+  def encode(cls, value, prefix=six.int2byte(BYTES_CODE), reverse=False):
+    packed = reverse_bits(value) if reverse else value
+    terminator = encode_marker(TERMINATOR, reverse)
+    # Escape each occurrence of the terminator. The first byte of whatever
+    # follows must not contain the escape character.
+    packed = packed.replace(terminator, terminator + reverse_bits(terminator))
+    return prefix + packed + six.int2byte(TERMINATOR)
+
+  @classmethod
+  def decode(cls, blob, pos, reverse=False):
+    end = cls._find_terminator(blob, pos, reverse)
+    terminator = encode_marker(TERMINATOR, reverse)
+    packed = blob[pos:end].replace(terminator + reverse_bits(terminator),
+                                   terminator)
+    value = reverse_bits(packed) if reverse else packed
+    return value, end + 1
+
+  @staticmethod
+  def _find_terminator(blob, pos, reverse=False):
+    """ Finds the position of the terminator. """
+    terminator = encode_marker(TERMINATOR, reverse)
+    escape_byte = reverse_bits(terminator)
+    while True:
+      pos = blob.find(terminator, pos)
+      if pos < 0:
+        raise InternalError(u'Byte string is missing terminator')
+
+      if blob[pos + 1:pos + 2] != escape_byte:
+        return pos
+
+      pos += 2
 
 
-def decode_reference(val):
-  """ Converts a tuple to an entity key protobuf object. """
-  reference_val = entity_pb.PropertyValue_ReferenceValue()
-  reference_val.set_app(val[0])
-  reference_val.set_name_space(val[1])
-  reference_val.MergeFrom(decode_path(val[2:], reference_value=True))
-  return reference_val
+class Double(object):
+  @classmethod
+  def encode(cls, value, prefix=six.int2byte(DOUBLE_CODE), reverse=False):
+    adjusted_value = -value if reverse else value
+    packed = struct.pack('>d', adjusted_value)
+    # Flip all of the bits for negative values.
+    if six.indexbytes(value, 0) & 0x80 != 0x00:
+      # If it's negative and reversed, there is no transformation.
+      packed = packed if reverse else reverse_bits(packed)
+    else:
+      # Flip the sign bit for positive values.
+      packed = six.int2byte(six.indexbytes(packed, 0) ^ 0x80) + packed[1:]
+      if reverse:
+        packed = reverse_bits(packed)
+
+    return prefix + packed
+
+  @classmethod
+  def decode(cls, blob, pos, reverse=False):
+    packed = blob[pos:pos + 8]
+    pos += 8
+    # Restore all the original bits for reverse values.
+    if six.indexbytes(packed, 0) & 0x80 != 0x80:
+      # If it's negative and reversed, there is no transformation.
+      packed = packed if reverse else reverse_bits(packed)
+    else:
+      # Restore the sign bit for positive values.
+      packed = six.int2byte(six.indexbytes(packed, 0) ^ 0x80) + packed[1:]
+      if reverse:
+        packed = reverse_bits(packed)
+
+    adjusted_value = struct.unpack('>d', packed)[0]
+    value = -adjusted_value if reverse else adjusted_value
+    return value, pos
 
 
-ENCODERS = {
-  V3Types.NULL: lambda val: tuple(),
-  V3Types.INT64: lambda val: (val,),
-  V3Types.BOOLEAN: lambda val: (val,),
-  V3Types.STRING: lambda val: (decode_str(val),),
-  V3Types.DOUBLE: lambda val: (val,),
-  V3Types.POINT: lambda val: (val.x(), val.y()),
-  V3Types.USER: lambda val: (decode_str(val.email()),
-                             decode_str(val.auth_domain())),
-  V3Types.REFERENCE: encode_reference,
-  V3Types.reverse(V3Types.NULL): lambda val: tuple(),
-  V3Types.reverse(V3Types.INT64): lambda val: (val * -1,),
-  V3Types.reverse(V3Types.BOOLEAN): lambda val: (not val,),
-  V3Types.reverse(V3Types.STRING):
-    lambda val: (reverse_encode_string(decode_str(val)),),
-  V3Types.reverse(V3Types.DOUBLE): lambda val: (val * -1,),
-  V3Types.reverse(V3Types.POINT): lambda val: (val.x() * -1, val.y() * -1),
-  V3Types.reverse(V3Types.USER):
-    lambda val: (reverse_encode_string(decode_str(val.email())),
-                 reverse_encode_string(decode_str(val.auth_domain()))),
-  V3Types.reverse(V3Types.REFERENCE):
-    lambda val: tuple(reverse_encode_string(item)
-                      for item in encode_reference(val))
-}
+class Point(object):
+  @classmethod
+  def encode(cls, value, prefix=six.int2byte(POINT_CODE), reverse=False):
+    x_packed = Double.encode(value.x(), prefix=b'', reverse=reverse)
+    y_packed = Double.encode(value.y(), prefix=b'', reverse=reverse)
+    return prefix + x_packed + y_packed
+
+  @classmethod
+  def decode(cls, blob, pos, reverse=False):
+    x, pos = Double.decode(blob, pos, reverse)
+    y, pos = Double.decode(blob, pos, reverse)
+    point_val = entity_pb.PropertyValue_PointValue()
+    point_val.set_x(x)
+    point_val.set_y(y)
+    return point_val
 
 
-DECODERS = {
-  V3Types.INT64: lambda val: val[0],
-  V3Types.BOOLEAN: lambda val: val[0],
-  V3Types.STRING: lambda val: val[0],
-  V3Types.DOUBLE: lambda val: val[0],
-  V3Types.POINT: decode_point,
-  V3Types.USER: decode_user,
-  V3Types.REFERENCE: decode_reference,
-  V3Types.reverse(V3Types.INT64): lambda val: val[0] * -1,
-  V3Types.reverse(V3Types.BOOLEAN): lambda val: not val[0],
-  V3Types.reverse(V3Types.STRING): lambda val: reverse_decode_string(val[0]),
-  V3Types.reverse(V3Types.DOUBLE): lambda val: val[0] * -1,
-  V3Types.reverse(V3Types.POINT):
-    lambda val: decode_point((val[0] * -1, val[1] * -1)),
-  V3Types.reverse(V3Types.USER):
-    lambda val: decode_user((reverse_decode_string(val[0]),
-                             reverse_decode_string(val[1]))),
-  V3Types.reverse(V3Types.REFERENCE):
-    lambda val: decode_reference(tuple(reverse_decode_string(item)
-                                       for item in val))
-}
+class Text(object):
+  @classmethod
+  def encode(cls, unicode_string, prefix=b'', reverse=False):
+    byte_array = bytearray(unicode_string, encoding='utf-8')
+    # Ensure the encoded value does not contain the terminator. UTF-8 does not
+    # use 0xFF, so this can be done without exceeding the largest byte value.
+    for index, byte_value in enumerate(byte_array):
+      byte_array[index] = byte_value + 1
+      if reverse:
+        byte_array[index] = byte_value ^ 0xFF
+
+    terminator = encode_marker(TERMINATOR, reverse)
+    return prefix + bytes(byte_array) + terminator
+
+  @classmethod
+  def decode(cls, blob, pos, reverse=False):
+    terminator = encode_marker(TERMINATOR, reverse)
+    byte_array = bytearray()
+    while pos < len(blob):
+      byte_value = six.indexbytes(blob, pos)
+      pos += 1
+      if byte_value == terminator:
+        break
+
+      if reverse:
+        byte_value ^= 0xFF
+
+      # Shift the byte back to its original value.
+      byte_array.append(byte_value - 1)
+
+    return byte_array.decode('utf-8'), pos
 
 
-def unpack_value(value):
-  """ Extracts the value from a V3 PropertyValue object.
+class User(object):
+  @classmethod
+  def encode(cls, value, prefix=six.int2byte(POINT_CODE), reverse=False):
+    packed = (Text.encode(decode_str(value.email()), reverse=reverse) +
+              Text.encode(decode_str(value.auth_domain()), reverse=reverse))
+    return prefix + packed
 
-  Args:
-    value: A PropertyValue protobuf object.
-  Returns:
-    A tuple in the form of (<value-type>, <value>).
-  """
-  for type_name, encoded_type in V3Types.accessible:
-    if getattr(value, 'has_{}value'.format(type_name))():
-      return encoded_type, getattr(value, '{}value'.format(type_name))()
+  @classmethod
+  def decode(cls, blob, pos, reverse=False):
+    email, pos = Text.decode(blob, pos, reverse)
+    auth_domain, pos = Double.decode(blob, pos, reverse)
+    user_val = entity_pb.PropertyValue_UserValue()
+    user_val.set_email(email)
+    user_val.set_auth_domain(auth_domain)
+    return user_val
 
-  return V3Types.NULL, None
+
+class Path(object):
+  KIND_MARKER = 0x1C
+
+  MIN_ID_MARKER = INT64_ZERO_CODE - 8
+
+  # Marks an item as a name rather than an ID. These should be be placed after
+  # entries with IDs.
+  NAME_MARKER = 0x1D
+
+  @classmethod
+  def pack(cls, path, omit_kind=False, prefix=b'', omit_terminator=False,
+           reverse=False):
+    if not isinstance(path, tuple):
+      path = cls.flatten(path)
+
+    if omit_kind:
+      path = path[:-2] + (None,) + path[-1:]
+
+    encoded_items = []
+    kind_marker = encode_marker(cls.KIND_MARKER, reverse)
+    for index in range(0, len(path), 2):
+      kind = path[index]
+      if kind:
+        encoded_items.append(Text.encode(kind, kind_marker, reverse))
+
+      encoded_items.append(cls.encode_id_or_name(path[index + 1], reverse))
+
+    terminator = b'' if omit_terminator else encode_marker(TERMINATOR, reverse)
+    return b''.join([prefix] + encoded_items + [terminator])
+
+  @classmethod
+  def encode_id_or_name(cls, id_or_name, reverse=False):
+    if isinstance(id_or_name, six.text_type):
+      name_marker = encode_marker(cls.NAME_MARKER, reverse)
+      return Text.encode(id_or_name, name_marker, reverse)
+    elif isinstance(id_or_name, int):
+      return Int64.encode(id_or_name, reverse)
+    else:
+      raise BadRequest(u'Invalid path element type')
+
+  @classmethod
+  def unpack(cls, blob, pos, kind=None, reverse=False):
+    items = []
+    terminator = encode_marker(TERMINATOR, reverse)
+    kind_marker = encode_marker(cls.KIND_MARKER, reverse)
+    name_marker = encode_marker(cls.KIND_MARKER, reverse)
+    while pos < len(blob):
+      marker = blob[pos]
+      pos += 1
+      if marker == terminator:
+        break
+
+      if marker != kind_marker:
+        if not kind:
+          raise InternalError(u'Encoded path is missing kind')
+
+        items.append(kind)
+        kind = None
+      else:
+        elem_kind, pos = Text.decode(blob, pos, reverse)
+        items.append(elem_kind)
+
+      marker = blob[pos]
+      pos += 1
+      if marker == name_marker:
+        elem_name, pos = Text.decode(blob, pos, reverse)
+        items.append(elem_name)
+      else:
+        elem_id, pos = Int64.decode(marker, blob, pos, reverse)
+        items.append(elem_id)
+
+    return tuple(items), pos
+
+  @staticmethod
+  def flatten(path):
+    """ Converts a key path protobuf object to a tuple. """
+    if isinstance(path, entity_pb.PropertyValue):
+      element_list = path.referencevalue().pathelement_list()
+    elif isinstance(path, entity_pb.PropertyValue_ReferenceValue):
+      element_list = path.pathelement_list()
+    else:
+      element_list = path.element_list()
+
+    return tuple(item for element in element_list
+                 for item in Path.encode_element(element))
+
+  @staticmethod
+  def decode(flat_path, reference_value=False):
+    """ Converts a tuple to a key path protobuf object. """
+    if reference_value:
+      path = entity_pb.PropertyValue_ReferenceValue()
+    else:
+      path = entity_pb.Path()
+
+    for index in range(0, len(flat_path), 2):
+      element = path.add_element()
+      element.set_type(flat_path[index])
+      id_or_name = flat_path[index + 1]
+      if isinstance(id_or_name, int):
+        element.set_id(id_or_name)
+      else:
+        element.set_name(id_or_name)
+
+    return path
+
+  @staticmethod
+  def encode_element(element):
+    """ Converts a path element protobuf object to a tuple. """
+    if element.has_id():
+      id_or_name = int(element.id())
+    elif element.has_name():
+      id_or_name = decode_str(element.name())
+    else:
+      raise BadRequest('All path elements must either have a name or ID')
+
+    return decode_str(element.type()), id_or_name
+
+  @staticmethod
+  def decode_element(element_tuple):
+    """ Converts a tuple to a path element protobuf object. """
+    path_element = entity_pb.Path_Element()
+    path_element.set_type(element_tuple[0])
+    if isinstance(element_tuple[1], int):
+      path_element.set_id(element_tuple[1])
+    else:
+      path_element.set_name(element_tuple[1])
+
+    return path_element
+
+
+class Reference(object):
+  @classmethod
+  def encode(cls, value, prefix=six.int2byte(REFERENCE_CODE), reverse=False):
+    return b''.join([
+      prefix,
+      Text.encode(decode_str(value.app()), reverse=reverse),
+      Text.encode(decode_str(value.name_space()), reverse=reverse),
+      Path.pack(Path.flatten(value), prefix=prefix, reverse=reverse)
+    ])
+
+  @classmethod
+  def decode(cls, blob, pos, reverse=False):
+    project_id, pos = Text.decode(blob, pos, reverse)
+    namespace, pos = Double.decode(blob, pos, reverse)
+    flat_path = Path.unpack(blob, pos, reverse=reverse)
+    reference_val = entity_pb.PropertyValue_ReferenceValue()
+    reference_val.set_app(project_id)
+    reference_val.set_name_space(namespace)
+    reference_val.MergeFrom(Path.decode(flat_path, reference_value=True))
+    return reference_val
 
 
 def encode_value(value, reverse=False):
-  """ Converts a PropertyValue to a tuple. """
   if isinstance(value, six.integer_types):
-    encoded_type = V3Types.INT64
-  else:
-    encoded_type, value = unpack_value(value)
+    return Int64.encode(value, reverse)
 
-  if reverse:
-    encoded_type = V3Types.reverse(encoded_type)
+  if value.has_int64value():
+    return Int64.encode(value.int64value(), reverse)
 
-  return (encoded_type,) + ENCODERS[encoded_type](value)
+  if value.has_booleanvalue():
+    to_encode = TRUE_CODE if value.booleanvalue() else FALSE_CODE
+    return encode_marker(to_encode, reverse)
+
+  if value.has_stringvalue():
+    prefix = encode_marker(BYTES_CODE, reverse)
+    return Bytes.encode(value.stringvalue(), prefix, reverse)
+
+  if value.has_doublevalue():
+    prefix = encode_marker(DOUBLE_CODE, reverse)
+    return Double.encode(value.doublevalue(), prefix, reverse)
+
+  if value.has_pointvalue():
+    prefix = encode_marker(POINT_CODE, reverse)
+    return Point.encode(value.pointvalue(), prefix, reverse)
+
+  if value.has_uservalue():
+    prefix = encode_marker(USER_CODE, reverse)
+    return User.encode(value.uservalue(), prefix, reverse)
+
+  if value.has_referencevalue():
+    prefix = encode_marker(REFERENCE_CODE, reverse)
+    return Reference.encode(value.referencevalue(), prefix, reverse)
+
+  return encode_marker(NULL_CODE, reverse)
 
 
-def decode_value(encoded_value):
-  """ Converts a tuple to a PropertyValue. """
+def decode_value(blob, pos, reverse=False):
   prop_value = entity_pb.PropertyValue()
-  encoded_type = encoded_value[0]
-  if V3Types.null(encoded_type):
-    return prop_value
+  marker = blob[pos]
+  pos += 1
+  code = ord(marker ^ 0xFF) if reverse else ord(marker)
+  if code == NULL_CODE:
+    pass
+  elif INT64_ZERO_CODE - 8 <= code <= INT64_ZERO_CODE + 8:
+    int_val, pos = Int64.decode(marker, blob, pos, reverse)
+    prop_value.set_int64value(int_val)
+  elif code in (TRUE_CODE, FALSE_CODE):
+    prop_value.set_booleanvalue(code == TRUE_CODE)
+  elif code == BYTES_CODE:
+    bytes_val, pos = Bytes.decode(blob, pos, reverse)
+    prop_value.set_stringvalue(bytes_val)
+  elif code == DOUBLE_CODE:
+    double_val, pos = Double.decode(blob, pos, reverse)
+    prop_value.set_doublevalue(double_val)
+  elif code == POINT_CODE:
+    point_val, pos = Point.decode(blob, pos, reverse)
+    prop_value.mutable_pointvalue().MergeFrom(point_val)
+  elif code == USER_CODE:
+    user_val, pos = User.decode(blob, pos, reverse)
+    prop_value.mutable_uservalue().MergeFrom(user_val)
+  elif code == REFERENCE_CODE:
+    ref_val, pos = Reference.decode(blob, pos, reverse)
+    prop_value.mutable_referencevalue().MergeFrom(ref_val)
 
-  decoded_value = DECODERS[encoded_type](encoded_value[1:])
-  type_name = V3Types.name(encoded_type).lower()
-  if V3Types.scalar(encoded_type):
-    getattr(prop_value, 'set_{}value'.format(type_name))(decoded_value)
-  elif V3Types.compound(encoded_type):
-    compound_val = getattr(prop_value, 'mutable_{}value'.format(type_name))()
-    compound_val.MergeFrom(decoded_value)
-
-  return prop_value
-
-
-def encode_sortable_int(value, byte_count):
-  """ Encodes an integer using the specified number of bytes. """
-  format_str = u'>Q' if byte_count > 4 else u'>I'
-  encoded = struct.pack(format_str, value)
-  if any(byte != b'\x00' for byte in encoded[:-1 * byte_count]):
-    raise InternalError(u'Value exceeds maximum size')
-
-  return encoded[-1 * byte_count:]
-
-
-def decode_sortable_int(encoded_value):
-  """ Converts a byte string to an integer. """
-  format_str = u'>Q' if len(encoded_value) > 4 else u'>I'
-  format_size = 8 if len(encoded_value) > 4 else 4
-  encoded_value = b'\x00' * (format_size - len(encoded_value)) + encoded_value
-  return struct.unpack(format_str, encoded_value)[0]
+  return prop_value, pos
 
 
-encode_read_vs = lambda read_version: encode_sortable_int(
+encode_read_vs = lambda read_version: Int64.encode_bare(
   read_version, READ_VS_SIZE)
 
 

--- a/AppDB/appscale/datastore/fdb/codecs.py
+++ b/AppDB/appscale/datastore/fdb/codecs.py
@@ -343,7 +343,11 @@ class Path(object):
       path = entity_pb.Path()
 
     for index in range(0, len(flat_path), 2):
-      element = path.add_element()
+      if reference_value:
+        element = path.add_pathelement()
+      else:
+        element = path.add_element()
+
       element.set_type(flat_path[index])
       id_or_name = flat_path[index + 1]
       if isinstance(id_or_name, int):
@@ -385,19 +389,19 @@ class Reference(object):
       prefix,
       Text.encode(decode_str(value.app()), reverse=reverse),
       Text.encode(decode_str(value.name_space()), reverse=reverse),
-      Path.pack(Path.flatten(value), prefix=prefix, reverse=reverse)
+      Path.pack(Path.flatten(value), reverse=reverse)
     ])
 
   @classmethod
   def decode(cls, blob, pos, reverse=False):
     project_id, pos = Text.decode(blob, pos, reverse)
-    namespace, pos = Double.decode(blob, pos, reverse)
-    flat_path = Path.unpack(blob, pos, reverse=reverse)
+    namespace, pos = Text.decode(blob, pos, reverse)
+    flat_path, pos = Path.unpack(blob, pos, reverse=reverse)
     reference_val = entity_pb.PropertyValue_ReferenceValue()
     reference_val.set_app(project_id)
     reference_val.set_name_space(namespace)
     reference_val.MergeFrom(Path.decode(flat_path, reference_value=True))
-    return reference_val
+    return reference_val, pos
 
 
 def encode_value(value, reverse=False):

--- a/AppDB/appscale/datastore/fdb/codecs.py
+++ b/AppDB/appscale/datastore/fdb/codecs.py
@@ -1,0 +1,320 @@
+"""
+This module contains shared encoding and decoding utilities for translating
+datastore types to bytestrings and vice versa.
+"""
+import struct
+import sys
+
+import six
+
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+from appscale.datastore.dbconstants import BadRequest, InternalError
+from appscale.datastore.fdb.utils import fdb
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.datastore import entity_pb
+
+# The number of bytes used to encode a read versionstamp.
+READ_VS_SIZE = 8
+
+
+class V3Types(object):
+  NULL = b'\x00'
+  INT64 = b'\x01'
+  BOOLEAN = b'\x02'
+  STRING = b'\x03'
+  DOUBLE = b'\x04'
+  POINT = b'\x05'
+  USER = b'\x06'
+  REFERENCE = b'\x07'
+
+  accessible = (
+    ('int64', INT64), ('boolean', BOOLEAN), ('string', STRING),
+    ('double', DOUBLE), ('point', POINT), ('user', USER),
+    ('reference', REFERENCE))
+
+  @classmethod
+  def null(cls, encoded_type):
+    return encoded_type == cls.NULL or cls.reverse(encoded_type) == cls.NULL
+
+  @classmethod
+  def scalar(cls, encoded_type):
+    scalar_types = (cls.INT64, cls.BOOLEAN, cls.STRING, cls.DOUBLE)
+    return (encoded_type in scalar_types or
+            cls.reverse(encoded_type) in scalar_types)
+
+  @classmethod
+  def compound(cls, encoded_type):
+    compound_types = (cls.POINT, cls.USER, cls.REFERENCE)
+    return (encoded_type in compound_types or
+            cls.reverse(encoded_type) in compound_types)
+
+  @classmethod
+  def name(cls, encoded_type):
+    return next(key for key, val in V3Types.__dict__.items()
+                if val == encoded_type or val == cls.reverse(encoded_type))
+
+  @staticmethod
+  def reverse(encoded_type):
+    return bytes(bytearray([255 - ord(encoded_type)]))
+
+
+def decode_str(string):
+  """ Converts byte strings to unicode strings. """
+  if isinstance(string, six.text_type):
+    return string
+
+  return string.decode('utf-8')
+
+
+def encode_element(element):
+  """ Converts a path element protobuf object to a tuple. """
+  if element.has_id():
+    id_or_name = element.id()
+  elif element.has_name():
+    id_or_name = decode_str(element.name())
+  else:
+    raise BadRequest('All path elements must either have a name or ID')
+
+  return decode_str(element.type()), id_or_name
+
+
+def decode_element(element_tuple):
+  """ Converts a tuple to a path element protobuf object. """
+  path_element = entity_pb.Path_Element()
+  path_element.set_type(element_tuple[0])
+  if isinstance(element_tuple[1], int):
+    path_element.set_id(element_tuple[1])
+  else:
+    path_element.set_name(element_tuple[1])
+
+  return path_element
+
+
+def encode_ancestor_range(subspace, path):
+  """ Determines the start and stop key selectors for an ancestor range. """
+  embedded_value = fdb.tuple.pack(path)
+  # In order to exclude the ancestor itself, the range is manually selected
+  # using the potential values for the next element in the key path. It's
+  # normally a unicode string specifying the kind of the next element, but it
+  # can also be an integer if it's the last element and the index directory
+  # includes the kind.
+  embedded_start = embedded_value + six.int2byte(fdb.tuple.STRING_CODE)
+  embedded_stop = embedded_value + six.int2byte(fdb.tuple.POS_INT_END + 1)
+  prefix = subspace.rawPrefix + six.int2byte(fdb.tuple.NESTED_CODE)
+  start = fdb.KeySelector.first_greater_than(prefix + embedded_start)
+  stop = fdb.KeySelector.first_greater_or_equal(prefix + embedded_stop)
+  return start, stop
+
+
+def encode_path(path):
+  """ Converts a key path protobuf object to a tuple. """
+  if isinstance(path, entity_pb.PropertyValue):
+    element_list = path.referencevalue().pathelement_list()
+  elif isinstance(path, entity_pb.PropertyValue_ReferenceValue):
+    element_list = path.pathelement_list()
+  else:
+    element_list = path.element_list()
+
+  return tuple(item for element in element_list
+               for item in encode_element(element))
+
+
+def decode_path(encoded_path, reference_value=False):
+  """ Converts a tuple to a key path protobuf object. """
+  if reference_value:
+    path = entity_pb.PropertyValue_ReferenceValue()
+  else:
+    path = entity_pb.Path()
+
+  for index in range(0, len(encoded_path), 2):
+    element = path.add_element()
+    element.set_type(encoded_path[index])
+    id_or_name = encoded_path[index + 1]
+    if isinstance(id_or_name, int):
+      element.set_id(id_or_name)
+    else:
+      element.set_name(id_or_name)
+
+  return path
+
+
+def reverse_encode_string(unicode_string):
+  """ Encodes strings so that they will be sorted in reverse order. """
+  byte_array = bytearray(unicode_string, encoding='utf-8')
+  # In order to place smaller byte values before larger ones, each byte is
+  # inverted. In order to ensure that the shorter of two strings with otherwise
+  # identical prefixes will be placed after the longer string, the largest byte
+  # value (255) is used to terminate the string.
+  # Since b'\x00' would normally be encoded as the terminator with this
+  # conversion, each value is first shifted up a value before being inverted.
+  # For example, b'\x00' -> b'\x01' -> b'\xfe'. Luckily, b'\xff' is not used
+  # by UTF-8, so every encoded UTF-8 byte can be incremented without exceeding
+  # the largest byte value.
+  for index, byte_value in enumerate(byte_array):
+    byte_array[index] = 255 - (byte_value + 1)
+
+  return bytes(byte_array) + b'\xff'
+
+
+def reverse_decode_string(byte_string):
+  """ Recovers the original unicode string from a reverse-encoded one. """
+  byte_array = bytearray(byte_string[:-1])
+  for index, byte_value in enumerate(byte_array):
+    byte_array[index] = (255 - byte_value) - 1
+
+  return byte_array.decode('utf-8')
+
+
+def decode_point(val):
+  """ Converts a tuple to a PointValue property value object. """
+  point_val = entity_pb.PropertyValue_PointValue()
+  point_val.set_x(val[0])
+  point_val.set_y(val[1])
+  return point_val
+
+
+def decode_user(val):
+  """ Converts a tuple to a UserValue property value object. """
+  user_val = entity_pb.PropertyValue_UserValue()
+  user_val.set_email(val[0])
+  user_val.set_auth_domain(val[1])
+  return user_val
+
+
+def encode_reference(val):
+  """ Converts an entity key protobuf object to a tuple. """
+  project_id = decode_str(val.app())
+  namespace = decode_str(val.name_space())
+  return (project_id, namespace) + encode_path(val)
+
+
+def decode_reference(val):
+  """ Converts a tuple to an entity key protobuf object. """
+  reference_val = entity_pb.PropertyValue_ReferenceValue()
+  reference_val.set_app(val[0])
+  reference_val.set_name_space(val[1])
+  reference_val.MergeFrom(decode_path(val[2:], reference_value=True))
+  return reference_val
+
+
+ENCODERS = {
+  V3Types.NULL: lambda val: tuple(),
+  V3Types.INT64: lambda val: (val,),
+  V3Types.BOOLEAN: lambda val: (val,),
+  V3Types.STRING: lambda val: (decode_str(val),),
+  V3Types.DOUBLE: lambda val: (val,),
+  V3Types.POINT: lambda val: (val.x(), val.y()),
+  V3Types.USER: lambda val: (decode_str(val.email()),
+                             decode_str(val.auth_domain())),
+  V3Types.REFERENCE: encode_reference,
+  V3Types.reverse(V3Types.NULL): lambda val: tuple(),
+  V3Types.reverse(V3Types.INT64): lambda val: (val * -1,),
+  V3Types.reverse(V3Types.BOOLEAN): lambda val: (not val,),
+  V3Types.reverse(V3Types.STRING):
+    lambda val: (reverse_encode_string(decode_str(val)),),
+  V3Types.reverse(V3Types.DOUBLE): lambda val: (val * -1,),
+  V3Types.reverse(V3Types.POINT): lambda val: (val.x() * -1, val.y() * -1),
+  V3Types.reverse(V3Types.USER):
+    lambda val: (reverse_encode_string(decode_str(val.email())),
+                 reverse_encode_string(decode_str(val.auth_domain()))),
+  V3Types.reverse(V3Types.REFERENCE):
+    lambda val: tuple(reverse_encode_string(item)
+                      for item in encode_reference(val))
+}
+
+
+DECODERS = {
+  V3Types.INT64: lambda val: val[0],
+  V3Types.BOOLEAN: lambda val: val[0],
+  V3Types.STRING: lambda val: val[0],
+  V3Types.DOUBLE: lambda val: val[0],
+  V3Types.POINT: decode_point,
+  V3Types.USER: decode_user,
+  V3Types.REFERENCE: decode_reference,
+  V3Types.reverse(V3Types.INT64): lambda val: val[0] * -1,
+  V3Types.reverse(V3Types.BOOLEAN): lambda val: not val[0],
+  V3Types.reverse(V3Types.STRING): lambda val: reverse_decode_string(val[0]),
+  V3Types.reverse(V3Types.DOUBLE): lambda val: val[0] * -1,
+  V3Types.reverse(V3Types.POINT):
+    lambda val: decode_point((val[0] * -1, val[1] * -1)),
+  V3Types.reverse(V3Types.USER):
+    lambda val: decode_user((reverse_decode_string(val[0]),
+                             reverse_decode_string(val[1]))),
+  V3Types.reverse(V3Types.REFERENCE):
+    lambda val: decode_reference(tuple(reverse_decode_string(item)
+                                       for item in val))
+}
+
+
+def unpack_value(value):
+  """ Extracts the value from a V3 PropertyValue object.
+
+  Args:
+    value: A PropertyValue protobuf object.
+  Returns:
+    A tuple in the form of (<value-type>, <value>).
+  """
+  for type_name, encoded_type in V3Types.accessible:
+    if getattr(value, 'has_{}value'.format(type_name))():
+      return encoded_type, getattr(value, '{}value'.format(type_name))()
+
+  return V3Types.NULL, None
+
+
+def encode_value(value, reverse=False):
+  """ Converts a PropertyValue to a tuple. """
+  if isinstance(value, six.integer_types):
+    encoded_type = V3Types.INT64
+  else:
+    encoded_type, value = unpack_value(value)
+
+  if reverse:
+    encoded_type = V3Types.reverse(encoded_type)
+
+  return (encoded_type,) + ENCODERS[encoded_type](value)
+
+
+def decode_value(encoded_value):
+  """ Converts a tuple to a PropertyValue. """
+  prop_value = entity_pb.PropertyValue()
+  encoded_type = encoded_value[0]
+  if V3Types.null(encoded_type):
+    return prop_value
+
+  decoded_value = DECODERS[encoded_type](encoded_value[1:])
+  type_name = V3Types.name(encoded_type).lower()
+  if V3Types.scalar(encoded_type):
+    getattr(prop_value, 'set_{}value'.format(type_name))(decoded_value)
+  elif V3Types.compound(encoded_type):
+    compound_val = getattr(prop_value, 'mutable_{}value'.format(type_name))()
+    compound_val.MergeFrom(decoded_value)
+
+  return prop_value
+
+
+def encode_sortable_int(value, byte_count):
+  """ Encodes an integer using the specified number of bytes. """
+  format_str = u'>Q' if byte_count > 4 else u'>I'
+  encoded = struct.pack(format_str, value)
+  if any(byte != b'\x00' for byte in encoded[:-1 * byte_count]):
+    raise InternalError(u'Value exceeds maximum size')
+
+  return encoded[-1 * byte_count:]
+
+
+def decode_sortable_int(encoded_value):
+  """ Converts a byte string to an integer. """
+  format_str = u'>Q' if len(encoded_value) > 4 else u'>I'
+  format_size = 8 if len(encoded_value) > 4 else 4
+  encoded_value = b'\x00' * (format_size - len(encoded_value)) + encoded_value
+  return struct.unpack(format_str, encoded_value)[0]
+
+
+encode_read_vs = lambda read_version: encode_sortable_int(
+  read_version, READ_VS_SIZE)
+
+
+def encode_vs_index(vs_position):
+  """ Encodes an FDB key index position. """
+  return struct.pack(u'<L', vs_position)

--- a/AppDB/appscale/datastore/fdb/data.py
+++ b/AppDB/appscale/datastore/fdb/data.py
@@ -1,0 +1,513 @@
+"""
+This module stores and retrieves entity data as well as the metadata needed to
+achieve snapshot isolation during transactions. The DataManager is the main
+interface that clients can use to interact with the data layer. See its
+documentation for implementation details.
+"""
+from __future__ import division
+import logging
+import math
+import struct
+import sys
+
+import six.moves as sm
+from tornado import gen
+
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+from appscale.datastore.dbconstants import BadRequest, InternalError
+from appscale.datastore.fdb.cache import NSCache
+from appscale.datastore.fdb.codecs import (
+  decode_path, decode_sortable_int, encode_path, encode_sortable_int,
+  encode_vs_index)
+from appscale.datastore.fdb.utils import (
+  ABSENT_VERSION, DS_ROOT, EncodedTypes, fdb, hash_tuple, KVIterator,
+  MAX_ENTITY_SIZE, VS_SIZE)
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.datastore import entity_pb
+
+logger = logging.getLogger(__name__)
+
+
+class VersionEntry(object):
+  """ Encapsulates details for an entity version. """
+  __SLOTS__ = [u'project_id', u'namespace', u'path', u'commit_vs',
+               u'version', u'_encoded_entity', u'_decoded_entity']
+
+  def __init__(self, project_id, namespace, path, commit_vs=None,
+               encoded_entity=None, version=None):
+    self.project_id = project_id
+    self.namespace = namespace
+    self.path = path
+    self.commit_vs = commit_vs
+    self.version = ABSENT_VERSION if version is None else version
+    self._encoded_entity = encoded_entity
+    self._decoded_entity = None
+
+  @property
+  def complete(self):
+    return self._encoded_entity is not None or self._decoded_entity is not None
+
+  @property
+  def present(self):
+    return self.version != ABSENT_VERSION
+
+  @property
+  def key(self):
+    key = entity_pb.Reference()
+    key.set_app(self.project_id)
+    key.set_name_space(self.namespace)
+    key.mutable_path().MergeFrom(decode_path(self.path))
+    return key
+
+  @property
+  def encoded(self):
+    if self._encoded_entity is not None:
+      return self._encoded_entity
+    elif self._decoded_entity is not None:
+      self._encoded_entity = self._decoded_entity.Encode()
+      return self._encoded_entity
+    else:
+      return None
+
+  @property
+  def decoded(self):
+    if self._decoded_entity is not None:
+      return self._decoded_entity
+    elif self._encoded_entity is not None:
+      self._decoded_entity = entity_pb.EntityProto(self._encoded_entity)
+      return self._decoded_entity
+    else:
+      return None
+
+
+class DataNamespace(object):
+  """
+  A DataNamespace handles the encoding and decoding details for entity data
+  for a specific project_id/namespace combination.
+
+  The directory path looks like (<project-dir>, 'data', <namespace>).
+
+  Within this directory, keys are encoded as
+  <scatter-byte> + <path-tuple> + <commit-vs> + <index>.
+
+  The <scatter-byte> is a single byte determined by hashing the entity path.
+  Its purpose is to spread writes more evenly across the cluster and minimize
+  hotspots.
+
+  The <path-tuple> is an encoded tuple containing the entity path.
+
+  The <commit-vs> is a 10-byte versionstamp that specifies the commit version
+  of the transaction that wrote the entity data.
+
+  The <index> is a single byte specifying which chunk number the KV contains.
+
+  Values are encoded as <entity-version> + <entity-encoding> + <entity>.
+
+  The <entity-version> is an integer specifying the approximate insert
+  timestamp in microseconds (according to the client performing the insert).
+  Though there is a one-to-one mapping of commit versionstamps to entity
+  versions, the datastore uses a different value for the entity version in
+  order to satisfy the 8-byte constraint and to follow the GAE convention of
+  the value representing a timestamp. It is encoded using 7 bytes.
+
+  The <entity-encoding> is a single byte specifying the encoding scheme of the
+  entity to follow.
+
+  The <entity> is an encoded protobuffer value.
+
+  Since encoded values can exceed the size limit imposed by FoundationDB,
+  values encoded values are split into chunks. Each chunk is stored as a
+  KV and ordered by a unique <index> byte.
+  """
+  DIR_NAME = u'data'
+
+  # The max number of bytes for each FDB value.
+  _CHUNK_SIZE = 10000
+
+  # The number of bytes used to store an entity version.
+  _VERSION_SIZE = 7
+
+  # The number of bytes used to encode the chunk index.
+  _INDEX_SIZE = 1
+
+  def __init__(self, directory):
+    self.directory = directory
+
+  @property
+  def project_id(self):
+    return self.directory.get_path()[len(DS_ROOT)]
+
+  @property
+  def namespace(self):
+    return self.directory.get_path()[len(DS_ROOT) + 2]
+
+  @property
+  def path_slice(self):
+    """ The portion of keys that contain the encoded path. """
+    return slice(len(self.directory.rawPrefix) + 1,
+                 -1 * (VS_SIZE + self._INDEX_SIZE))
+
+  @property
+  def vs_slice(self):
+    """ The portion of keys that contain the commit versionstamp. """
+    return slice(self.path_slice.stop, self.path_slice.stop + VS_SIZE)
+
+  @property
+  def index_slice(self):
+    """ The portion of keys that contain the chunk index. """
+    return slice(-1 * self._INDEX_SIZE, None)
+
+  @property
+  def version_slice(self):
+    """ The portion of values that contain the entity version. """
+    return slice(None, self._VERSION_SIZE)
+
+  @property
+  def encoding_slice(self):
+    """ The portion of values that specify the entity encoding type. """
+    return slice(self._VERSION_SIZE, self._VERSION_SIZE + 1)
+
+  @property
+  def entity_slice(self):
+    """ The portion of values that contain the encoded entity. """
+    return slice(self._VERSION_SIZE + 1, None)
+
+  def encode(self, path, entity, version):
+    """ Encodes a tuple of KV tuples for a given version entry.
+
+    Args:
+      path: A tuple or protobuf path object.
+      entity: An encoded entity or protobuf object.
+      version: An integer specifying the new entity version.
+    Returns:
+      A tuple of KV tuples suitable for writing in an FDB transaction.
+    """
+    if isinstance(entity, entity_pb.EntityProto):
+      entity = entity.Encode()
+
+    if len(entity) > MAX_ENTITY_SIZE:
+      raise BadRequest(u'Entity exceeds maximum size')
+
+    encoded_version = encode_sortable_int(version, self._VERSION_SIZE)
+    full_value = b''.join([encoded_version, EncodedTypes.ENTITY_V3, entity])
+    chunk_count = int(math.ceil(len(full_value) / self._CHUNK_SIZE))
+    return tuple(self._encode_kv(full_value, index, path, commit_vs=None)
+                 for index in sm.range(chunk_count))
+
+  def encode_key(self, path, commit_vs, index):
+    """ Encodes a key for the given version entry.
+
+    Args:
+      path: A tuple or protobuf path object.
+      commit_vs: A 10-byte string specifying the version's commit versionstamp
+        or None.
+      index: An integer specifying the chunk index.
+    Returns:
+      A string containing an FDB key. If commit_vs was None, the key should be
+      used with set_versionstamped_key.
+    """
+    encoded_index = bytes(bytearray((index,)))
+    encoded_key = b''.join([self._encode_path_prefix(path),
+                            commit_vs or b'\x00' * VS_SIZE,
+                            encoded_index])
+    if not commit_vs:
+      vs_index = len(encoded_key) - (VS_SIZE + self._INDEX_SIZE)
+      encoded_key += encode_vs_index(vs_index)
+
+    return encoded_key
+
+  def decode(self, kvs):
+    """ Decodes KVs to a version entry.
+
+    Args:
+      kvs: An iterable containing KeyValue objects.
+    Returns:
+      A VersionEntry object.
+    """
+    path = fdb.tuple.unpack(kvs[0].key[self.path_slice])
+    commit_vs = kvs[0].key[self.vs_slice]
+    first_index = ord(kvs[0].key[self.index_slice])
+
+    encoded_entity = None
+    version = None
+    if first_index == 0:
+      encoded_val = b''.join([kv.value for kv in kvs])
+      version = decode_sortable_int(encoded_val[self.version_slice])
+      encoding = encoded_val[self.encoding_slice]
+      encoded_entity = encoded_val[self.entity_slice]
+      if encoding != EncodedTypes.ENTITY_V3:
+        raise InternalError(u'Unknown entity type')
+
+    return VersionEntry(self.project_id, self.namespace, path, commit_vs,
+                        encoded_entity, version)
+
+  def get_slice(self, path, commit_vs=None, read_vs=None):
+    """ Gets the range of keys relevant to the given constraints.
+
+    Args:
+      path: A tuple or protobuf path object.
+      commit_vs: The commit versionstamp for a specific entity version.
+      read_vs: The transaction's read versionstamp. All newer entity versions
+        are ignored.
+    Returns:
+      A slice specifying the start and stop keys.
+    """
+    path_prefix = self._encode_path_prefix(path)
+    if commit_vs is not None:
+      prefix = path_prefix + commit_vs
+      # All chunks for a given version.
+      return slice(fdb.KeySelector.first_greater_or_equal(prefix + b'\x00'),
+                   fdb.KeySelector.first_greater_than(prefix + b'\xff'))
+
+    if read_vs is not None:
+      version_prefix = path_prefix + read_vs
+      # All versions for a given path except those written after the read_vs.
+      return slice(
+        fdb.KeySelector.first_greater_or_equal(path_prefix + b'\x00'),
+        fdb.KeySelector.first_greater_than(version_prefix + b'\xff'))
+
+    # All versions for a given path.
+    return slice(fdb.KeySelector.first_greater_or_equal(path_prefix + b'\x00'),
+                 fdb.KeySelector.first_greater_than(path_prefix + b'\xff'))
+
+  def _encode_path_prefix(self, path):
+    """ Encodes the portion of the key up to and including the path.
+
+    Args:
+      path: A tuple or protobuf path object.
+    Returns:
+      A string containing the path prefix.
+    """
+    if not isinstance(path, tuple):
+      path = encode_path(path)
+
+    return b''.join([self.directory.rawPrefix, hash_tuple(path),
+                     fdb.tuple.pack(path)])
+
+  def _encode_kv(self, full_value, index, path, commit_vs):
+    """ Encodes an individual KV entry for a single chunk.
+
+    Args:
+      full_value: A string containing the full encoded version entry value.
+      index: An integer specifying the chunk index.
+      path: A tuple or protobuf path object.
+      commit_vs: A 10-byte string specifying the version's commit versionstamp
+        or None.
+    Returns:
+      A tuple in the form of (key, value) suitable for using with FDB. If
+      commit_vs was None, the tuple should be used with set_versionstamped_key.
+    """
+    data_range = slice(index * self._CHUNK_SIZE,
+                       (index + 1) * self._CHUNK_SIZE)
+    encoded_val = full_value[data_range]
+    return self.encode_key(path, commit_vs, index), encoded_val
+
+
+class GroupUpdatesNS(object):
+  """
+  A GroupUpdatesNS handles the encoding and decoding details for commit
+  versionstamps for each entity group. These are used to materialize conflicts
+  for transactions that involve ancestory queries on the same entity groups.
+
+  The directory path looks like (<project-dir>, 'group-updates', <namespace>).
+
+  Within this directory, keys are encoded as <scatter-byte> + <path-tuple>.
+
+  The <scatter-byte> is a single byte determined by hashing the group path.
+  Its purpose is to spread writes more evenly across the cluster and minimize
+  hotspots.
+
+  The <path-tuple> is an encoded tuple containing the group path.
+
+  Values are 10-byte strings that specify the latest commit version for the
+  entity group.
+  """
+  DIR_NAME = u'group-updates'
+
+  def __init__(self, directory):
+    self.directory = directory
+
+  def encode(self, path):
+    """ Creates a KV tuple for updating a group's commit versionstamp.
+
+    Args:
+      path: A tuple or protobuf path object.
+    Returns:
+      A (key, value) tuple suitable for set_versionstamped_value.
+    """
+    if not isinstance(path, tuple):
+      path = encode_path(path)
+
+    group_path = path[:2]
+    val = b'\x00' * VS_SIZE + struct.pack('<L', 0)
+    return self.encode_key(group_path), val
+
+  def encode_key(self, group_path):
+    """ Encodes a key for a given entity group.
+
+    Args:
+      group_path: A tuple containing path elements.
+    Returns:
+      A byte string containing the relevant FDB key.
+    """
+    return b''.join([self.directory.rawPrefix, hash_tuple(group_path),
+                     fdb.tuple.pack(group_path)])
+
+
+class DataManager(object):
+  """
+  The DataManager is the main interface that clients can use to interact with
+  the data layer. It makes use of the DataNamespace and GroupUpdateNS
+  namespaces to handle the encoding and decoding details when satisfying
+  requests. When a client requests data, the DataManager encapsulates entity
+  data in a VersionEntry object.
+
+  See the DataNamespace and GroupUpdateNS classes for implementation details
+  about how data is stored and retrieved.
+  """
+  def __init__(self, tornado_fdb, project_cache):
+    self._tornado_fdb = tornado_fdb
+    self._data_cache = NSCache(self._tornado_fdb, project_cache, DataNamespace)
+    self._group_updates_cache = NSCache(
+      self._tornado_fdb, project_cache, GroupUpdatesNS)
+
+  @gen.coroutine
+  def get_latest(self, tr, key, read_vs=None, include_data=True):
+    """ Gets the newest entity version for the given read VS.
+
+    Args:
+      tr: An FDB transaction.
+      key: A protubuf reference object.
+      read_vs: A 10-byte string specifying the FDB read versionstamp. Newer
+        versionstamps are ignored.
+      include_data: A boolean specifying whether or not to fetch all of the
+        entity's KVs.
+    """
+    data_ns = yield self._data_cache.get_from_key(tr, key)
+    desired_slice = data_ns.get_slice(key.path(), read_vs=read_vs)
+    last_entry = yield self._last_version(
+      tr, data_ns, desired_slice, include_data)
+    if last_entry is None:
+      last_entry = VersionEntry(data_ns.project_id, data_ns.namespace,
+                                encode_path(key.path()))
+
+    raise gen.Return(last_entry)
+
+  @gen.coroutine
+  def get_entry(self, tr, index_entry, snapshot=False):
+    """ Gets the entity data from an index entry.
+
+    Args:
+      tr: An FDB transaction.
+      index_entry: An IndexEntry object.
+      snapshot: If True, the read will not cause a transaction conflict.
+    Returns:
+      A VersionEntry or None.
+    """
+    version_entry = yield self.get_version_from_path(
+      tr, index_entry.project_id, index_entry.namespace, index_entry.path,
+      index_entry.commit_vs, snapshot)
+    raise gen.Return(version_entry)
+
+  @gen.coroutine
+  def get_version_from_path(self, tr, project_id, namespace, path, commit_vs,
+                            snapshot=False):
+    """ Gets the entity data for a specific version.
+
+    Args:
+      tr: An FDB transaction.
+      project_id: A string specifying the project ID.
+      namespace: A string specifying the namespace.
+      path: A tuple or protobuf path object.
+      commit_vs: A 10-byte string specyfing the FDB commit versionstamp.
+      snapshot: If True, the read will not cause a transaction conflict.
+    Returns:
+      A VersionEntry or None.
+    """
+    data_ns = yield self._data_cache.get(tr, project_id, namespace)
+    desired_slice = data_ns.get_slice(path, commit_vs)
+    kvs = yield KVIterator(tr, self._tornado_fdb, desired_slice,
+                           snapshot=snapshot).list()
+    raise gen.Return(data_ns.decode(kvs))
+
+  @gen.coroutine
+  def last_group_vs(self, tr, project_id, namespace, group_path):
+    """ Gets the most recent commit versionstamp for the entity group.
+
+    Args:
+      tr: An FDB transaction.
+      project_id: A string specifying the project ID.
+      namespace: A string specifying the namespace.
+      group_path: A tuple containing the group's path elements.
+    Returns:
+      A 10-byte string specifying the versionstamp or None.
+    """
+    group_ns = yield self._group_updates_cache.get(tr, project_id, namespace)
+    last_updated_vs = yield self._tornado_fdb.get(
+      tr, group_ns.encode_key(group_path))
+    if not last_updated_vs.present():
+      return
+
+    raise gen.Return(last_updated_vs.value)
+
+  @gen.coroutine
+  def put(self, tr, key, version, encoded_entity):
+    """ Writes a new version entry and updates the entity group VS.
+
+    Args:
+      tr: An FDB transaction.
+      key: A protobuf reference object.
+      version: An integer specifying the new entity version.
+      encoded_entity: A string specifying the encoded entity data.
+    """
+    data_ns = yield self._data_cache.get_from_key(tr, key)
+    for fdb_key, val in data_ns.encode(key.path(), encoded_entity, version):
+      tr[fdb_key] = val
+
+    group_ns = yield self._group_updates_cache.get(
+      tr, data_ns.project_id, data_ns.namespace)
+    tr.set_versionstamped_value(*group_ns.encode(key.path()))
+
+  @gen.coroutine
+  def hard_delete(self, tr, key, commit_vs):
+    """ Deletes a version entry. Only the GC should use this.
+
+    Args:
+      tr: An FDB transaction.
+      key: A protobuf reference object.
+      commit_vs: A 10-byte string specifying the commit versionstamp.
+    """
+    data_ns = yield self._data_cache.get_from_key(tr, key)
+    del tr[data_ns.get_slice(key.path(), commit_vs)]
+
+  @gen.coroutine
+  def _last_version(self, tr, data_ns, desired_slice, include_data=True):
+    """ Gets the most recent entity data for a given slice.
+
+    Args:
+      tr: An FDB transaction.
+      data_ns: A DataNamespace.
+      desired_slice: A slice specifying the start and stop keys.
+      include_data: A boolean indicating that all chunks should be fetched.
+    Returns:
+      A VersionEntry or None.
+    """
+    kvs, count, more_results = yield self._tornado_fdb.get_range(
+      tr, desired_slice, limit=1, reverse=True)
+
+    if not kvs:
+      return
+
+    last_kv = kvs[0]
+    entry = data_ns.decode([last_kv])
+    if not include_data or entry.complete:
+      raise gen.Return(entry)
+
+    # Retrieve the remaining chunks.
+    version_slice = data_ns.get_slice(entry.path, entry.commit_vs)
+    end_key = data_ns.encode_key(entry.path, entry.commit_vs, entry.index)
+    remaining_slice = slice(version_slice.start,
+                            fdb.KeySelector.first_greater_or_equal(end_key))
+    kvs = yield KVIterator(tr, self._tornado_fdb, remaining_slice).list()
+    raise gen.Return(data_ns.decode(kvs + [last_kv]))

--- a/AppDB/appscale/datastore/fdb/data.py
+++ b/AppDB/appscale/datastore/fdb/data.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 class VersionEntry(object):
   """ Encapsulates details for an entity version. """
-  __SLOTS__ = ['project_id', 'namespace', 'path', 'commit_vs', 'version',
+  __slots__ = ['project_id', 'namespace', 'path', 'commit_vs', 'version',
                '_encoded_entity', '_decoded_entity']
 
   def __init__(self, project_id, namespace, path, commit_vs=None,

--- a/AppDB/appscale/datastore/fdb/data.py
+++ b/AppDB/appscale/datastore/fdb/data.py
@@ -130,7 +130,7 @@ class DataNamespace(object):
 
   Since encoded values can exceed the size limit imposed by FoundationDB,
   values encoded values are split into chunks. Each chunk is stored as a
-  KV and ordered by a unique <index> byte.
+  Key-Value and ordered by a unique <index> byte.
   """
   DIR_NAME = u'data'
 
@@ -194,14 +194,14 @@ class DataNamespace(object):
     return project_id, cls.DIR_NAME, namespace
 
   def encode(self, path, entity, version):
-    """ Encodes a tuple of KV tuples for a given version entry.
+    """ Encodes a tuple of Key-Value tuples for a given version entry.
 
     Args:
       path: A tuple or protobuf path object.
       entity: An encoded entity or protobuf object.
       version: An integer specifying the new entity version.
     Returns:
-      A tuple of KV tuples suitable for writing in an FDB transaction.
+      A tuple of Key-Value tuples suitable for writing in an FDB transaction.
     """
     if isinstance(entity, entity_pb.EntityProto):
       entity = entity.Encode()
@@ -247,7 +247,7 @@ class DataNamespace(object):
     return encoded_key
 
   def decode(self, kvs):
-    """ Decodes KVs to a version entry.
+    """ Decodes Key-Values to a version entry.
 
     Args:
       kvs: An iterable containing KeyValue objects.
@@ -341,7 +341,7 @@ class GroupUpdatesNS(object):
     return project_id, cls.DIR_NAME, namespace
 
   def encode(self, path):
-    """ Creates a KV tuple for updating a group's commit versionstamp.
+    """ Creates a Key-Value tuple for updating a group's commit versionstamp.
 
     Args:
       path: A tuple or protobuf path object.
@@ -394,7 +394,7 @@ class DataManager(object):
       read_versionstamp: A 10-byte string specifying the FDB read versionstamp.
         Newer versionstamps are ignored.
       include_data: A boolean specifying whether or not to fetch all of the
-        entity's KVs.
+        entity's Key-Values.
       snapshot: If True, the read will not cause a transaction conflict.
     """
     data_ns = yield self._data_ns_from_key(tr, key)

--- a/AppDB/appscale/datastore/fdb/data.py
+++ b/AppDB/appscale/datastore/fdb/data.py
@@ -271,6 +271,9 @@ class DataNamespace(object):
     Returns:
       A string containing the path prefix.
     """
+    if not isinstance(path, tuple):
+      path = Path.flatten(path)
+
     return b''.join([self.directory.rawPrefix, hash_tuple(path),
                      Path.pack(path)])
 

--- a/AppDB/appscale/datastore/fdb/fdb_datastore.py
+++ b/AppDB/appscale/datastore/fdb/fdb_datastore.py
@@ -1,0 +1,429 @@
+"""
+A datastore implementation that uses FoundationDB.
+
+All datastore state is split between multiple FoundationDB directories. All of
+the state for a given project is stored in (appscale, datastore, <project-id>).
+Within each project directory, there is a directory for each of the following:
+
+data: encoded entity data
+indexes: entity key references by property values
+transactions: transaction metadata
+
+See each submodule for more implementation details.
+"""
+import logging
+import sys
+
+from tornado import gen
+from tornado.ioloop import IOLoop
+
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+from appscale.datastore.dbconstants import (
+  BadRequest, ConcurrentModificationException, InternalError)
+from appscale.datastore.fdb.cache import ProjectCache
+from appscale.datastore.fdb.codecs import decode_str, encode_read_vs
+from appscale.datastore.fdb.data import DataManager
+from appscale.datastore.fdb.gc import GarbageCollector
+from appscale.datastore.fdb.indexes import (
+  get_order_info, IndexManager, KEY_PROP)
+from appscale.datastore.fdb.transactions import TransactionManager
+from appscale.datastore.fdb.utils import (
+  fdb, next_entity_version, DS_ROOT, ScatteredAllocator, TornadoFDB)
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.datastore import entity_pb
+
+logger = logging.getLogger(__name__)
+
+
+class FDBDatastore(object):
+  """ A datastore implementation that uses FoundationDB. """
+
+  def __init__(self):
+    self.index_manager = None
+    self._data_manager = None
+    self._db = None
+    self._scattered_allocator = ScatteredAllocator()
+    self._tornado_fdb = None
+    self._tx_manager = None
+    self._gc = None
+
+  def start(self):
+    self._db = fdb.open()
+    self._tornado_fdb = TornadoFDB(IOLoop.current())
+    ds_dir = fdb.directory.create_or_open(self._db, DS_ROOT)
+    project_cache = ProjectCache(self._tornado_fdb, ds_dir)
+    self._data_manager = DataManager(self._tornado_fdb, project_cache)
+    self.index_manager = IndexManager(
+      self._db, self._tornado_fdb, self._data_manager, project_cache)
+    self._tx_manager = TransactionManager(self._tornado_fdb, project_cache)
+    self._gc = GarbageCollector(
+      self._db, self._tornado_fdb, self._data_manager, self.index_manager,
+      self._tx_manager, project_cache)
+    self._gc.start()
+
+  @gen.coroutine
+  def dynamic_put(self, project_id, put_request, put_response):
+    #logger.debug('put_request:\n{}'.format(put_request))
+    project_id = decode_str(project_id)
+    # TODO: Enforce max key length (100 elements).
+    # Enforce max element size (1500 bytes).
+    # Enforce max kind size (1500 bytes).
+    # Enforce key name regex (reserved names match __.*__).
+
+    if put_request.auto_id_policy() != put_request.CURRENT:
+      raise BadRequest('Sequential allocator is not implemented')
+
+    tr = self._db.create_transaction()
+
+    if put_request.has_transaction():
+      logger.debug('put in tx: {}'.format(put_request.transaction().handle()))
+      yield self._tx_manager.log_puts(tr, project_id, put_request)
+      writes = [(entity.key(), None, None, None)
+                for entity in put_request.entity_list()]
+    else:
+      futures = []
+      for entity in put_request.entity_list():
+        futures.append(self._upsert(tr, entity))
+
+      writes = yield futures
+
+    old_entities = [(old_entity, old_vs) for _, old_entity, old_vs, _ in writes
+                    if old_entity is not None]
+    vs_future = None
+    if old_entities:
+      vs_future = tr.get_versionstamp()
+
+    yield self._tornado_fdb.commit(tr)
+
+    if old_entities:
+      self._gc.clear_later(old_entities, vs_future.wait().value)
+
+    for key, _, _, new_version in writes:
+      put_response.add_key().CopyFrom(key)
+      if new_version is not None:
+        put_response.add_version(new_version)
+
+    logger.debug('success')
+    #logger.debug('put_response:\n{}'.format(put_response))
+
+  @gen.coroutine
+  def dynamic_get(self, project_id, get_request, get_response):
+    logger.debug('get_request:\n{}'.format(get_request))
+    project_id = decode_str(project_id)
+    tr = self._db.create_transaction()
+
+    read_vs = None
+    if get_request.has_transaction():
+      yield self._tx_manager.log_lookups(tr, project_id, get_request)
+
+      # Ensure the GC hasn't cleaned up an entity written after the tx start.
+      safe_read_stamps = yield [self._gc.safe_read_vs(tr, key)
+                                for key in get_request.key_list()]
+      safe_read_stamps = [vs for vs in safe_read_stamps if vs is not None]
+      read_vs = encode_read_vs(get_request.transaction().handle())
+      if any(safe_vs > read_vs for safe_vs in safe_read_stamps):
+        raise BadRequest(u'The specified transaction has expired')
+
+    futures = []
+    for key in get_request.key_list():
+      futures.append(self._data_manager.get_latest(tr, key, read_vs))
+
+    version_entries = yield futures
+
+    # If this read is in a transaction, logging the RPC is a mutation.
+    yield self._tornado_fdb.commit(tr)
+
+    for entry in version_entries:
+      response_entity = get_response.add_entity()
+      response_entity.mutable_key().MergeFrom(entry.key)
+      response_entity.set_version(entry.version)
+      if entry.complete:
+        entity = entity_pb.EntityProto(entry.encoded)
+        response_entity.mutable_entity().MergeFrom(entity)
+
+    logger.debug('fetched paths: {}'.format(
+      [entry.path for entry in version_entries if entry.present]))
+
+  @gen.coroutine
+  def dynamic_delete(self, project_id, delete_request):
+    logger.debug('delete_request:\n{}'.format(delete_request))
+    project_id = decode_str(project_id)
+    tr = self._db.create_transaction()
+
+    if delete_request.has_transaction():
+      yield self._tx_manager.log_deletes(tr, project_id, delete_request)
+      deletes = [(None, None, None) for _ in delete_request.key_list()]
+    else:
+      futures = []
+      for key in delete_request.key_list():
+        futures.append(self._delete(tr, key))
+
+      deletes = yield futures
+
+    old_entities = [(old_entity, old_vs) for old_entity, old_vs, _ in deletes
+                    if old_entity is not None]
+    vs_future = None
+    if old_entities:
+      vs_future = tr.get_versionstamp()
+
+    yield self._tornado_fdb.commit(tr)
+
+    if old_entities:
+      self._gc.clear_later(old_entities, vs_future.wait().value)
+
+    # TODO: Once the Cassandra backend is removed, populate a delete response.
+    for old_entity, old_vs, new_version in deletes:
+      logger.debug('new_version: {}'.format(new_version))
+
+  @gen.coroutine
+  def _dynamic_run_query(self, query, query_result):
+    logger.debug('query: {}'.format(query))
+    project_id = decode_str(query.app())
+    tr = self._db.create_transaction()
+    read_vs = None
+    if query.has_transaction():
+      yield self._tx_manager.log_query(tr, project_id, query)
+
+      # Ensure the GC hasn't cleaned up an entity written after the tx start.
+      safe_vs = yield self._gc.safe_read_vs(tr, query.ancestor())
+      read_vs = encode_read_vs(query.transaction().handle())
+      if safe_vs is not None and safe_vs > read_vs:
+        raise BadRequest(u'The specified transaction has expired')
+
+    fetch_data = self.index_manager.include_data(query)
+    rpc_limit, check_more_results = self.index_manager.rpc_limit(query)
+
+    iterator = yield self.index_manager.get_iterator(tr, query, read_vs)
+    for prop_name in query.property_name_list():
+      prop_name = decode_str(prop_name)
+      if prop_name not in iterator.prop_names:
+        raise BadRequest(
+          u'Projections on {} are not supported'.format(prop_name))
+
+    data_futures = [] if fetch_data else None
+    unique_keys = set()
+    results = []
+    entries_fetched = 0
+    skipped_results = 0
+    cursor = None
+    while True:
+      remainder = rpc_limit - entries_fetched
+      iter_offset = max(query.offset() - entries_fetched, 0)
+      entries, more_iterator_results = yield iterator.next_page()
+      entries_fetched += len(entries)
+      if not entries and more_iterator_results:
+        continue
+
+      if not entries and not more_iterator_results:
+        break
+
+      skipped_results += min(len(entries), iter_offset)
+      suitable_entries = entries[iter_offset:remainder]
+      if entries[:remainder]:
+        cursor = entries[:remainder][-1]
+
+      if not fetch_data and not query.keys_only():
+        results.extend([entry.prop_result() for entry in suitable_entries])
+        continue
+
+      for entry in suitable_entries:
+        if entry.path in unique_keys:
+          continue
+
+        unique_keys.add(entry.path)
+        if fetch_data:
+          data_futures.append(
+            self._data_manager.get_entry(tr, entry, snapshot=True))
+        else:
+          results.append(entry.key_result())
+
+      if not more_iterator_results:
+        break
+
+    if fetch_data:
+      entity_results = yield data_futures
+      results = [entity.encoded for entity in entity_results]
+    else:
+      results = [result.Encode() for result in results]
+
+    yield self._tornado_fdb.commit(tr)
+
+    query_result.result_list().extend(results)
+    # TODO: Figure out how ndb multi queries use compiled cursors.
+    if query.compile():
+      ordered_props = tuple(prop_name for prop_name, _ in get_order_info(query)
+                            if prop_name != KEY_PROP)
+      mutable_cursor = query_result.mutable_compiled_cursor()
+      if cursor is not None:
+        mutable_cursor.MergeFrom(cursor.cursor_result(ordered_props))
+
+    more_results = check_more_results and entries_fetched > rpc_limit
+    query_result.set_more_results(more_results)
+
+    if skipped_results:
+      query_result.set_skipped_results(skipped_results)
+
+    if query.keys_only():
+      query_result.set_keys_only(True)
+
+    logger.debug(u'{} results'.format(len(query_result.result_list())))
+
+  @gen.coroutine
+  def setup_transaction(self, project_id, is_xg):
+    project_id = decode_str(project_id)
+    tr = self._db.create_transaction()
+    txid = yield self._tx_manager.create(tr, project_id, is_xg)
+    logger.debug(u'Started new transaction: {}:{}'.format(project_id, txid))
+    yield self._tornado_fdb.commit(tr)
+    raise gen.Return(txid)
+
+  @gen.coroutine
+  def apply_txn_changes(self, project_id, txid):
+    logger.debug(u'Applying {}:{}'.format(project_id, txid))
+    project_id = decode_str(project_id)
+    tr = self._db.create_transaction()
+    read_vs = encode_read_vs(txid)
+    lookups, queried_groups, mutations = yield self._tx_manager.get_metadata(
+      tr, project_id, txid)
+
+    try:
+      old_entities = yield self._apply_mutations(
+        tr, project_id, queried_groups, mutations, lookups, read_vs)
+    finally:
+      yield self._tx_manager.delete(tr, project_id, txid)
+
+    vs_future = None
+    if old_entities:
+      vs_future = tr.get_versionstamp()
+
+    yield self._tornado_fdb.commit(tr)
+
+    if old_entities:
+      old_decoded = [entity.decoded for entity in old_entities]
+      self._gc.clear_later(old_decoded, vs_future.wait().value)
+
+    logger.debug(u'Finished applying {}:{}'.format(project_id, txid))
+
+  @gen.coroutine
+  def rollback_transaction(self, project_id, txid):
+    project_id = decode_str(project_id)
+    logger.debug(u'Rolling back {}:{}'.format(project_id, txid))
+
+    tr = self._db.create_transaction()
+    yield self._tx_manager.delete(tr, project_id, txid)
+    yield self._tornado_fdb.commit(tr)
+
+  @gen.coroutine
+  def update_composite_index(self, project_id, index):
+    project_id = decode_str(project_id)
+    yield self.index_manager.update_composite_index(project_id, index)
+
+  @gen.coroutine
+  def _upsert(self, tr, entity):
+    last_element = entity.key().path().element(-1)
+    auto_id = False
+    if not last_element.has_name():
+      auto_id = not (last_element.has_id() and last_element.id() != 0)
+
+    if auto_id:
+      last_element.set_id(self._scattered_allocator.get_id())
+
+    old_entity = yield self._data_manager.get_latest(tr, entity.key())
+
+    # If the datastore chose an ID, don't overwrite existing data.
+    if auto_id and old_entity.present:
+      self._scattered_allocator.invalidate()
+      raise InternalError('The datastore chose an existing ID')
+
+    new_version = next_entity_version(old_entity.version)
+    yield self._data_manager.put(
+      tr, entity.key(), new_version, entity.Encode())
+    yield self.index_manager.put_entries(
+      tr, old_entity.decoded, old_entity.commit_vs, entity)
+    if old_entity.present:
+      yield self._gc.index_deleted_version(tr, old_entity)
+
+    raise gen.Return(
+      (entity.key(), old_entity, old_entity.commit_vs, new_version))
+
+  @gen.coroutine
+  def _delete(self, tr, key):
+    old_entity = yield self._data_manager.get_latest(tr, key)
+
+    if not old_entity.present:
+      raise gen.Return((None, None, None))
+
+    new_version = next_entity_version(old_entity.version)
+    yield self._data_manager.put(tr, key, new_version, b'')
+    yield self.index_manager.put_entries(
+      tr, old_entity.decoded, old_entity.commit_vs, new_entity=None)
+    if old_entity.present:
+      yield self._gc.index_deleted_version(tr, old_entity)
+
+    raise gen.Return((old_entity.decoded, old_entity.commit_vs, new_version))
+
+  @gen.coroutine
+  def _apply_mutations(self, tr, project_id, queried_groups, mutations,
+                       lookups, read_vs):
+    # TODO: Check if transactional tasks count as a side effect.
+    if not mutations:
+      raise gen.Return([])
+
+    group_update_futures = [
+      self._data_manager.last_group_vs(tr, project_id, namespace, group_path)
+      for namespace, group_path in queried_groups]
+
+    # Index keys that require a full lookup rather than a versionstamp.
+    require_data = set()
+    for mutation in mutations:
+      key = (mutation if isinstance(mutation, entity_pb.Reference)
+             else mutation.key())
+      require_data.add(key.Encode())
+
+    # Start fetching versionstamps for lookups first to invalidate sooner.
+    futures = {}
+    for key in lookups:
+      encoded_key = key.Encode()
+      futures[encoded_key] = self._data_manager.get_latest(
+        tr, key, include_data=encoded_key in require_data)
+
+    # Fetch remaining entities that were mutated.
+    for mutation in mutations:
+      key = (mutation if isinstance(mutation, entity_pb.Reference)
+             else mutation.key())
+      encoded_key = key.Encode()
+      if encoded_key not in futures:
+        futures[encoded_key] = self._data_manager.get_latest(tr, key)
+
+    group_updates = yield group_update_futures
+    group_updates = [vs for vs in group_updates if vs is not None]
+    if any(commit_vs > read_vs for commit_vs in group_updates):
+      raise ConcurrentModificationException(
+        u'A queried group was modified after this transaction was started.')
+
+    version_entries = yield [futures[key.Encode()] for key in lookups]
+    if any(entry.present and entry.commit_vs > read_vs
+           for entry in version_entries):
+      raise ConcurrentModificationException(
+        u'An entity was modified after this transaction was started.')
+
+    # Apply mutations.
+    old_entities = []
+    for mutation in mutations:
+      op = 'delete' if isinstance(mutation, entity_pb.Reference) else 'put'
+      key = mutation if op == 'delete' else mutation.key()
+      old_entity = yield futures[key.Encode()]
+      if old_entity.present:
+        old_entities.append(old_entity)
+
+      new_version = next_entity_version(old_entity.version)
+      new_encoded = mutation.Encode() if op == 'put' else b''
+      yield self._data_manager.put(tr, key, new_version, new_encoded)
+      new_entity = mutation if op == 'put' else None
+      yield self.index_manager.put_entries(
+        tr, old_entity.decoded, old_entity.commit_vs, new_entity)
+      if old_entity.present:
+        yield self._gc.index_deleted_version(tr, old_entity)
+
+    raise gen.Return(old_entities)

--- a/AppDB/appscale/datastore/fdb/gc.py
+++ b/AppDB/appscale/datastore/fdb/gc.py
@@ -151,8 +151,8 @@ class DeletedVersionIndex(object):
     """
     scatter_byte = bytes(bytearray([byte_num]))
     prefix = self.directory.rawPrefix + scatter_byte
-    return slice(fdb.KeySelector.first_greater_or_equal(prefix + b'\x00'),
-                 fdb.KeySelector.first_greater_than(prefix + safe_vs))
+    return slice(fdb.KeySelector.first_greater_or_equal(prefix),
+                 fdb.KeySelector.first_greater_or_equal(prefix + safe_vs))
 
 
 class SafeReadDir(object):

--- a/AppDB/appscale/datastore/fdb/gc.py
+++ b/AppDB/appscale/datastore/fdb/gc.py
@@ -31,7 +31,7 @@ class NoProjects(Exception):
 
 class DeletedVersionEntry(object):
   """ Encapsulates details for a deleted entity version. """
-  __SLOTS__ = ['project_id', 'namespace', 'path', 'original_vs', 'deleted_vs']
+  __slots__ = ['project_id', 'namespace', 'path', 'original_vs', 'deleted_vs']
 
   def __init__(self, project_id, namespace, path, original_vs, deleted_vs):
     self.project_id = project_id

--- a/AppDB/appscale/datastore/fdb/gc.py
+++ b/AppDB/appscale/datastore/fdb/gc.py
@@ -15,10 +15,11 @@ from tornado.ioloop import IOLoop
 
 from appscale.datastore.dbconstants import MAX_TX_DURATION
 from appscale.datastore.fdb.codecs import (
-  decode_str, encode_read_vs, encode_vs_index, Path)
+  decode_str, encode_read_version, encode_versionstamp_index, Path)
 from appscale.datastore.fdb.polling_lock import PollingLock
 from appscale.datastore.fdb.utils import (
-  DS_ROOT, fdb, hash_tuple, KVIterator, MAX_FDB_TX_DURATION, VS_SIZE)
+  DS_ROOT, fdb, hash_tuple, MAX_FDB_TX_DURATION, ResultIterator,
+  VERSIONSTAMP_SIZE)
 
 logger = logging.getLogger(__name__)
 
@@ -30,19 +31,21 @@ class NoProjects(Exception):
 
 class DeletedVersionEntry(object):
   """ Encapsulates details for a deleted entity version. """
-  __slots__ = ['project_id', 'namespace', 'path', 'original_vs', 'deleted_vs']
+  __slots__ = ['project_id', 'namespace', 'path', 'original_versionstamp',
+               'deleted_versionstamp']
 
-  def __init__(self, project_id, namespace, path, original_vs, deleted_vs):
+  def __init__(self, project_id, namespace, path, original_versionstamp,
+               deleted_versionstamp):
     self.project_id = project_id
     self.namespace = namespace
     self.path = path
-    self.original_vs = original_vs
-    self.deleted_vs = deleted_vs
+    self.original_versionstamp = original_versionstamp
+    self.deleted_versionstamp = deleted_versionstamp
 
   def __repr__(self):
     return u'DeletedVersionEntry({!r}, {!r}, {!r}, {!r}, {!r})'.format(
-      self.project_id, self.namespace, self.path, self.original_vs,
-      self.deleted_vs)
+      self.project_id, self.namespace, self.path, self.original_versionstamp,
+      self.deleted_versionstamp)
 
 
 class DeletedVersionIndex(object):
@@ -54,20 +57,20 @@ class DeletedVersionIndex(object):
   (<project-dir>, 'deleted-versions', <namespace>).
 
   Within this directory, keys are encoded as
-  <scatter-byte> + <deleted-vs> + <path> + <original-vs>.
+  <scatter-byte> + <deleted-versionstamp> + <path> + <original-versionstamp>.
 
   The <scatter-byte> is a single byte determined by hashing the entity path.
   Its purpose is to spread writes more evenly across the cluster and minimize
   hotspots. This is especially important for this index because each write is
-  given a new, larger <deleted-vs> value than the last.
+  given a new, larger <deleted-versionstamp> value than the last.
 
-  The <deleted-vs> is a 10-byte versionstamp that specifies the commit version
-  of the transaction that deleted the entity version.
+  The <deleted-versionstamp> is a 10-byte versionstamp that specifies the
+  commit version of the transaction that deleted the entity version.
 
   The <path> contains the entity path. See codecs.Path for encoding details.
 
-  The <original-vs> is a 10-byte versionstamp that specifies the commit version
-  of the transaction that originally wrote the entity data.
+  The <original-versionstamp> is a 10-byte versionstamp that specifies the
+  commit version of the transaction that originally wrote the entity data.
 
   None of the keys in this index have values.
   """
@@ -85,20 +88,20 @@ class DeletedVersionIndex(object):
     return self.directory.get_path()[len(DS_ROOT) + 2]
 
   @property
-  def del_vs_slice(self):
+  def del_versionstamp_slice(self):
     """ The portion of keys that contain the deleted versionstamp. """
     prefix_size = len(self.directory.rawPrefix) + 1
-    return slice(prefix_size, prefix_size + VS_SIZE)
+    return slice(prefix_size, prefix_size + VERSIONSTAMP_SIZE)
 
   @property
   def path_slice(self):
     """ The portion of keys that contain the encoded path. """
-    return slice(self.del_vs_slice.stop, -VS_SIZE)
+    return slice(self.del_versionstamp_slice.stop, -VERSIONSTAMP_SIZE)
 
   @property
-  def original_vs_slice(self):
+  def original_versionstamp_slice(self):
     """ The portion of keys that contain the original versionstamp. """
-    return slice(-VS_SIZE, None)
+    return slice(-VERSIONSTAMP_SIZE, None)
 
   def __repr__(self):
     return u'DeletedVersionIndex({!r})'.format(self.directory)
@@ -110,30 +113,30 @@ class DeletedVersionIndex(object):
 
     return project_id, cls.DIR_NAME, namespace
 
-  def encode_key(self, path, original_vs, deleted_vs=None):
+  def encode_key(self, path, original_versionstamp, deleted_versionstamp=None):
     """ Encodes a key for a deleted version index entry.
 
     Args:
       path: A tuple or protobuf path object.
-      original_vs: A 10-byte string specifying the entity version's original
-        commit versionstamp.
-      deleted_vs: A 10-byte string specifying the entity version's delete
-        versionstamp or None.
+      original_versionstamp: A 10-byte string specifying the entity version's
+        original commit versionstamp.
+      deleted_versionstamp: A 10-byte string specifying the entity version's
+        delete versionstamp or None.
     Returns:
-      A string containing an FDB key. If deleted_vs was None, the key should
-      be used with set_versionstamped_key.
+      A string containing an FDB key. If deleted_versionstamp was None, the key
+      should be used with set_versionstamped_key.
     """
     if not isinstance(path, tuple):
       path = Path.flatten(path)
 
     scatter_byte = hash_tuple(path)
     key = b''.join([self.directory.rawPrefix, scatter_byte,
-                    deleted_vs or b'\x00' * VS_SIZE,
+                    deleted_versionstamp or b'\x00' * VERSIONSTAMP_SIZE,
                     Path.pack(path),
-                    original_vs])
-    if not deleted_vs:
-      vs_index = len(self.directory.rawPrefix) + len(scatter_byte)
-      key += encode_vs_index(vs_index)
+                    original_versionstamp])
+    if not deleted_versionstamp:
+      versionstamp_index = len(self.directory.rawPrefix) + len(scatter_byte)
+      key += encode_versionstamp_index(versionstamp_index)
 
     return key
 
@@ -145,28 +148,29 @@ class DeletedVersionIndex(object):
     Returns:
       A DeletedVersionEntry object.
     """
-    deleted_vs = kv.key[self.del_vs_slice]
+    deleted_versionstamp = kv.key[self.del_versionstamp_slice]
     path = Path.unpack(kv.key, self.path_slice.start)[0]
-    original_vs = kv.key[self.original_vs_slice]
+    original_versionstamp = kv.key[self.original_versionstamp_slice]
     return DeletedVersionEntry(self.project_id, self.namespace, path,
-                               original_vs, deleted_vs)
+                               original_versionstamp, deleted_versionstamp)
 
-  def get_slice(self, byte_num, safe_vs):
+  def get_slice(self, byte_num, safe_versionstamp):
     """
     Gets the range of keys within a scatter byte up to the given deleted
     versionstamp.
 
     Args:
       byte_num: An integer specifying a scatter byte value.
-      safe_vs: A 10-byte value indicating the latest deleted versionstamp that
-        should be considered for deletion.
+      safe_versionstamp: A 10-byte value indicating the latest deleted
+        versionstamp that should be considered for deletion.
     Returns:
       A slice specifying the start and stop keys.
     """
     scatter_byte = bytes(bytearray([byte_num]))
     prefix = self.directory.rawPrefix + scatter_byte
-    return slice(fdb.KeySelector.first_greater_or_equal(prefix),
-                 fdb.KeySelector.first_greater_or_equal(prefix + safe_vs))
+    return slice(
+      fdb.KeySelector.first_greater_or_equal(prefix),
+      fdb.KeySelector.first_greater_or_equal(prefix + safe_versionstamp))
 
 
 class SafeReadDir(object):
@@ -258,36 +262,39 @@ class GarbageCollector(object):
     IOLoop.current().spawn_callback(self._process_deferred_deletes)
     IOLoop.current().spawn_callback(self._groom_projects)
 
-  def clear_later(self, entries, new_vs):
+  def clear_later(self, entries, new_versionstamp):
     """ Clears deleted entities after sufficient time has passed. """
     safe_time = monotonic.monotonic() + MAX_TX_DURATION
     for entry in entries:
       # TODO: Strip raw properties and enforce a max queue size to keep memory
       # usage reasonable.
-      self._queue.append((safe_time, entry, new_vs))
+      self._queue.append((safe_time, entry, new_versionstamp))
 
   @gen.coroutine
-  def safe_read_vs(self, tr, key):
+  def safe_read_versionstamp(self, tr, key):
     """
     Retrieves the safe read versionstamp for an entity key. Read versionstamps
     that are larger than this value are safe to use.
     """
     safe_read_dir = yield self._safe_read_dir_from_key(tr, key)
     safe_read_key = safe_read_dir.encode_key(key.path())
-    # A concurrent change to the safe read VS does not affect what the current
-    # transaction can read, so "snapshot" is used to reduce conflicts.
-    vs = yield self._tornado_fdb.get(tr, safe_read_key, snapshot=True)
-    if not vs.present():
+    # A concurrent change to the safe read versionstamp does not affect what
+    # the current transaction can read, so "snapshot" is used to reduce
+    # conflicts.
+    versionstamp = yield self._tornado_fdb.get(
+      tr, safe_read_key, snapshot=True)
+    if not versionstamp.present():
       return
 
-    raise gen.Return(vs.value)
+    raise gen.Return(versionstamp.value)
 
   @gen.coroutine
   def index_deleted_version(self, tr, version_entry):
     """ Marks a deleted entity version as a candidate for a later cleanup. """
     index = yield self._del_version_index(
       tr, version_entry.project_id, version_entry.namespace)
-    key = index.encode_key(version_entry.path, version_entry.commit_vs)
+    key = index.encode_key(
+      version_entry.path, version_entry.commit_versionstamp)
     tr.set_versionstamped_key(key, b'')
 
   @gen.coroutine
@@ -315,11 +322,11 @@ class GarbageCollector(object):
         yield gen.sleep(safe_time - current_time + self._DEFERRED_DEL_PADDING)
         break
 
-      safe_time, version_entry, deleted_vs = self._queue.popleft()
+      safe_time, version_entry, deleted_versionstamp = self._queue.popleft()
       if tr is None:
         tr = self._db.create_transaction()
 
-      yield self._hard_delete(tr, version_entry, deleted_vs)
+      yield self._hard_delete(tr, version_entry, deleted_versionstamp)
       if monotonic.monotonic() > tx_deadline:
         yield self._tornado_fdb.commit(tr)
         break
@@ -332,7 +339,7 @@ class GarbageCollector(object):
         yield self._lock.acquire()
         tr = self._db.create_transaction()
         safe_version = yield self._tornado_fdb.get_read_version(tr)
-        safe_vs = encode_read_vs(safe_version)
+        safe_versionstamp = encode_read_version(safe_version)
         yield gen.sleep(self._SAFETY_INTERVAL)
 
         yield self._lock.acquire()
@@ -345,8 +352,9 @@ class GarbageCollector(object):
           continue
 
         deleted_versions = yield self._groom_deleted_versions(
-          tr, project_id, namespace, batch, safe_vs)
-        yield self._groom_expired_transactions(tr, project_id, batch, safe_vs)
+          tr, project_id, namespace, batch, safe_versionstamp)
+        yield self._groom_expired_transactions(
+          tr, project_id, batch, safe_versionstamp)
         if deleted_versions:
           logger.debug(
             u'GC deleted {} entity versions'.format(deleted_versions))
@@ -431,36 +439,40 @@ class GarbageCollector(object):
 
   @gen.coroutine
   def _groom_deleted_versions(self, tr, project_id, namespace, batch_num,
-                              safe_vs):
+                              safe_versionstamp):
     del_version_dir = yield self._del_version_index(tr, project_id, namespace)
     ranges = sm.range(batch_num * self._BATCH_SIZE,
                       (batch_num + 1) * self._BATCH_SIZE)
     tx_deadline = monotonic.monotonic() + MAX_FDB_TX_DURATION - 1
     delete_counts = yield [
-      self._groom_range(tr, del_version_dir, byte_num, safe_vs, tx_deadline)
+      self._groom_range(tr, del_version_dir, byte_num, safe_versionstamp,
+                        tx_deadline)
       for byte_num in ranges]
     raise gen.Return(sum(delete_counts))
 
   @gen.coroutine
-  def _groom_expired_transactions(self, tr, project_id, batch_num, safe_vs):
+  def _groom_expired_transactions(self, tr, project_id, batch_num,
+                                  safe_versionstamp):
     ranges = sm.range(batch_num * self._BATCH_SIZE,
                       (batch_num + 1) * self._BATCH_SIZE)
-    yield [self._tx_manager.clear_range(tr, project_id, byte_num, safe_vs)
+    yield [self._tx_manager.clear_range(tr, project_id, byte_num,
+                                        safe_versionstamp)
            for byte_num in ranges]
 
   @gen.coroutine
-  def _groom_range(self, tr, index, byte_num, safe_vs, tx_deadline):
-    iterator = KVIterator(tr, self._tornado_fdb,
-                          index.get_slice(byte_num, safe_vs))
+  def _groom_range(self, tr, index, byte_num, safe_versionstamp, tx_deadline):
+    iterator = ResultIterator(tr, self._tornado_fdb,
+                              index.get_slice(byte_num, safe_versionstamp))
     deleted = 0
     while True:
-      kvs, more = yield iterator.next_page()
-      for kv in kvs:
-        index_entry = index.decode(kv)
+      results, more = yield iterator.next_page()
+      for result in results:
+        index_entry = index.decode(result)
         version_entry = yield self._data_manager.get_version_from_path(
           tr, index_entry.project_id, index_entry.namespace, index_entry.path,
-          index_entry.original_vs)
-        yield self._hard_delete(tr, version_entry, index_entry.deleted_vs)
+          index_entry.original_versionstamp)
+        yield self._hard_delete(
+          tr, version_entry, index_entry.deleted_versionstamp)
         deleted += 1
 
       if not more or monotonic.monotonic() > tx_deadline:
@@ -469,20 +481,21 @@ class GarbageCollector(object):
     raise gen.Return(deleted)
 
   @gen.coroutine
-  def _hard_delete(self, tr, version_entry, deleted_vs):
+  def _hard_delete(self, tr, version_entry, deleted_versionstamp):
     yield self._data_manager.hard_delete(tr, version_entry)
     yield self._index_manager.hard_delete_entries(tr, version_entry)
     index = yield self._del_version_index(
       tr, version_entry.project_id, version_entry.namespace)
-    index_key = index.encode_key(version_entry.path, version_entry.commit_vs,
-                                 deleted_vs)
+    index_key = index.encode_key(
+      version_entry.path, version_entry.commit_versionstamp,
+      deleted_versionstamp)
     del tr[index_key]
 
     # Keep track of safe versionstamps to invalidate stale txids.
     safe_read_dir = yield self._safe_read_dir(
       tr, version_entry.project_id, version_entry.namespace)
     safe_read_key = safe_read_dir.encode_key(version_entry.path)
-    tr.byte_max(safe_read_key, deleted_vs)
+    tr.byte_max(safe_read_key, deleted_versionstamp)
 
   @gen.coroutine
   def _safe_read_dir(self, tr, project_id, namespace):

--- a/AppDB/appscale/datastore/fdb/gc.py
+++ b/AppDB/appscale/datastore/fdb/gc.py
@@ -7,6 +7,7 @@ resource is still available.
 from __future__ import division
 import logging
 import monotonic
+import random
 from collections import deque
 
 import six.moves as sm
@@ -305,7 +306,7 @@ class GarbageCollector(object):
       except Exception:
         # TODO: Exponential backoff here.
         logger.exception(u'Unexpected error while processing GC queue')
-        yield gen.sleep(1)
+        yield gen.sleep(random.random() * 2)
         continue
 
   @gen.coroutine
@@ -363,7 +364,7 @@ class GarbageCollector(object):
         cursor = (project_id, namespace, batch)
       except Exception:
         logger.exception(u'Unexpected error while grooming projects')
-        yield gen.sleep(10)
+        yield gen.sleep(random.random() * 20)
 
   def _next_namespace(self, tr, section_dir, current_namespace=None):
     # TODO: This can be made async.

--- a/AppDB/appscale/datastore/fdb/gc.py
+++ b/AppDB/appscale/datastore/fdb/gc.py
@@ -224,6 +224,10 @@ class SafeReadDir(object):
 
 
 class GarbageCollector(object):
+  """
+  The GarbageCollector ensures that old entity versions and transaction IDs
+  don't stick around for too long.
+  """
   # The FDB key used to acquire a GC lock.
   _LOCK_KEY = u'gc-lock'
 

--- a/AppDB/appscale/datastore/fdb/gc.py
+++ b/AppDB/appscale/datastore/fdb/gc.py
@@ -1,0 +1,441 @@
+"""
+This module keeps track of outdated transactions and entity versions and
+deletes them when sufficient time has passed. The GarbageCollector is the main
+interface that clients can use to mark resources as old and determine if a
+resource is still available.
+"""
+from __future__ import division
+import logging
+import monotonic
+from collections import deque
+
+import six.moves as sm
+from tornado import gen
+from tornado.ioloop import IOLoop
+
+from appscale.datastore.dbconstants import MAX_TX_DURATION
+from appscale.datastore.fdb.cache import NSCache
+from appscale.datastore.fdb.codecs import (
+  decode_str, encode_path, encode_read_vs, encode_vs_index)
+from appscale.datastore.fdb.polling_lock import PollingLock
+from appscale.datastore.fdb.utils import (
+  DS_ROOT, fdb, hash_tuple, KVIterator, MAX_FDB_TX_DURATION, VS_SIZE)
+
+logger = logging.getLogger(__name__)
+
+
+class NoProjects(Exception):
+  """ Indicates that there are no existing projects. """
+  pass
+
+
+class DeletedVersionEntry(object):
+  """ Encapsulates details for a deleted entity version. """
+  __SLOTS__ = [u'project_id', u'namespace', u'path', u'original_vs',
+               u'deleted_vs']
+
+  def __init__(self, project_id, namespace, path, original_vs, deleted_vs):
+    self.project_id = project_id
+    self.namespace = namespace
+    self.path = path
+    self.original_vs = original_vs
+    self.deleted_vs = deleted_vs
+
+
+class DeletedVersionIndex(object):
+  """
+  A DeletedVersionIndex handles the encoding and decoding details for deleted
+  version references.
+
+  The directory path looks like
+  (<project-dir>, 'deleted-versions', <namespace>).
+
+  Within this directory, keys are encoded as
+  <scatter-byte> + <deleted-vs> + <path-tuple> + <original-vs>.
+
+  The <scatter-byte> is a single byte determined by hashing the entity path.
+  Its purpose is to spread writes more evenly across the cluster and minimize
+  hotspots. This is especially important for this index because each write is
+  given a new, larger <deleted-vs> value than the last.
+
+  The <deleted-vs> is a 10-byte versionstamp that specifies the commit version
+  of the transaction that deleted the entity version.
+
+  The <path-tuple> is an encoded tuple containing the entity path.
+
+  The <original-vs> is a 10-byte versionstamp that specifies the commit version
+  of the transaction that originally wrote the entity data.
+
+  None of the keys in this index have values.
+  """
+  DIR_NAME = u'deleted-versions'
+
+  def __init__(self, directory):
+    self.directory = directory
+
+  @property
+  def project_id(self):
+    return self.directory.get_path()[len(DS_ROOT)]
+
+  @property
+  def namespace(self):
+    return self.directory.get_path()[len(DS_ROOT) + 2]
+
+  @property
+  def del_vs_slice(self):
+    """ The portion of keys that contain the deleted versionstamp. """
+    prefix_size = len(self.directory.rawPrefix) + 1
+    return slice(prefix_size, prefix_size + VS_SIZE)
+
+  @property
+  def path_slice(self):
+    """ The portion of keys that contain the encoded path. """
+    return slice(self.del_vs_slice.stop, -1 * VS_SIZE)
+
+  @property
+  def original_vs_slice(self):
+    """ The portion of keys that contain the original versionstamp. """
+    return slice(-1 * VS_SIZE, None)
+
+  def encode_key(self, path, original_vs, deleted_vs=None):
+    """ Encodes a key for a deleted version index entry.
+
+    Args:
+      path: A tuple or protobuf path object.
+      original_vs: A 10-byte string specifying the entity version's original
+        commit versionstamp.
+      deleted_vs: A 10-byte string specifying the entity version's delete
+        versionstamp or None.
+    Returns:
+      A string containing an FDB key. If deleted_vs was None, the key should
+      be used with set_versionstamped_key.
+    """
+    if not isinstance(path, tuple):
+      path = encode_path(path)
+
+    scatter_byte = hash_tuple(path)
+    key = b''.join([self.directory.rawPrefix, scatter_byte,
+                    deleted_vs or b'\x00' * VS_SIZE,
+                    fdb.tuple.pack(path),
+                    original_vs])
+    if not deleted_vs:
+      vs_index = len(self.directory.rawPrefix) + len(scatter_byte)
+      key += encode_vs_index(vs_index)
+
+    return key
+
+  def decode(self, kv):
+    """ Decodes a KV to a DeletedVersionEntry.
+
+    Args:
+      kv: An FDB KeyValue object.
+    Returns:
+      A DeletedVersionEntry object.
+    """
+    deleted_vs = kv.key[self.del_vs_slice]
+    path = fdb.tuple.unpack(kv.key[self.path_slice])
+    original_vs = kv.key[self.original_vs_slice]
+    return DeletedVersionEntry(self.project_id, self.namespace, path,
+                               original_vs, deleted_vs)
+
+  def get_slice(self, byte_num, safe_vs):
+    """
+    Gets the range of keys within a scatter byte up to the given deleted
+    versionstamp.
+
+    Args:
+      byte_num: An integer specifying a scatter byte value.
+      safe_vs: A 10-byte value indicating the latest deleted versionstamp that
+        should be considered for deletion.
+    Returns:
+      A slice specifying the start and stop keys.
+    """
+    scatter_byte = bytes(bytearray([byte_num]))
+    prefix = self.directory.rawPrefix + scatter_byte
+    return slice(fdb.KeySelector.first_greater_or_equal(prefix + b'\x00'),
+                 fdb.KeySelector.first_greater_than(prefix + safe_vs))
+
+
+class SafeReadDir(object):
+  """
+  SafeReadDirs keep track of the most recent garbage collection versionstamps.
+  These versionstamps are used to invalidate stale transaction IDs.
+
+  When the datastore requests data inside a transaction, the SafeReadDir is
+  first checked to make sure that the garbage collector has not cleaned up an
+  entity that was mutated after the start of the transaction. Since a mutation
+  always means a new version entry, this ensures that valid reads always have
+  access to a version entry older than their read versionstamp.
+
+  Put another way, the newest versionstamp values in this directory are going
+  to be older than the datastore transaction duration limit. Therefore,
+  datastore transactions that see a newer value than their read versionstamp
+  are no longer valid.
+
+  The directory path looks like (<project-dir>, 'safe-read', <namespace>).
+
+  Within this directory, keys are simply a single <scatter-byte> derived from
+  the entity group that was involved in the garbage collection. The entity
+  group is used in order to cover ancestory queries.
+
+  Values are 10-byte versionstamps that indicate the most recently deleted
+  entity version that has been garbage collected.
+  """
+  DIR_NAME = u'safe-read'
+
+  def __init__(self, directory):
+    self.directory = directory
+
+  def encode_key(self, path):
+    """ Encodes a key for a safe read versionstamp entry.
+
+    Args:
+      path: A tuple or protobuf path object.
+    Returns:
+      A string containing an FDB key.
+    """
+    if not isinstance(path, tuple):
+      path = encode_path(path)
+
+    entity_group = path[:2]
+    return self.directory.rawPrefix + hash_tuple(entity_group)
+
+
+class GarbageCollector(object):
+  # The FDB key used to acquire a GC lock.
+  _LOCK_KEY = u'gc-lock'
+
+  # The number of extra seconds to wait before checking which versions are safe
+  # to delete. A larger value results in fewer GC transactions. It also results
+  # in a more relaxed max transaction duration.
+  _DEFERRED_DEL_PADDING = 30
+
+  # Give the deferred deletion process a chance to succeed before grooming.
+  _SAFETY_INTERVAL = MAX_TX_DURATION * 2
+
+  # The percantage of scattered index space to groom at a time. This fraction's
+  # reciprocal should be a factor of 256.
+  _BATCH_PERCENT = .125
+
+  # The number of ranges to groom within a single transaction.
+  _BATCH_SIZE = int(_BATCH_PERCENT * 256)
+
+  # The total number of batches in a directory.
+  _TOTAL_BATCHES = int(1 / _BATCH_PERCENT)
+
+  def __init__(self, db, tornado_fdb, data_manager, index_manager, tx_manager,
+               project_cache):
+    self._db = db
+    self._queue = deque()
+    self._tornado_fdb = tornado_fdb
+    self._data_manager = data_manager
+    self._index_manager = index_manager
+    self._tx_manager = tx_manager
+    self._project_cache = project_cache
+    lock_key = self._project_cache.root.pack((self._LOCK_KEY,))
+    self._lock = PollingLock(self._db, self._tornado_fdb, lock_key)
+    self._del_version_index_cache = NSCache(
+      self._tornado_fdb, self._project_cache, DeletedVersionIndex)
+    self._safe_read_dir_cache = NSCache(
+      self._tornado_fdb, self._project_cache, SafeReadDir)
+
+  def start(self):
+    """ Starts the garbage collection work. """
+    self._lock.start()
+    IOLoop.current().spawn_callback(self._process_deferred_deletes)
+    IOLoop.current().spawn_callback(self._groom_projects)
+
+  def clear_later(self, entities, new_vs):
+    """ Clears deleted entities after sufficient time has passed. """
+    safe_time = monotonic.monotonic() + MAX_TX_DURATION
+    for old_entity, old_vs in entities:
+      # TODO: Strip raw properties and enforce a max queue size to keep memory
+      # usage reasonable.
+      self._queue.append((safe_time, old_entity, old_vs, new_vs))
+
+  @gen.coroutine
+  def safe_read_vs(self, tr, key):
+    """
+    Retrieves the safe read versionstamp for an entity key. Read versionstamps
+    that are larger than this value are safe to use.
+    """
+    safe_read_dir = yield self._safe_read_dir_cache.get_from_key(tr, key)
+    safe_read_key = safe_read_dir.encode_key(key.path())
+    # A concurrent change to the safe read VS does not affect what the current
+    # transaction can read, so "snapshot" is used to reduce conflicts.
+    vs = yield self._tornado_fdb.get(tr, safe_read_key, snapshot=True)
+    if not vs.present():
+      return
+
+    raise gen.Return(vs.value)
+
+  @gen.coroutine
+  def index_deleted_version(self, tr, version_entry):
+    """ Marks a deleted entity version as a candidate for a later cleanup. """
+    index = yield self._del_version_index_cache.get(
+      tr, version_entry.project_id, version_entry.namespace)
+    key = index.encode_key(version_entry.path, version_entry.commit_vs)
+    tr.set_versionstamped_key(key, b'')
+
+  @gen.coroutine
+  def _process_deferred_deletes(self):
+    while True:
+      try:
+        yield self._process_queue()
+      except Exception:
+        # TODO: Exponential backoff here.
+        logger.exception(u'Unexpected error while processing GC queue')
+        yield gen.sleep(1)
+        continue
+
+  @gen.coroutine
+  def _process_queue(self):
+    current_time = monotonic.monotonic()
+    tx_deadline = current_time + MAX_FDB_TX_DURATION - 1
+    tr = None
+    while True:
+      safe_time = next(iter(self._queue), [current_time + MAX_TX_DURATION])[0]
+      if current_time < safe_time:
+        if tr is not None:
+          yield self._tornado_fdb.commit(tr)
+
+        yield gen.sleep(safe_time - current_time + self._DEFERRED_DEL_PADDING)
+        break
+
+      safe_time, old_entity, original_vs, deleted_vs = self._queue.popleft()
+      if tr is None:
+        tr = self._db.create_transaction()
+
+      yield self._hard_delete(tr, old_entity, original_vs, deleted_vs)
+      if monotonic.monotonic() > tx_deadline:
+        yield self._tornado_fdb.commit(tr)
+        break
+
+  @gen.coroutine
+  def _groom_projects(self):
+    cursor = (u'', u'', 0)  # Last (project_id, namespace, batch) groomed.
+    while True:
+      try:
+        yield self._lock.acquire()
+        tr = self._db.create_transaction()
+        safe_version = yield self._tornado_fdb.get_read_version(tr)
+        safe_vs = encode_read_vs(safe_version)
+        yield gen.sleep(self._SAFETY_INTERVAL)
+
+        yield self._lock.acquire()
+        tr = self._db.create_transaction()
+        try:
+          project_id, namespace, batch = yield self._next_batch(tr, *cursor)
+        except NoProjects as error:
+          logger.info(str(error))
+          yield gen.sleep(self._SAFETY_INTERVAL)
+          continue
+
+        yield self._groom_deleted_versions(
+          tr, project_id, namespace, batch, safe_vs)
+        yield self._groom_expired_transactions(tr, project_id, batch, safe_vs)
+      except Exception:
+        logger.exception(u'Unexpected error while grooming projects')
+        yield gen.sleep(10)
+
+  @gen.coroutine
+  def _next_batch(self, tr, project_id, namespace, batch_num):
+    project_dirs = yield self._project_cache.list(tr)
+    project_ids = [p_dir.get_path()[-1] for p_dir in project_dirs]
+    if not project_ids:
+      raise NoProjects(u'There are no projects to groom')
+
+    previous_dir_found = True
+    if project_id not in project_ids:
+      project_id = next((project for project in project_ids
+                         if project > project_id), project_ids[0])
+      namespace = u''
+      batch_num = 0
+      previous_dir_found = False
+
+    project_dir = next(p_dir for p_dir in project_dirs
+                       if p_dir.get_path()[-1] == project_id)
+    namespace_dirs = yield self._del_version_index_cache.list(tr, project_dir)
+    namespaces = [p_dir.namespace for p_dir in namespace_dirs] or [u'']
+    if namespace not in namespaces:
+      namespace = next((ns for ns in namespaces if ns > namespace),
+                       namespaces[0])
+      batch_num = 0
+      previous_dir_found = False
+
+    if previous_dir_found:
+      batch_num += 1
+
+    if batch_num >= self._TOTAL_BATCHES:
+      namespace = next((ns for ns in namespaces if ns > namespace), None)
+      if namespace is None:
+        project_id = next((project for project in project_ids
+                           if project > project_id), project_ids[0])
+        project_dir = next(p_dir for p_dir in project_dirs
+                           if p_dir.get_path()[-1] == project_id)
+        namespace_dirs = yield self._del_version_index_cache.list(
+          tr, project_dir)
+        namespace = next((p_dir.namespace for p_dir in namespace_dirs), u'')
+
+      batch_num = 0
+
+    raise gen.Return((project_id, namespace, batch_num))
+
+  @gen.coroutine
+  def _groom_deleted_versions(self, tr, project_id, namespace, batch_num,
+                              safe_vs):
+    del_version_dir = yield self._del_version_index_cache.get(
+      tr, project_id, namespace)
+    ranges = sm.range(batch_num * self._BATCH_SIZE,
+                      (batch_num + 1) * self._BATCH_SIZE)
+    tx_deadline = monotonic.monotonic() + MAX_FDB_TX_DURATION - 1
+    delete_counts = yield [
+      self._groom_range(tr, del_version_dir, byte_num, safe_vs, tx_deadline)
+      for byte_num in ranges]
+    yield self._tornado_fdb.commit(tr)
+    deleted = sum(delete_counts)
+    if deleted:
+      logger.debug(u'GC deleted {} entities'.format(deleted))
+
+  @gen.coroutine
+  def _groom_expired_transactions(self, tr, project_id, batch_num, safe_vs):
+    ranges = sm.range(batch_num * self._BATCH_SIZE,
+                      (batch_num + 1) * self._BATCH_SIZE)
+    yield [self._tx_manager.clear_range(tr, project_id, byte_num, safe_vs)
+           for byte_num in ranges]
+
+  @gen.coroutine
+  def _groom_range(self, tr, index, byte_num, safe_vs, tx_deadline):
+    iterator = KVIterator(tr, self._tornado_fdb,
+                          index.get_slice(byte_num, safe_vs))
+    deleted = 0
+    while True:
+      kvs, more = yield iterator.next_page()
+      for kv in kvs:
+        entry = index.decode(kv)
+        entity = yield self._data_manager.get_version_from_path(
+          tr, entry.project_id, entry.namespace, entry.path, entry.commit_vs)
+        self._hard_delete(tr, entity.decoded, entry.original_vs,
+                          entry.deleted_vs)
+        deleted += 1
+
+      if not more or monotonic.monotonic() > tx_deadline:
+        break
+
+    raise gen.Return(deleted)
+
+  @gen.coroutine
+  def _hard_delete(self, tr, entity, original_vs, deleted_vs):
+    project_id = decode_str(entity.key().app())
+    namespace = decode_str(entity.key().name_space())
+
+    yield self._data_manager.hard_delete(tr, entity.key(), original_vs)
+    self._index_manager.hard_delete_entries(tr, entity, original_vs)
+    index = yield self._del_version_index_cache.get(tr, project_id, namespace)
+    del tr[index.encode_key(entity.key().path(), original_vs, deleted_vs)]
+
+    # Keep track of safe versionstamps to invalidate stale txids.
+    safe_read_dir = yield self._safe_read_dir_cache.get(
+      tr, project_id, namespace)
+    safe_read_key = safe_read_dir.encode_key(entity.key().path())
+    tr.byte_max(safe_read_key, deleted_vs)

--- a/AppDB/appscale/datastore/fdb/gc.py
+++ b/AppDB/appscale/datastore/fdb/gc.py
@@ -231,7 +231,7 @@ class GarbageCollector(object):
     self._index_manager = index_manager
     self._tx_manager = tx_manager
     self._project_cache = project_cache
-    lock_key = self._project_cache.root.pack((self._LOCK_KEY,))
+    lock_key = self._project_cache.root_dir.pack((self._LOCK_KEY,))
     self._lock = PollingLock(self._db, self._tornado_fdb, lock_key)
     self._del_version_index_cache = NSCache(
       self._tornado_fdb, self._project_cache, DeletedVersionIndex)

--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -36,6 +36,7 @@ first_gt_or_equal = fdb.KeySelector.first_greater_or_equal
 
 
 class FilterProperty(object):
+  """ Encapsulates details for a FilterProperty that came from a query. """
   __slots__ = ['name', 'filters']
 
   def __init__(self, prop_name, filters):
@@ -142,6 +143,7 @@ def get_scan_direction(query, index):
 
 
 class IndexEntry(object):
+  """ Encapsulates details for an index entry. """
   __slots__ = ['project_id', 'namespace', 'path', 'commit_versionstamp',
                'deleted_versionstamp']
 
@@ -187,6 +189,7 @@ class IndexEntry(object):
 
 
 class PropertyEntry(IndexEntry):
+  """ Encapsulates details for a single-property index entry. """
   __slots__ = ['prop_name', 'value']
 
   def __init__(self, project_id, namespace, path, prop_name, value,
@@ -232,6 +235,7 @@ class PropertyEntry(IndexEntry):
 
 
 class CompositeEntry(IndexEntry):
+  """ Encapsulates details for a composite index entry. """
   __slots__ = ['properties']
 
   def __init__(self, project_id, namespace, path, properties,
@@ -276,6 +280,11 @@ class CompositeEntry(IndexEntry):
 
 
 class IndexIterator(object):
+  """
+  Returns pages of index entry results. It ignores Key-Values that do not apply
+  to the given read_versionstamp. It converts usable Key-Values to IndexEntry
+  objects.
+  """
   def __init__(self, tr, tornado_fdb, index, key_slice, fetch_limit, reverse,
                read_versionstamp=None, snapshot=False):
     self.index = index
@@ -324,6 +333,11 @@ class IndexIterator(object):
 
 
 class MergeJoinIterator(object):
+  """
+  Returns pages of index entry results from multiple ranges. It ignores
+  Key-Values that do not apply to the given read_versionstamp. It converts
+  usable Key-Values to IndexEntry objects.
+  """
   def __init__(self, tr, tornado_fdb, filter_props, indexes, fetch_limit,
                read_versionstamp=None, ancestor_path=None, snapshot=False):
     self.indexes = indexes
@@ -455,6 +469,7 @@ class MergeJoinIterator(object):
 
 
 class IndexSlice(object):
+  """ Encapsulates details about an index range in a way that's mutable. """
   __slots__ = ['_directory_prefix', '_order_info', '_ancestor', '_start_parts',
                '_stop_parts']
 

--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -19,8 +19,8 @@ from appscale.datastore.fdb.codecs import (
   decode_str, decode_value, encode_value, encode_vs_index, Path)
 from appscale.datastore.fdb.sdk import ListCursor
 from appscale.datastore.fdb.utils import (
-  DS_ROOT, fdb, get_scatter_val, MAX_FDB_TX_DURATION, KVIterator, SCATTER_PROP,
-  VS_SIZE)
+  format_prop_val, DS_ROOT, fdb, get_scatter_val, MAX_FDB_TX_DURATION,
+  KVIterator, SCATTER_PROP, VS_SIZE)
 from appscale.datastore.dbconstants import BadRequest, InternalError
 from appscale.datastore.index_manager import IndexInaccessible
 from appscale.datastore.utils import _FindIndexToUse
@@ -199,6 +199,11 @@ class PropertyEntry(IndexEntry):
     return u'PropertyEntry(%r, %r, %r, %r, %r, %r, %r)' % (
       self.project_id, self.namespace, self.path, self.prop_name, self.value,
       self.commit_vs, self.deleted_vs)
+
+  def __str__(self):
+    return u'PropertyEntry(%s, %r, %s, %s, %s, %r, %r)' % (
+      self.project_id, self.namespace, self.path, self.prop_name,
+      format_prop_val(self.value), self.commit_vs, self.deleted_vs)
 
   def prop_result(self):
     entity = entity_pb.EntityProto()

--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -1308,7 +1308,7 @@ class IndexManager(object):
   def update_composite_index(self, project_id, index_pb, cursor=(None, None)):
     start_ns, start_key = cursor
     project_id = decode_str(project_id)
-    kind = decode_str(index_pb.entity_type())
+    kind = decode_str(index_pb.definition().entity_type())
     tr = self._db.create_transaction()
     deadline = monotonic.monotonic() + MAX_FDB_TX_DURATION - 1
     kind_indexes = yield self._indexes_for_kind(tr, project_id, kind)
@@ -1321,9 +1321,9 @@ class IndexManager(object):
       composite_dir = yield self._directory_cache.get(tr, composite_path)
       order_info = tuple(
         (decode_str(prop.name()), prop.direction())
-        for prop in index_pb.property_list())
+        for prop in index_pb.definition().property_list())
       composite_index = CompositeIndex(
-        composite_dir, kind, index_pb.ancestor(), order_info)
+        composite_dir, kind, index_pb.definition().ancestor(), order_info)
 
       logger.info(u'Backfilling {}'.format(composite_index))
       remaining_range = kind_index.directory.range()

--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -40,7 +40,7 @@ first_gt_or_equal = fdb.KeySelector.first_greater_or_equal
 
 
 class FilterProperty(object):
-  __slots__ = [u'name', u'filters']
+  __slots__ = ['name', 'filters']
 
   def __init__(self, prop_name, filters):
     self.name = prop_name
@@ -146,7 +146,7 @@ def get_scan_direction(query, index):
 
 
 class IndexEntry(object):
-  __SLOTS__ = ['project_id', 'namespace', 'path', 'commit_vs', 'deleted_vs']
+  __slots__ = ['project_id', 'namespace', 'path', 'commit_vs', 'deleted_vs']
 
   def __init__(self, project_id, namespace, path, commit_vs, deleted_vs):
     self.project_id = project_id
@@ -189,7 +189,7 @@ class IndexEntry(object):
 
 
 class PropertyEntry(IndexEntry):
-  __SLOTS__ = ['prop_name', 'value']
+  __slots__ = ['prop_name', 'value']
 
   def __init__(self, project_id, namespace, path, prop_name, value, commit_vs,
                deleted_vs):
@@ -228,7 +228,7 @@ class PropertyEntry(IndexEntry):
 
 
 class CompositeEntry(IndexEntry):
-  __SLOTS__ = ['properties']
+  __slots__ = ['properties']
 
   def __init__(self, project_id, namespace, path, properties, commit_vs,
                deleted_vs):
@@ -449,7 +449,7 @@ class MergeJoinIterator(object):
 
 
 class IndexSlice(object):
-  __SLOTS__ = ['_directory_prefix', '_order_info', '_omit_kind', '_ancestor',
+  __slots__ = ['_directory_prefix', '_order_info', '_omit_kind', '_ancestor',
                '_start_parts', '_stop_parts']
 
   def __init__(self, directory_prefix, order_info, omit_kind=False,
@@ -604,7 +604,7 @@ class IndexSlice(object):
 
 class Index(object):
   """ The base class for different datastore index types. """
-  __SLOTS__ = ['directory']
+  __slots__ = ['directory']
 
   def __init__(self, directory):
     self.directory = directory
@@ -852,7 +852,7 @@ class CompositeIndex(Index):
   The <commit-vs> is a 10-byte versionstamp that specifies the commit version
   of the transaction that wrote the index entry.
   """
-  __SLOTS__ = ['kind', 'ancestor', 'order_info']
+  __slots__ = ['kind', 'ancestor', 'order_info']
 
   DIR_NAME = u'composite'
 

--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -1,0 +1,1396 @@
+"""
+This module stores and queries entity indexes. The IndexManager is the main
+interface that clients can use to interact with the index layer. See its
+documentation for implementation details.
+"""
+from __future__ import division
+
+import itertools
+import logging
+import monotonic
+import sys
+
+import six
+from tornado import gen
+
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+from appscale.datastore.fdb.cache import NSCache
+from appscale.datastore.fdb.codecs import (
+  decode_element, decode_path, decode_str, decode_value, encode_ancestor_range,
+  encode_path, encode_value)
+from appscale.datastore.fdb.sdk import ListCursor
+from appscale.datastore.fdb.utils import (
+  fdb, get_scatter_val, MAX_FDB_TX_DURATION, KVIterator, SCATTER_PROP)
+from appscale.datastore.dbconstants import BadRequest, InternalError
+from appscale.datastore.index_manager import IndexInaccessible
+from appscale.datastore.utils import _FindIndexToUse
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.datastore import datastore_pb, entity_pb
+from google.appengine.datastore.datastore_pb import Query_Filter, Query_Order
+
+logger = logging.getLogger(__name__)
+
+INDEX_DIR = u'indexes'
+
+KEY_PROP = u'__key__'
+
+START_FILTERS = (Query_Filter.GREATER_THAN_OR_EQUAL, Query_Filter.GREATER_THAN)
+STOP_FILTERS = (Query_Filter.LESS_THAN_OR_EQUAL, Query_Filter.LESS_THAN)
+
+
+class FilterProperty(object):
+  __slots__ = [u'name', u'filters']
+
+  def __init__(self, prop_name, filters):
+    self.name = prop_name
+    self.filters = filters
+
+  @property
+  def equality(self):
+    return all(op == Query_Filter.EQUAL for op, _ in self.filters)
+
+  def __repr__(self):
+    return u'FilterProperty(%r, %r)' % (self.name, self.filters)
+
+
+def group_filters(query):
+  filter_props = []
+  for query_filter in query.filter_list():
+    if query_filter.property_size() != 1:
+      raise BadRequest(u'Each filter must have exactly one property')
+
+    prop = query_filter.property(0)
+    prop_name = decode_str(prop.name())
+    filter_info = (query_filter.op(), prop.value())
+    if filter_props and filter_props[-1].name == prop_name:
+      filter_props[-1].filters.append(filter_info)
+    else:
+      filter_props.append(FilterProperty(prop_name, [filter_info]))
+
+  # Since the filter list can come in any order, put inequality filters last.
+  inequality_index = None
+  for index, filter_prop in enumerate(filter_props):
+    if not filter_prop.equality:
+      inequality_index = index
+      break
+
+  if inequality_index is not None:
+    inequality_prop = filter_props.pop(inequality_index)
+    filter_props.append(inequality_prop)
+
+  # Put key filters last.
+  key_index = None
+  for index, filter_prop in enumerate(filter_props):
+    if filter_prop.name == KEY_PROP:
+      key_index = index
+      break
+
+  if key_index is not None:
+    key_prop = filter_props.pop(key_index)
+    filter_props.append(key_prop)
+
+  for filter_prop in filter_props[:-1]:
+    if filter_prop.name == KEY_PROP:
+      raise BadRequest(
+        u'Only the last filter property can be on {}'.format(KEY_PROP))
+
+    if not filter_prop.equality:
+      raise BadRequest(u'All but the last property must be equality filters')
+
+  return tuple(filter_props)
+
+
+def get_order_info(query):
+  filter_props = group_filters(query)
+
+  # Orders on equality filters can be ignored.
+  equality_props = [prop.name for prop in filter_props if prop.equality]
+  relevant_orders = [order for order in query.order_list()
+                     if order.property() not in equality_props]
+
+  order_info = []
+  for filter_prop in filter_props:
+    if filter_prop.equality:
+      continue
+
+    direction = next(
+      (order.direction() for order in relevant_orders
+       if order.property() == filter_prop.name), Query_Order.ASCENDING)
+    order_info.append((filter_prop.name, direction))
+
+  filter_prop_names = [prop.name for prop in filter_props]
+  order_info.extend(
+    [(decode_str(order.property()), order.direction())
+     for order in relevant_orders
+     if order.property() not in filter_prop_names])
+
+  return tuple(order_info)
+
+
+def get_scan_direction(query, index):
+  order_info = get_order_info(query)
+  if not order_info:
+    return Query_Order.ASCENDING
+
+  first_property, first_direction = order_info[0]
+  if first_property == KEY_PROP or isinstance(index, SinglePropIndex):
+    return first_direction
+
+  index_direction = next(direction for prop_name, direction in index.order_info
+                         if prop_name == first_property)
+  if index_direction == first_direction:
+    return Query_Order.ASCENDING
+  else:
+    return Query_Order.DESCENDING
+
+
+def get_fdb_key_selector(op, encoded_value):
+  """ Like Python's slice notation, FDB range queries include the start and
+      exclude the stop. Therefore, the stop selector must point to the first
+      key that will be excluded from the results. """
+  if op == Query_Filter.GREATER_THAN_OR_EQUAL:
+    return fdb.KeySelector.first_greater_or_equal(encoded_value)
+  elif op == Query_Filter.GREATER_THAN:
+    return fdb.KeySelector.first_greater_than(encoded_value + b'\xff')
+  elif op == Query_Filter.LESS_THAN_OR_EQUAL:
+    return fdb.KeySelector.first_greater_or_equal(encoded_value + b'\xff')
+  elif op == Query_Filter.LESS_THAN:
+    return fdb.KeySelector.first_greater_than(encoded_value)
+  else:
+    raise BadRequest(u'Unsupported filter operator')
+
+
+class IndexEntry(object):
+  __SLOTS__ = [u'project_id', u'namespace', u'path', u'commit_vs',
+               u'deleted_vs']
+
+  def __init__(self, project_id, namespace, path, commit_vs, deleted_vs):
+    self.project_id = project_id
+    self.namespace = namespace
+    self.path = path
+    self.commit_vs = commit_vs
+    if deleted_vs is None:
+      deleted_vs = fdb.tuple.Versionstamp()
+
+    self.deleted_vs = deleted_vs
+
+  @property
+  def key(self):
+    key = entity_pb.Reference()
+    key.set_app(self.project_id)
+    key.set_name_space(self.namespace)
+    key.mutable_path().MergeFrom(decode_path(self.path))
+    return key
+
+  @property
+  def group(self):
+    group = entity_pb.Path()
+    group.add_element().MergeFrom(decode_element(self.path[:2]))
+    return group
+
+  def __repr__(self):
+    return u'IndexEntry(%r, %r, %r, %r, %r)' % (
+      self.project_id, self.namespace, self.path, self.commit_vs,
+      self.deleted_vs)
+
+  def key_result(self):
+    entity = entity_pb.EntityProto()
+    entity.mutable_key().MergeFrom(self.key)
+    entity.mutable_entity_group()
+    return entity
+
+  def cursor_result(self, ordered_props):
+    compiled_cursor = datastore_pb.CompiledCursor()
+    position = compiled_cursor.add_position()
+    position.mutable_key().MergeFrom(self.key)
+    position.set_start_inclusive(False)
+    return compiled_cursor
+
+
+class PropertyEntry(IndexEntry):
+  __SLOTS__ = [u'prop_name', u'value']
+
+  def __init__(self, project_id, namespace, path, prop_name, value, commit_vs,
+               deleted_vs):
+    super(PropertyEntry, self).__init__(
+      project_id, namespace, path, commit_vs, deleted_vs)
+    self.prop_name = prop_name
+    self.value = value
+
+  def __repr__(self):
+    return u'PropertyEntry(%r, %r, %r, %r, %r, %r, %r)' % (
+      self.project_id, self.namespace, self.path, self.prop_name, self.value,
+      self.commit_vs, self.deleted_vs)
+
+  def prop_result(self):
+    entity = entity_pb.EntityProto()
+    entity.mutable_key().MergeFrom(self.key)
+    entity.mutable_entity_group().MergeFrom(self.group)
+    prop = entity.add_property()
+    prop.set_name(self.prop_name)
+    prop.set_meaning(entity_pb.Property.INDEX_VALUE)
+    prop.set_multiple(False)
+    prop.mutable_value().MergeFrom(self.value)
+    return entity
+
+  def cursor_result(self, ordered_props):
+    compiled_cursor = datastore_pb.CompiledCursor()
+    position = compiled_cursor.add_position()
+    position.mutable_key().MergeFrom(self.key)
+    position.set_start_inclusive(False)
+    if self.prop_name in ordered_props:
+      index_value = position.add_indexvalue()
+      index_value.set_property(self.prop_name)
+      index_value.mutable_value().MergeFrom(self.value)
+
+    return compiled_cursor
+
+
+class CompositeEntry(IndexEntry):
+  __SLOTS__ = [u'properties']
+
+  def __init__(self, project_id, namespace, path, properties, commit_vs,
+               deleted_vs):
+    super(CompositeEntry, self).__init__(
+      project_id, namespace, path, commit_vs, deleted_vs)
+    self.properties = properties
+
+  def __repr__(self):
+    return u'CompositeEntry(%r, %r, %r, %r, %r, %r)' % (
+      self.project_id, self.namespace, self.path, self.properties,
+      self.commit_vs, self.deleted_vs)
+
+  def prop_result(self):
+    entity = entity_pb.EntityProto()
+    entity.mutable_key().MergeFrom(self.key)
+    entity.mutable_entity_group().MergeFrom(self.group)
+    for prop_name, value in self.properties:
+      prop = entity.add_property()
+      prop.set_name(prop_name)
+      prop.set_meaning(entity_pb.Property.INDEX_VALUE)
+      # TODO: Check if this is sometimes True.
+      prop.set_multiple(False)
+      prop.mutable_value().MergeFrom(value)
+
+    return entity
+
+  def cursor_result(self, ordered_props):
+    compiled_cursor = datastore_pb.CompiledCursor()
+    position = compiled_cursor.add_position()
+    position.mutable_key().MergeFrom(self.key)
+    position.set_start_inclusive(False)
+    for prop_name, value in self.properties:
+      if prop_name not in ordered_props:
+        continue
+
+      index_value = position.add_indexvalue()
+      index_value.set_property(prop_name)
+      index_value.mutable_value().MergeFrom(value)
+
+    return compiled_cursor
+
+
+class IndexIterator(object):
+  def __init__(self, tr, tornado_fdb, index, key_slice, fetch_limit, reverse,
+               read_vs=None, snapshot=False):
+    self.index = index
+    self._kv_iterator = KVIterator(
+      tr, tornado_fdb, key_slice, fetch_limit, reverse, snapshot=snapshot)
+    self._read_vs = read_vs
+    self._done = False
+
+  @property
+  def prop_names(self):
+    return self.index.prop_names
+
+  @property
+  def start_key(self):
+    return self._kv_iterator.slice.start.key
+
+  @gen.coroutine
+  def next_page(self):
+    if self._done:
+      raise gen.Return(([], False))
+
+    kvs, more_results = yield self._kv_iterator.next_page()
+    usable_entries = []
+    for kv in kvs:
+      entry = self.index.decode(kv)
+      if not self._usable(entry):
+        self._kv_iterator.increase_limit()
+        more_results = not self._kv_iterator.done_with_range
+        continue
+
+      usable_entries.append(entry)
+
+    if not more_results:
+      self._done = True
+
+    raise gen.Return((usable_entries, more_results))
+
+  def _usable(self, entry):
+    if self._read_vs and entry.deleted_vs:
+      return entry.commit_vs < self._read_vs < entry.deleted_vs
+    elif self._read_vs:
+      return entry.commit_vs < self._read_vs
+    else:
+      return True
+
+
+class MergeJoinIterator(object):
+  def __init__(self, tr, tornado_fdb, filter_props, indexes, fetch_limit,
+               read_vs=None, ancestor_path=None, snapshot=False):
+    self.indexes = indexes
+    self._filter_props = filter_props
+    self._read_vs = read_vs
+    self._tr = tr
+    self._tornado_fdb = tornado_fdb
+    self._fetch_limit = fetch_limit
+    self._fetched = 0
+    self._snapshot = snapshot
+    self._done = False
+    self._candidate_path = None
+    self._candidate_entries = []
+    self._ancestor_path = ancestor_path
+
+  @property
+  def prop_names(self):
+    prop_names = set()
+    for index, _, _, _ in self.indexes:
+      prop_names.update(index.prop_names)
+
+    return tuple(prop_names)
+
+  @gen.coroutine
+  def next_page(self):
+    if self._done:
+      raise gen.Return(([], False))
+
+    result = None
+    for i, (index, key_slice, prop_name, value) in enumerate(self.indexes):
+      usable_entry = None
+      # TODO: Keep cache of ranges to reduce unnecessary lookups.
+      index_exhausted = False
+      while True:
+        kvs, count, more = yield self._tornado_fdb.get_range(
+          self._tr, key_slice, 0, fdb.StreamingMode.small, 1,
+          snapshot=self._snapshot)
+        if not count:
+          index_exhausted = True
+          break
+
+        key_slice = slice(fdb.KeySelector.first_greater_than(kvs[-1].key),
+                          key_slice.stop)
+        for kv in kvs:
+          entry = index.decode(kv)
+          if self._usable(entry):
+            usable_entry = entry
+            break
+
+        if usable_entry is not None:
+          break
+
+      if index_exhausted:
+        self._done = True
+        break
+
+      if usable_entry.path == self._candidate_path:
+        self._candidate_entries.append(usable_entry)
+      else:
+        self._candidate_path = usable_entry.path
+        self._candidate_entries = [usable_entry]
+
+      next_index_op = Query_Filter.GREATER_THAN_OR_EQUAL
+      if len(self._candidate_entries) == len(self.indexes):
+        properties = []
+        for partial_entry in self._candidate_entries:
+          if isinstance(partial_entry, PropertyEntry):
+            properties.append((partial_entry.prop_name, partial_entry.value))
+          else:
+            for property in partial_entry.properties:
+              if property not in properties:
+                properties.append(property)
+
+        result = CompositeEntry(
+          usable_entry.project_id, usable_entry.namespace,
+          self._candidate_path, properties, usable_entry.commit_vs,
+          usable_entry.deleted_vs)
+        self._candidate_entries = []
+        next_index_op = Query_Filter.GREATER_THAN
+
+      next_index_i = (i + 1) % len(self.indexes)
+      next_index, next_slice, next_prop_name, next_value =\
+        self.indexes[next_index_i]
+
+      # TODO: This probably doesn't work for all cases.
+      last_prop = None
+      if isinstance(next_index, CompositeIndex):
+        last_prop = next_index.prop_names[-1]
+
+      tmp_filter_props = []
+      for filter_prop in self._filter_props:
+        if (filter_prop.name in (next_prop_name, last_prop, KEY_PROP) or
+            filter_prop.name not in next_index.prop_names):
+          continue
+        else:
+          tmp_filter_props.append(filter_prop)
+
+      tmp_filter_props.append(
+        FilterProperty(next_prop_name, [(Query_Filter.EQUAL, next_value)]))
+
+      if last_prop is not None:
+        val = next(value for prop_name, value in usable_entry.properties
+                   if prop_name == last_prop)
+        tmp_filter_props.append(
+          FilterProperty(last_prop, [(Query_Filter.EQUAL, val)]))
+
+      tmp_filter_props.append(
+        FilterProperty(KEY_PROP, [(next_index_op, usable_entry.path)]))
+
+      new_slice = next_index.get_slice(tmp_filter_props,
+                                       ancestor_path=self._ancestor_path)
+      self.indexes[next_index_i][1] = new_slice
+
+    results = [result] if result is not None else []
+    self._fetched += len(results)
+    if self._fetched == self._fetch_limit:
+      self._done = True
+
+    raise gen.Return((results, not self._done))
+
+  def _usable(self, entry):
+    if self._read_vs and entry.deleted_vs:
+      return entry.commit_vs < self._read_vs < entry.deleted_vs
+    elif self._read_vs:
+      return entry.commit_vs < self._read_vs
+    else:
+      return True
+
+
+class Index(object):
+  """ The base class for different datastore index types. """
+  __SLOTS__ = [u'directory']
+
+  def __init__(self, directory):
+    self.directory = directory
+
+  @property
+  def project_id(self):
+    return self.directory.get_path()[2]
+
+  @property
+  def namespace(self):
+    return self.directory.get_path()[4]
+
+  @property
+  def prop_names(self):
+    return tuple()
+
+  def pack_method(self, versionstamp):
+    if versionstamp.is_complete():
+      return self.directory.pack
+    else:
+      return self.directory.pack_with_versionstamp
+
+  def encode_path(self, path):
+    raise NotImplementedError()
+
+  def get_slice(self, filter_props, ancestor_path=tuple(), start_cursor=None,
+                end_cursor=None, reverse=False):
+    subspace = self.directory
+    start = None
+    stop = None
+    if ancestor_path:
+      start, stop = encode_ancestor_range(subspace, ancestor_path)
+
+    for filter_prop in filter_props:
+      if filter_prop.name != KEY_PROP:
+        raise BadRequest(u'Unexpected filter: {}'.format(filter_prop.name))
+
+      if filter_prop.equality:
+        encoded_path = self.encode_path(filter_prop.filters[0][1])
+        subspace = subspace.subspace((encoded_path,))
+        continue
+
+      for op, value in filter_prop.filters:
+        encoded_path = self.encode_path(value)
+        if op in START_FILTERS:
+          start = get_fdb_key_selector(op, subspace.pack((encoded_path,)))
+        elif op in STOP_FILTERS:
+          stop = get_fdb_key_selector(op, subspace.pack((encoded_path,)))
+        else:
+          raise BadRequest(u'Unexpected filter operation: {}'.format(op))
+
+    if start_cursor is not None:
+      encoded_path = self.encode_path(start_cursor.key().path())
+      if not reverse:
+        start = get_fdb_key_selector(Query_Filter.GREATER_THAN,
+                                     subspace.pack((encoded_path,)))
+      else:
+        stop = get_fdb_key_selector(Query_Filter.LESS_THAN,
+                                    subspace.pack((encoded_path,)))
+
+    if end_cursor is not None:
+      encoded_path = self.encode_path(start_cursor.key().path())
+      if not reverse:
+        stop = get_fdb_key_selector(Query_Filter.LESS_THAN_OR_EQUAL,
+                                    subspace.pack((encoded_path,)))
+      else:
+        start = get_fdb_key_selector(Query_Filter.GREATER_THAN_OR_EQUAL,
+                                     subspace.pack((encoded_path,)))
+
+    selector = fdb.KeySelector.first_greater_or_equal
+    start = start or selector(subspace.range().start)
+    stop = stop or selector(subspace.range().stop)
+    return slice(start, stop)
+
+
+class KindlessIndex(Index):
+  """
+  A KindlessIndex handles the encoding and decoding details for kind index
+  entries. These are just paths that point to entity keys.
+
+  The FDB directory for a kindless index looks like
+  (<project-dir>, 'indexes', <namespace>, 'kindless').
+
+  Within this directory, keys are encoded as (<path-tuple>, <commit-vs>).
+
+  The <path-tuple> is an encoded tuple containing the entity path.
+
+  The <commit-vs> is a 10-byte versionstamp that specifies the commit version
+  of the transaction that wrote the index entry.
+  """
+  DIR_NAME = u'kindless'
+
+  def __repr__(self):
+    return u'KindlessIndex(%r)' % self.directory
+
+  def encode_path(self, path):
+    if not isinstance(path, tuple):
+      path = encode_path(path)
+
+    return path
+
+  def encode(self, path, commit_vs):
+    return self.pack_method(commit_vs)((path, commit_vs))
+
+  def decode(self, kv):
+    path, commit_vs = self.directory.unpack(kv.key)
+    deleted_vs = None
+    if kv.value:
+      deleted_vs = fdb.tuple.Versionstamp(kv.value)
+
+    return IndexEntry(self.project_id, self.namespace, path, commit_vs,
+                      deleted_vs)
+
+
+class KindIndex(Index):
+  """
+  A KindIndex handles the encoding and decoding details for kind index entries.
+  These are paths grouped by kind that point to entity keys.
+
+  The FDB directory for a kind index looks like
+  (<project-dir>, 'indexes', <namespace>, 'kind', <kind>).
+
+  Within this directory, keys are encoded as
+  (<kindless-path-tuple>, <commit-vs>).
+
+  The <kindless-path-tuple> is an encoded tuple containing the entity path
+  with the kind missing from the last path element. This is omitted since the
+  directory path contains this.
+
+  The <commit-vs> is a 10-byte versionstamp that specifies the commit version
+  of the transaction that wrote the index entry.
+  """
+  DIR_NAME = u'kind'
+
+  @property
+  def kind(self):
+    return self.directory.get_path()[-1]
+
+  def __repr__(self):
+    return u'KindIndex(%r)' % self.directory
+
+  def encode_path(self, path):
+    if not isinstance(path, tuple):
+      path = encode_path(path)
+
+    kindless_path = path[:-2] + path[-1:]
+    return kindless_path
+
+  def encode(self, path, commit_vs):
+    return self.pack_method(commit_vs)((self.encode_path(path), commit_vs))
+
+  def decode(self, kv):
+    kindless_path, commit_vs = self.directory.unpack(kv.key)
+    path = kindless_path[:-1] + (self.kind,) + kindless_path[-1:]
+    deleted_vs = None
+    if kv.value:
+      deleted_vs = fdb.tuple.Versionstamp(kv.value)
+
+    return IndexEntry(self.project_id, self.namespace, path, commit_vs,
+                      deleted_vs)
+
+
+class SinglePropIndex(Index):
+  """
+  A SinglePropIndex handles the encoding and decoding details for single-prop
+  index entries. These are property values for a particular kind that point to
+  entity keys.
+
+  The FDB directory for a single-prop index looks like
+  (<project-dir>, 'indexes', <namespace>, 'single-property', <kind>,
+   <prop-name>).
+
+  Within this directory, keys are encoded as
+  (<encoded-value>, <kindless-path-tuple>, <commit-vs>).
+
+  The <encoded-value> is a tuple in the form of
+  (<encoded-type>, <encoded-value). See the codecs module for details about
+  how different datastore value types are encoded.
+
+  The <kindless-path-tuple> is an encoded tuple containing the entity path
+  with the kind missing from the last path element. This is omitted since the
+  directory path contains this.
+
+  The <commit-vs> is a 10-byte versionstamp that specifies the commit version
+  of the transaction that wrote the index entry.
+  """
+  DIR_NAME = u'single-property'
+
+  @property
+  def kind(self):
+    return self.directory.get_path()[-2]
+
+  @property
+  def prop_name(self):
+    return self.directory.get_path()[-1]
+
+  @property
+  def prop_names(self):
+    return (self.directory.get_path()[-1],)
+
+  def __repr__(self):
+    return u'SinglePropIndex(%r)' % self.directory
+
+  def encode_path(self, path):
+    if not isinstance(path, tuple):
+      path = encode_path(path)
+
+    kindless_path = path[:-2] + path[-1:]
+    return kindless_path
+
+  def encode(self, value, path, commit_vs):
+    return self.pack_method(commit_vs)(
+      (encode_value(value), self.encode_path(path), commit_vs))
+
+  def decode(self, kv):
+    encoded_value, kindless_path, commit_vs = self.directory.unpack(kv.key)
+    value = decode_value(encoded_value)
+    path = kindless_path[:-1] + (self.kind,) + kindless_path[-1:]
+    deleted_vs = None
+    if kv.value:
+      deleted_vs = fdb.tuple.Versionstamp(kv.value)
+
+    return PropertyEntry(self.project_id, self.namespace, path, self.prop_name,
+                         value, commit_vs, deleted_vs)
+
+  def get_slice(self, filter_props, ancestor_path=tuple(), start_cursor=None,
+                end_cursor=None, reverse=False):
+    subspace = self.directory
+    start = None
+    stop = None
+    if ancestor_path:
+      # Apply property equality first if it exists.
+      if filter_props and filter_props[0].name == self.prop_name:
+        if not filter_props[0].equality:
+          raise BadRequest(u'Invalid index for ancestor query')
+
+        value = filter_props[0].filters[0][1]
+        subspace = subspace.subspace((encode_value(value),))
+        filter_props = filter_props[1:]
+
+      start, stop = encode_ancestor_range(subspace, ancestor_path)
+
+    for filter_prop in filter_props:
+      if filter_prop.name == self.prop_name:
+        encoder = encode_value
+      elif filter_prop.name == KEY_PROP:
+        encoder = self.encode_path
+      else:
+        raise BadRequest(u'Unexpected filter: {}'.format(filter_prop.name))
+
+      if filter_prop.equality:
+        encoded_value = encoder(filter_prop.filters[0][1])
+        subspace = subspace.subspace((encoded_value,))
+        continue
+
+      for op, value in filter_prop.filters:
+        encoded_value = encoder(value)
+        if op in START_FILTERS:
+          start = get_fdb_key_selector(op, subspace.pack((encoded_value,)))
+        elif op in STOP_FILTERS:
+          stop = get_fdb_key_selector(op, subspace.pack((encoded_value,)))
+        else:
+          raise BadRequest(u'Unexpected filter operation: {}'.format(op))
+
+    if start_cursor is not None:
+      if not reverse and start is not None:
+        unpacked_key = self.directory.unpack(start.key)
+      elif reverse and stop is not None:
+        unpacked_key = self.directory.unpack(stop.key)
+      else:
+        unpacked_key = self.directory.unpack(subspace.rawPrefix)
+
+      cursor_prop = next((prop for prop in start_cursor.property_list()
+                         if prop.name() == self.prop_name), None)
+      if cursor_prop is None:
+        encoded_value = unpacked_key[0]
+      else:
+        encoded_value = encode_value(cursor_prop.value())
+
+      encoded_path = self.encode_path(start_cursor.key().path())
+      encoded_cursor = (encoded_value, encoded_path)
+      if not reverse:
+        start = get_fdb_key_selector(Query_Filter.GREATER_THAN,
+                                     self.directory.pack(encoded_cursor))
+      else:
+        stop = get_fdb_key_selector(Query_Filter.LESS_THAN,
+                                    self.directory.pack(encoded_cursor))
+
+    if end_cursor is not None:
+      if not reverse and stop is not None:
+        unpacked_key = self.directory.unpack(stop.key)
+      elif reverse and start is not None:
+        unpacked_key = self.directory.unpack(start.key)
+      else:
+        unpacked_key = self.directory.unpack(subspace.rawPrefix)
+
+      cursor_prop = next((prop for prop in end_cursor.property_list()
+                         if prop.name() == self.prop_name), None)
+      if cursor_prop is None:
+        encoded_value = unpacked_key[0]
+      else:
+        encoded_value = encode_value(cursor_prop.value())
+
+      encoded_path = self.encode_path(end_cursor.key().path())
+      encoded_cursor = (encoded_value, encoded_path)
+      if not reverse:
+        stop = get_fdb_key_selector(Query_Filter.LESS_THAN_OR_EQUAL,
+                                    self.directory.pack(encoded_cursor))
+      else:
+        start = get_fdb_key_selector(Query_Filter.GREATER_THAN_OR_EQUAL,
+                                     self.directory.pack(encoded_cursor))
+
+    selector = fdb.KeySelector.first_greater_or_equal
+    start = start or selector(subspace.range().start)
+    stop = stop or selector(subspace.range().stop)
+    return slice(start, stop)
+
+
+class CompositeIndex(Index):
+  """
+  A CompositeIndex handles the encoding and decoding details for composite
+  index entries.
+
+  The FDB directory for a composite index looks like
+  (<project-dir>, 'indexes', <namespace>, 'composite', <index-id>).
+
+  Within this directory, keys are encoded as
+  (<ancestor-fragment (optional)>, <encoded-values>, <remaining-path-tuple>,
+   <commit-vs>).
+
+  If the index definition requires an ancestor, the <ancestor-fragment>
+  contains an encoded tuple specifying the full or partial path of the entity's
+  ancestor. The number of entries written for ancestor composite indexes is
+  equal to the number of ancestor path elements. For example, an entity with
+  three path elements would be encoded with the following two entries:
+  (('Kind1', 'key1'), <encoded-values>, ('Kind2', 'key2', 'key3'), <commit-vs>)
+  (('Kind1', 'key1, 'Kind2', 'key2'), <encoded-values>, ('key3',), <commit-vs>)
+
+  The <encoded-values> portion is a nested tuple in the form of
+  (<encoded-value1>, <encoded-value2>, ...). The number of values depends on
+  the index definition. Each <encoded-value> is a tuple in the form of
+  (<encoded-type>, <encoded-value). See the codecs module for details about how
+  different datastore value types are encoded.
+
+  The <remaining-path-tuple> is an encoded tuple containing the portion of the
+  entity path that isn't specified by the <ancestor-fragment>. If the index
+  definition does not require an ancestor, this is equivalent to the
+  <kindless-path> portion of a kind or single-prop index.
+
+  The <commit-vs> is a 10-byte versionstamp that specifies the commit version
+  of the transaction that wrote the index entry.
+  """
+  __SLOTS__ = [u'kind', u'ancestor', u'order_info']
+
+  DIR_NAME = u'composite'
+
+  def __init__(self, directory, kind, ancestor, order_info):
+    super(CompositeIndex, self).__init__(directory)
+    self.kind = kind
+    self.ancestor = ancestor
+    self.order_info = order_info
+
+  @property
+  def id(self):
+    return int(self.directory.get_path()[6])
+
+  @property
+  def prop_names(self):
+    return tuple(prop_name for prop_name, _ in self.order_info)
+
+  def __repr__(self):
+    return u'CompositeIndex(%r, %r, %r, %r)' % (
+      self.directory, self.kind, self.ancestor, self.order_info)
+
+  def encode_path(self, path):
+    if not isinstance(path, tuple):
+      path = encode_path(path)
+
+    kindless_path = path[:-2] + path[-1:]
+    return kindless_path
+
+  def encode(self, prop_list, path, commit_vs):
+    encoded_values_by_prop = []
+    for index_prop_name, direction in self.order_info:
+      reverse = direction == Query_Order.DESCENDING
+      encoded_values_by_prop.append(
+        tuple(encode_value(prop.value(), reverse) for prop in prop_list
+              if prop.name() == index_prop_name))
+
+    pack = self.pack_method(commit_vs)
+    encoded_value_combos = itertools.product(*encoded_values_by_prop)
+    if not self.ancestor:
+      return tuple(pack(values + (self.encode_path(path),) + (commit_vs,))
+                   for values in encoded_value_combos)
+
+    keys = []
+    for index in range(2, len(path), 2):
+      ancestor_path = path[:index]
+      remaining_path = self.encode_path(path[index:])
+      keys.extend(
+        [pack((ancestor_path,) + values + (remaining_path,) + (commit_vs,))
+         for values in encoded_value_combos])
+
+    return tuple(keys)
+
+  def decode(self, kv):
+    unpacked_key = self.directory.unpack(kv.key)
+    if self.ancestor:
+      kindless_path = unpacked_key[0] + unpacked_key[-2]
+      values = unpacked_key[1:-2]
+    else:
+      kindless_path = unpacked_key[-2]
+      values = unpacked_key[:-2]
+
+    properties = []
+    for index, prop_name in enumerate(self.prop_names):
+      properties.append((prop_name, decode_value(values[index])))
+
+    path = kindless_path[:-1] + (self.kind,) + kindless_path[-1:]
+    commit_vs = unpacked_key[-1]
+    deleted_vs = None
+    if kv.value:
+      deleted_vs = fdb.tuple.Versionstamp(kv.value)
+
+    return CompositeEntry(self.project_id, self.namespace, path, properties,
+                          commit_vs, deleted_vs)
+
+  def get_slice(self, filter_props, ancestor_path=tuple(), start_cursor=None,
+                end_cursor=None, reverse=False):
+    subspace = self.directory
+    if ancestor_path:
+      subspace = subspace.subspace((ancestor_path,))
+
+    start = None
+    stop = None
+
+    ordered_filter_props = []
+    for prop_name in self.prop_names + (KEY_PROP,):
+      try:
+        filter_prop = next(filter_prop for filter_prop in filter_props
+                           if filter_prop.name == prop_name)
+        ordered_filter_props.append(filter_prop)
+      except StopIteration:
+        continue
+
+    for filter_prop in ordered_filter_props:
+      index_direction = next(
+        (direction for name, direction in self.order_info
+         if name == filter_prop.name), Query_Order.ASCENDING)
+      reverse = index_direction == Query_Order.DESCENDING
+      if filter_prop.name in self.prop_names:
+        encoder = lambda val: encode_value(val, reverse)
+      elif filter_prop.name == KEY_PROP:
+        encoder = self.encode_path
+      else:
+        raise BadRequest(u'Unexpected filter: {}'.format(filter_prop.name))
+
+      if filter_prop.equality:
+        encoded_value = encoder(filter_prop.filters[0][1])
+        subspace = subspace.subspace((encoded_value,))
+        continue
+
+      for op, value in filter_prop.filters:
+        if filter_prop.name == KEY_PROP:
+          encoded_value = self.encode_path(value)
+        else:
+          encoded_value = encoder(value)
+
+        selector = get_fdb_key_selector(op, subspace.pack((encoded_value,)))
+        if ((op in START_FILTERS and not reverse) or
+            (op in STOP_FILTERS and reverse)):
+          start = selector
+        elif ((op in STOP_FILTERS and not reverse) or
+              (op in START_FILTERS and reverse)):
+          stop = selector
+        else:
+          raise BadRequest(u'Unexpected filter operation: {}'.format(op))
+
+    if start_cursor is not None:
+      if not reverse and start is not None:
+        unpacked_key = self.directory.unpack(start.key)
+      elif reverse and stop is not None:
+        unpacked_key = self.directory.unpack(stop.key)
+      else:
+        unpacked_key = self.directory.unpack(subspace.rawPrefix)
+
+      if self.ancestor:
+        unpacked_values = unpacked_key[1:]
+      else:
+        unpacked_values = unpacked_key[:]
+
+      full_path = encode_path(start_cursor.key().path())
+      remaining_path = self.encode_path(full_path[len(ancestor_path):])
+      encoded_values = []
+      for i, (prop_name, index_direction) in enumerate(self.order_info):
+        cursor_prop = next((prop for prop in start_cursor.property_list()
+                            if prop.name() == prop_name), None)
+        if cursor_prop is None:
+          encoded_value = unpacked_values[i]
+        else:
+          reverse_encode = index_direction == Query_Order.DESCENDING
+          encoded_value = encode_value(cursor_prop.value(), reverse_encode)
+
+        encoded_values.append(encoded_value)
+
+      if self.ancestor:
+        encoded_cursor = ((ancestor_path,) + tuple(encoded_values) +
+                          (remaining_path,))
+      else:
+        encoded_cursor = (tuple(encoded_values) + (remaining_path,))
+
+      if not reverse:
+        start = get_fdb_key_selector(Query_Filter.GREATER_THAN,
+                                     self.directory.pack(encoded_cursor))
+      else:
+        stop = get_fdb_key_selector(Query_Filter.LESS_THAN,
+                                    self.directory.pack(encoded_cursor))
+
+    if end_cursor is not None:
+      if not reverse and stop is not None:
+        unpacked_key = self.directory.unpack(stop.key)
+      elif reverse and start is not None:
+        unpacked_key = self.directory.unpack(start.key)
+      else:
+        unpacked_key = self.directory.unpack(subspace.rawPrefix)
+
+      if self.ancestor:
+        unpacked_values = unpacked_key[1:]
+      else:
+        unpacked_values = unpacked_key[:]
+
+      full_path = encode_path(end_cursor.key().path())
+      remaining_path = self.encode_path(full_path[len(ancestor_path):])
+      encoded_values = []
+      for i, (prop_name, index_direction) in enumerate(self.order_info):
+        cursor_prop = next((prop for prop in end_cursor.property_list()
+                            if prop.name() == prop_name), None)
+        if cursor_prop is None:
+          encoded_value = unpacked_values[i]
+        else:
+          reverse_encode = index_direction == Query_Order.DESCENDING
+          encoded_value = encode_value(cursor_prop.value(), reverse_encode)
+
+        encoded_values.append(encoded_value)
+
+      if self.ancestor:
+        encoded_cursor = ((ancestor_path,) + tuple(encoded_values) +
+                          (remaining_path,))
+      else:
+        encoded_cursor = (tuple(encoded_values) + (remaining_path,))
+
+      if not reverse:
+        stop = get_fdb_key_selector(Query_Filter.LESS_THAN_OR_EQUAL,
+                                    self.directory.pack(encoded_cursor))
+      else:
+        start = get_fdb_key_selector(Query_Filter.GREATER_THAN_OR_EQUAL,
+                                     self.directory.pack(encoded_cursor))
+
+    selector = fdb.KeySelector.first_greater_or_equal
+    start = start or selector(subspace.range().start)
+    stop = stop or selector(subspace.range().stop)
+    return slice(start, stop)
+
+
+class IndexManager(object):
+  """
+  The IndexManager is the main interface that clients can use to interact with
+  the index layer. It makes use of KindlessIndex, KindIndex, SinglePropIndex,
+  and CompositeIndex namespace directories to handle the encoding and decoding
+  details when satisfying requests. When a client requests data, the
+  IndexManager encapsulates index data in an IndexEntry object.
+  """
+  _MAX_RESULTS = 300
+
+  def __init__(self, db, tornado_fdb, data_manager, project_cache):
+    self.composite_index_manager = None
+    self._db = db
+    self._tornado_fdb = tornado_fdb
+    self._data_manager = data_manager
+    self._project_cache = project_cache
+    self._kindless_index_cache = NSCache(
+      self._tornado_fdb, self._project_cache, KindlessIndex)
+    self._kind_index_cache = NSCache(
+      self._tornado_fdb, self._project_cache, KindIndex)
+    self._single_prop_index_cache = NSCache(
+      self._tornado_fdb, self._project_cache, SinglePropIndex)
+    self._composite_index_cache = NSCache(
+      self._tornado_fdb, self._project_cache, CompositeIndex)
+
+  @gen.coroutine
+  def put_entries(self, tr, old_entity, old_vs, new_entity):
+    if old_entity is not None:
+      keys = yield self._get_index_keys(tr, old_entity, old_vs)
+      for key in keys:
+        tr.set_versionstamped_value(key, b'\x00' * 14)
+
+    if new_entity is not None:
+      keys = yield self._get_index_keys(tr, new_entity)
+      for key in keys:
+        tr.set_versionstamped_key(key, b'')
+
+  @gen.coroutine
+  def hard_delete_entries(self, tr, old_entity, old_vs):
+    keys = self._get_index_keys(tr, old_entity, old_vs)
+    for key in keys:
+      del tr[key]
+
+  def rpc_limit(self, query):
+    check_more_results = False
+    limit = None
+    if query.has_limit():
+      limit = query.limit()
+
+    if query.has_count() and (limit is None or limit > query.count()):
+      check_more_results = True
+      limit = query.count()
+
+    if limit is None or limit > self._MAX_RESULTS:
+      check_more_results = True
+      limit = self._MAX_RESULTS
+
+    if query.has_offset():
+      limit += query.offset()
+
+    return limit, check_more_results
+
+  def include_data(self, query):
+    if query.keys_only() and query.property_name_list():
+      raise BadRequest(
+        u'A keys-only query cannot include a property name list')
+
+    if query.keys_only():
+      return False
+
+    if not query.property_name_list():
+      return True
+
+    return False
+
+  @gen.coroutine
+  def get_iterator(self, tr, query, read_vs=None):
+    project_id = decode_str(query.app())
+    namespace = decode_str(query.name_space())
+    filter_props = group_filters(query)
+    ancestor_path = tuple()
+    if query.has_ancestor():
+      ancestor_path = encode_path(query.ancestor().path())
+
+    start_cursor = None
+    if query.has_compiled_cursor():
+      start_cursor = ListCursor(query)._GetLastResult()
+
+    end_cursor = None
+    if query.has_end_compiled_cursor():
+      end_compiled = query.end_compiled_cursor()
+      end_cursor = ListCursor(query)._DecodeCompiledCursor(end_compiled)[0]
+
+    rpc_limit, check_more_results = self.rpc_limit(query)
+    fetch_limit = rpc_limit
+    if check_more_results:
+      fetch_limit += 1
+
+    index = yield self._get_perfect_index(tr, query)
+    reverse = get_scan_direction(query, index) == Query_Order.DESCENDING
+
+    if index is None:
+      if not all(prop.equality for prop in filter_props):
+        raise BadRequest(u'Query not supported')
+
+      indexes = []
+      equality_props = [filter_prop for filter_prop in filter_props
+                        if filter_prop.name == KEY_PROP]
+      if len(equality_props) > 1:
+        raise BadRequest(u'Only one equality key filter is supported')
+
+      equality_prop = next(iter(equality_props), None)
+      other_props = [filter_prop for filter_prop in filter_props
+                     if filter_prop.name != KEY_PROP]
+      for filter_prop in other_props:
+        index = yield self._single_prop_index_cache.get(
+          tr, project_id, namespace, decode_str(query.kind()),
+          filter_prop.name)
+        for op, value in filter_prop.filters:
+          tmp_filter_prop = FilterProperty(filter_prop.name, [(op, value)])
+          if equality_prop is not None:
+            tmp_filter_props = (tmp_filter_prop, equality_prop)
+          else:
+            tmp_filter_props = (tmp_filter_prop,)
+
+          slice = index.get_slice(tmp_filter_props, ancestor_path,
+                                  start_cursor, end_cursor)
+          indexes.append([index, slice, filter_prop.name, value])
+
+      raise gen.Return(
+        MergeJoinIterator(tr, self._tornado_fdb, filter_props, indexes,
+                          fetch_limit, read_vs, ancestor_path, snapshot=True))
+
+    equality_prop = next(
+      (filter_prop for filter_prop in filter_props if filter_prop.equality),
+      None)
+    if equality_prop is not None and len(equality_prop.filters) > 1:
+      indexes = []
+      for op, value in equality_prop.filters:
+        tmp_filter_props = []
+        for filter_prop in filter_props:
+          if filter_prop.name == equality_prop.name:
+            tmp_filter_props.append(
+              FilterProperty(filter_prop.name, [(op, value)]))
+          else:
+            tmp_filter_props.append(filter_prop)
+
+        desired_slice = index.get_slice(
+          tmp_filter_props, ancestor_path, start_cursor, end_cursor, reverse)
+        indexes.append([index, desired_slice, equality_prop.name, value])
+
+      raise gen.Return(
+        MergeJoinIterator(tr, self._tornado_fdb, filter_props, indexes,
+                          fetch_limit, read_vs, ancestor_path, snapshot=True))
+
+    desired_slice = index.get_slice(filter_props, ancestor_path, start_cursor,
+                                    end_cursor, reverse)
+
+    iterator = IndexIterator(tr, self._tornado_fdb, index, desired_slice,
+                             fetch_limit, reverse, read_vs, snapshot=True)
+
+    raise gen.Return(iterator)
+
+  @gen.coroutine
+  def _get_index_keys(self, tr, entity, commit_vs=None):
+    if commit_vs is None:
+      commit_vs = fdb.tuple.Versionstamp()
+
+    project_id = decode_str(entity.key().app())
+    namespace = decode_str(entity.key().name_space())
+    path = encode_path(entity.key().path())
+    kind = path[-2]
+
+    kindless_index = yield self._kindless_index_cache.get(
+      tr, project_id, namespace)
+    kind_index = yield self._kind_index_cache.get(
+      tr, project_id, namespace, kind)
+    composite_indexes = yield self._get_indexes(
+      tr, project_id, namespace, kind)
+
+    all_keys = [kindless_index.encode(path, commit_vs),
+                kind_index.encode(path, commit_vs)]
+    entity_prop_names = []
+    for prop in entity.property_list():
+      prop_name = decode_str(prop.name())
+      entity_prop_names.append(prop_name)
+      index = yield self._single_prop_index_cache.get(
+        tr, project_id, namespace, kind, prop_name)
+      all_keys.append(index.encode(prop.value(), path, commit_vs))
+
+    scatter_val = get_scatter_val(path)
+    if scatter_val is not None:
+      index = yield self._single_prop_index_cache.get(
+        tr, project_id, namespace, kind, SCATTER_PROP)
+      all_keys.append(index.encode(scatter_val, path, commit_vs))
+
+    for index in composite_indexes:
+      if not all(index_prop_name in entity_prop_names
+                 for index_prop_name in index.prop_names):
+        continue
+
+      all_keys.extend(index.encode(entity.property_list(), path, commit_vs))
+
+    raise gen.Return(all_keys)
+
+  @gen.coroutine
+  def _get_perfect_index(self, tr, query):
+    project_id = decode_str(query.app())
+    namespace = decode_str(query.name_space())
+    filter_props = group_filters(query)
+    order_info = get_order_info(query)
+
+    prop_names = [filter_prop.name for filter_prop in filter_props]
+    prop_names.extend([prop_name for prop_name, _ in order_info
+                       if prop_name not in prop_names])
+    prop_names.extend([decode_str(prop_name)
+                       for prop_name in query.property_name_list()
+                       if prop_name not in prop_names])
+
+    if not query.has_kind():
+      if not all(prop_name == KEY_PROP for prop_name in prop_names):
+        raise BadRequest(u'kind must be specified when filtering or ordering '
+                         u'properties other than __key__')
+
+      kindless_index = yield self._kindless_index_cache.get(
+        tr, project_id, namespace)
+      raise gen.Return(kindless_index)
+
+    kind = decode_str(query.kind())
+    if all(prop_name == KEY_PROP for prop_name in prop_names):
+      kind_index = yield self._kind_index_cache.get(
+        tr, project_id, namespace, kind)
+      raise gen.Return(kind_index)
+
+    if sum(prop_name != KEY_PROP for prop_name in prop_names) == 1:
+      prop_name = next(prop_name for prop_name in prop_names
+                       if prop_name != KEY_PROP)
+      ordered_prop = prop_name in [order_name for order_name, _ in order_info]
+      if not query.has_ancestor() or not ordered_prop:
+        single_prop_index = yield self._single_prop_index_cache.get(
+          tr, project_id, namespace, decode_str(query.kind()), prop_name)
+        raise gen.Return(single_prop_index)
+
+    index_pb = _FindIndexToUse(query, self._get_indexes_pb(project_id))
+    if index_pb is not None:
+      index_order_info = tuple(
+        (decode_str(prop.name()), prop.direction())
+        for prop in index_pb.definition().property_list())
+      composite_index = yield self._composite_index_cache.get(
+        tr, project_id, namespace, index_pb.id(), kind=kind,
+        ancestor=index_pb.definition().ancestor(), order_info=index_order_info)
+      raise gen.Return(composite_index)
+
+  @gen.coroutine
+  def _get_indexes(self, tr, project_id, namespace, kind):
+    try:
+      project_index_manager = self.composite_index_manager.projects[project_id]
+    except KeyError:
+      raise BadRequest(u'project_id: {} not found'.format(project_id))
+
+    relevant_indexes = [index for index in project_index_manager.indexes
+                        if index.kind == kind]
+    fdb_indexes = []
+    for index in relevant_indexes:
+      order_info = []
+      for prop in index.properties:
+        direction = (Query_Order.DESCENDING if prop.direction == 'desc'
+                     else Query_Order.ASCENDING)
+        order_info.append((prop.name, direction))
+
+      composite_index = yield self._composite_index_cache.get(
+        tr, project_id, namespace, index.id, kind=index.kind,
+        ancestor=index.ancestor, order_info=order_info)
+      fdb_indexes.append(composite_index)
+
+    raise gen.Return(fdb_indexes)
+
+  def _get_indexes_pb(self, project_id):
+    try:
+      project_index_manager = self.composite_index_manager.projects[project_id]
+    except KeyError:
+      raise BadRequest(u'project_id: {} not found'.format(project_id))
+
+    try:
+      indexes = project_index_manager.indexes_pb
+    except IndexInaccessible:
+      raise InternalError(u'ZooKeeper is not accessible')
+
+    return indexes
+
+  @gen.coroutine
+  def update_composite_index(self, project_id, index_pb, cursor=(None, None)):
+    start_ns, start_key = cursor
+    kind = decode_str(index_pb.definition().entity_type())
+    ancestor = index_pb.definition().ancestor()
+    order_info = ((prop.name(), prop.direction())
+                  for prop in index_pb.definition().property_list())
+
+    tr = self._db.create_transaction()
+    project_dir = yield self._project_cache.get(tr, project_id)
+    # TODO: Make async.
+    indexes_dir = project_dir.create_or_open(tr, (INDEX_DIR,))
+    deadline = monotonic.monotonic() + MAX_FDB_TX_DURATION / 2
+    for namespace in indexes_dir.list(tr):
+      if start_ns is not None and namespace < start_ns:
+        continue
+
+      u_index_id = six.text_type(index_pb.id())
+      # TODO: Make async.
+      composite_index_dir = indexes_dir.create_or_open(
+        tr, (namespace, CompositeIndex.DIR_NAME, u_index_id))
+      composite_index = CompositeIndex(composite_index_dir, kind, ancestor,
+                                       order_info)
+      logger.info(u'Backfilling {}'.format(composite_index))
+      try:
+        # TODO: Make async.
+        kind_index_dir = indexes_dir.open(
+          tr, (namespace, KindIndex.DIR_NAME, kind))
+      except ValueError:
+        logger.info(u'No entities exist for {}'.format(composite_index))
+        continue
+
+      kind_index = KindIndex(kind_index_dir)
+      remaining_range = kind_index_dir.range()
+      if start_key is not None:
+        remaining_range = slice(
+          fdb.KeySelector.first_greater_than(start_key), remaining_range.stop)
+        start_key = None
+
+      kv_iterator = KVIterator(tr, self._tornado_fdb, remaining_range)
+      while True:
+        kvs, more_results = yield kv_iterator.next_page()
+        entries = [kind_index.decode(kv) for kv in kvs]
+        entity_results = yield [self._data_manager.get_entry(self, tr, entry)
+                                for entry in entries]
+        for index, kv in enumerate(kvs):
+          entity = entity_pb.EntityProto(entity_results[index].encoded_entity)
+          entry = entries[index]
+          keys = composite_index.encode(
+            entity.property_list(), entry.path, entry.commit_vs)
+          for key in keys:
+            deleted_val = (entry.deleted_vs.to_bytes()
+                           if entry.deleted_vs.is_complete() else b'')
+            tr[key] = deleted_val
+
+        if not more_results:
+          logger.info(u'Finished backfilling {}'.format(composite_index))
+          break
+
+        if monotonic.monotonic() > deadline:
+          try:
+            yield self._tornado_fdb.commit(tr)
+            cursor = (namespace, kvs[-1].key)
+          except fdb.FDBError as fdb_error:
+            logger.warning(u'Error while updating index: {}'.format(fdb_error))
+            tr.on_error(fdb_error).wait()
+
+          yield self.update_composite_index(project_id, index_pb, cursor)
+          return

--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -631,8 +631,8 @@ class Index(object):
     has_ancestor_field = getattr(self, 'ancestor', False)
     kind_in_dir = not isinstance(self, KindlessIndex)
     order_info = getattr(
-      self, 'order_info',
-      ((prop_name, Query_Order.ASCENDING) for prop_name in self.prop_names))
+      self, 'order_info', tuple((prop_name, Query_Order.ASCENDING)
+                                for prop_name in self.prop_names))
     index_slice = IndexSlice(
       self.directory.rawPrefix, order_info, omit_kind=kind_in_dir,
       ancestor=has_ancestor_field)
@@ -1200,7 +1200,7 @@ class IndexManager(object):
         order_info.append((prop.name, direction))
 
       composite_index = yield self._composite_index_cache.get(
-        tr, project_id, namespace, index.id, kind=index.kind,
+        tr, project_id, namespace, six.text_type(index.id), kind=index.kind,
         ancestor=index.ancestor, order_info=order_info)
       fdb_indexes.append(composite_index)
 

--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -33,7 +33,6 @@ logger = logging.getLogger(__name__)
 
 KEY_PROP = u'__key__'
 
-KeySelector = fdb.KeySelector
 first_gt_or_equal = fdb.KeySelector.first_greater_or_equal
 
 

--- a/AppDB/appscale/datastore/fdb/polling_lock.py
+++ b/AppDB/appscale/datastore/fdb/polling_lock.py
@@ -71,7 +71,7 @@ class PollingLock(object):
       try:
         yield self._acquire_lease()
       except Exception:
-        logger.exception('Unable to acquire lease')
+        logger.exception(u'Unable to acquire lease')
         yield gen.sleep(10)
 
   @gen.coroutine
@@ -97,7 +97,7 @@ class PollingLock(object):
       self._deadline = monotonic.monotonic() + self._LEASE_TIMEOUT
       self._event.set()
       if can_acquire:
-        logger.info('Acquired lock for {}'.format(repr(self.key)))
+        logger.info(u'Acquired lock for {!r}'.format(self.key))
 
       yield gen.sleep(self._HEARTBEAT_INTERVAL)
       return

--- a/AppDB/appscale/datastore/fdb/polling_lock.py
+++ b/AppDB/appscale/datastore/fdb/polling_lock.py
@@ -1,5 +1,6 @@
 import logging
 import monotonic
+import random
 import uuid
 
 from tornado import gen
@@ -71,7 +72,7 @@ class PollingLock(object):
         yield self._acquire_lease()
       except Exception:
         logger.exception(u'Unable to acquire lease')
-        yield gen.sleep(10)
+        yield gen.sleep(random.random() * 20)
 
   @gen.coroutine
   def _acquire_lease(self):
@@ -97,7 +98,7 @@ class PollingLock(object):
           raise
 
         # If there was a conflict, try to acquire again later.
-        yield gen.sleep(10)
+        yield gen.sleep(random.random() * 20)
         return
 
       self._owner = self._client_id

--- a/AppDB/appscale/datastore/fdb/polling_lock.py
+++ b/AppDB/appscale/datastore/fdb/polling_lock.py
@@ -1,0 +1,106 @@
+import logging
+import monotonic
+import uuid
+
+from tornado import gen
+from tornado.ioloop import IOLoop
+from tornado.locks import Event
+
+from appscale.datastore.fdb.utils import fdb
+
+logger = logging.getLogger(__name__)
+
+
+class PollingLock(object):
+  """ Acquires a lock by writing to a key. This is suitable for a leader
+      election in cases where some downtime and initial acquisition delay is
+      acceptable.
+
+      Unlike ZooKeeper and etcd, FoundationDB does not have a way
+      to specify that a key should be automatically deleted if a client does
+      not heartbeat at a regular interval. This implementation requires the
+      leader to update the key at regular intervals to indicate that it is
+      still alive. All the other lock candidates check at a longer interval to
+      see if the leader has stopped updating the key.
+
+      Since client timestamps are unreliable, candidates do not know the
+      absolute time the key was updated. Therefore, they each wait for the full
+      timeout interval before checking the key again.
+  """
+  # The number of seconds to wait before trying to claim the lease.
+  _LEASE_TIMEOUT = 60
+
+  # The number of seconds to wait before updating the lease.
+  _HEARTBEAT_INTERVAL = int(_LEASE_TIMEOUT / 10)
+
+  def __init__(self, db, tornado_fdb, key):
+    self.key = key
+    self._db = db
+    self._tornado_fdb = tornado_fdb
+
+    self._client_id = uuid.uuid4()
+    self._owner = None
+    self._op_id = None
+    self._deadline = None
+    self._event = Event()
+
+  @property
+  def acquired(self):
+    if self._deadline is None:
+      return False
+
+    return (self._owner == self._client_id and
+            monotonic.monotonic() < self._deadline)
+
+  @gen.coroutine
+  def start(self):
+    IOLoop.current().spawn_callback(self._run)
+
+  @gen.coroutine
+  def acquire(self):
+    # Since there is no automatic event timeout, the condition is checked
+    # before every acquisition.
+    if not self.acquired:
+      self._event.clear()
+
+    yield self._event.wait()
+
+  @gen.coroutine
+  def _run(self):
+    while True:
+      try:
+        yield self._acquire_lease()
+      except Exception:
+        logger.exception('Unable to acquire lease')
+        yield gen.sleep(10)
+
+  @gen.coroutine
+  def _acquire_lease(self):
+    tr = self._db.create_transaction()
+    lease_value = yield self._tornado_fdb.get(tr, self.key)
+
+    if lease_value.present():
+      self._owner, new_op_id = fdb.tuple.unpack(lease_value)
+      if new_op_id != self._op_id:
+        self._deadline = monotonic.monotonic() + self._LEASE_TIMEOUT
+        self._op_id = new_op_id
+    else:
+      self._owner = None
+
+    can_acquire = self._owner is None or monotonic.monotonic() > self._deadline
+    if can_acquire or self._owner == self._client_id:
+      op_id = uuid.uuid4()
+      tr[self.key] = fdb.tuple.pack((self._client_id, op_id))
+      yield self._tornado_fdb.commit(tr)
+      self._owner = self._client_id
+      self._op_id = op_id
+      self._deadline = monotonic.monotonic() + self._LEASE_TIMEOUT
+      self._event.set()
+      if can_acquire:
+        logger.info('Acquired lock for {}'.format(repr(self.key)))
+
+      yield gen.sleep(self._HEARTBEAT_INTERVAL)
+      return
+
+    # Since another candidate holds the lock, wait until it might expire.
+    yield gen.sleep(max(self._deadline - monotonic.monotonic(), 0))

--- a/AppDB/appscale/datastore/fdb/polling_lock.py
+++ b/AppDB/appscale/datastore/fdb/polling_lock.py
@@ -1,3 +1,7 @@
+"""
+This module contains PollingLock, which is an interface to obtain a primitive
+lock using FDB.
+"""
 import logging
 import monotonic
 import random

--- a/AppDB/appscale/datastore/fdb/sdk.py
+++ b/AppDB/appscale/datastore/fdb/sdk.py
@@ -1,0 +1,241 @@
+import logging
+import sys
+import threading
+
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.datastore import datastore_pb
+from google.appengine.datastore import datastore_index
+from google.appengine.runtime import apiproxy_errors
+
+logger = logging.getLogger(__name__)
+
+
+def _GuessOrders(filters, orders):
+  """Guess any implicit ordering.
+
+  The datastore gives a logical, but not necessarily predictable, ordering when
+  orders are not completely explicit. This function guesses at that ordering
+  (which is better then always ordering by __key__ for tests).
+
+  Args:
+    filters: The datastore_pb.Query_Filter that have already been normalized and
+      checked.
+    orders: The datastore_pb.Query_Order that have already been normalized and
+      checked. Mutated in place.
+  """
+  orders = orders[:]
+
+
+  if not orders:
+    for filter_pb in filters:
+      if filter_pb.op() != datastore_pb.Query_Filter.EQUAL:
+
+        order = datastore_pb.Query_Order()
+        order.set_property(filter_pb.property(0).name())
+        orders.append(order)
+        break
+
+
+  exists_props = (filter_pb.property(0).name() for filter_pb in filters
+                  if filter_pb.op() == datastore_pb.Query_Filter.EXISTS)
+  for prop in sorted(exists_props):
+    order = datastore_pb.Query_Order()
+    order.set_property(prop)
+    orders.append(order)
+
+
+  if not orders or orders[-1].property() != '__key__':
+    order = datastore_pb.Query_Order()
+    order.set_property('__key__')
+    orders.append(order)
+  return orders
+
+
+def order_property_names(query):
+  """ Generates a list of relevant order properties from the query.
+
+  Returns:
+    A set of Property objects.
+  """
+  filters, orders = datastore_index.Normalize(query.filter_list(),
+    query.order_list(), [])
+  orders = _GuessOrders(filters, orders)
+  return set(order.property()
+             for order in orders if order.property() != '__key__')
+
+
+class BaseCursor(object):
+  """A base query cursor over a list of entities.
+
+  Public properties:
+    cursor: the integer cursor
+    app: the app for which this cursor was created
+
+  Class attributes:
+    _next_cursor: the next cursor to allocate
+    _next_cursor_lock: protects _next_cursor
+  """
+  _next_cursor = 1
+  _next_cursor_lock = threading.Lock()
+
+  def __init__(self, app):
+    """Constructor.
+
+    Args:
+      app: The app this cursor is being created for.
+    """
+    self.app = app
+    self.cursor = self._AcquireCursorID()
+
+  def PopulateCursor(self, query_result):
+    """ Creates cursor for the given query result. """
+    if query_result.more_results():
+      cursor = query_result.mutable_cursor()
+      cursor.set_app(self.app)
+      cursor.set_cursor(self.cursor)
+
+  @classmethod
+  def _AcquireCursorID(cls):
+    """Acquires the next cursor id in a thread safe manner."""
+    cls._next_cursor_lock.acquire()
+    try:
+      cursor_id = cls._next_cursor
+      cls._next_cursor += 1
+    finally:
+      cls._next_cursor_lock.release()
+    return cursor_id
+
+
+def Check(test, msg='', error_code=datastore_pb.Error.BAD_REQUEST):
+  """Raises an apiproxy_errors.ApplicationError if the condition is false.
+
+  Args:
+    test: A condition to test.
+    msg: A string to return with the error.
+    error_code: One of datastore_pb.Error to use as an error code.
+
+  Raises:
+    apiproxy_errors.ApplicationError: If test is false.
+  """
+  if not test:
+    raise apiproxy_errors.ApplicationError(error_code, msg)
+
+
+class ListCursor(BaseCursor):
+    """A query cursor over a list of entities.
+
+    Public properties:
+      keys_only: whether the query is keys_only
+    """
+
+    def __init__(self, query):
+        """Constructor.
+
+        Args:
+          query: the query request proto
+        """
+        super(ListCursor, self).__init__(query.app())
+
+        self.__order_property_names = order_property_names(query)
+        if query.has_compiled_cursor() and query.compiled_cursor().position_list():
+            self.__last_result, _ = (self._DecodeCompiledCursor(
+                query.compiled_cursor()))
+        else:
+            self.__last_result = None
+
+        if query.has_end_compiled_cursor():
+            if query.end_compiled_cursor().position_list():
+                self.__end_result, _ = self._DecodeCompiledCursor(
+                    query.end_compiled_cursor())
+        else:
+            self.__end_result = None
+
+        self.__query = query
+        self.__offset = 0
+        self.__count = query.limit()
+
+        self.keys_only = query.keys_only()
+
+    def _GetLastResult(self):
+        """ Protected access to private member. """
+        return self.__last_result
+
+    def _GetEndResult(self):
+        """ Protected access to private member for last entity. """
+        return self.__end_result
+
+    @staticmethod
+    def _GetCursorOffset(results, cursor_entity, inclusive, compare):
+        """Converts a cursor entity into a offset into the result set even if the
+        cursor_entity no longer exists.
+
+        Args:
+          results: the query's results (sequence of datastore_pb.EntityProto)
+          cursor_entity: the datastore_pb.EntityProto from the compiled query
+          inclusive: boolean that specifies if to offset past the cursor_entity
+          compare: a function that takes two datastore_pb.EntityProto and compares
+            them.
+        Returns:
+          the integer offset
+        """
+        lo = 0
+        hi = len(results)
+        if inclusive:
+
+            while lo < hi:
+                mid = (lo + hi) // 2
+                if compare(results[mid], cursor_entity) < 0:
+                    lo = mid + 1
+                else:
+                    hi = mid
+        else:
+
+            while lo < hi:
+                mid = (lo + hi) // 2
+                if compare(cursor_entity, results[mid]) < 0:
+                    hi = mid
+                else:
+                    lo = mid + 1
+        return lo
+
+    def _DecodeCompiledCursor(self, compiled_cursor):
+        """Converts a compiled_cursor into a cursor_entity.
+
+        Args:
+          compiled_cursor: The datastore_pb.CompiledCursor to decode.
+
+        Returns:
+          (cursor_entity, inclusive): a datastore_pb.EntityProto and if it should
+          be included in the result set.
+        """
+        assert len(compiled_cursor.position_list()) == 1
+
+        position = compiled_cursor.position(0)
+
+        remaining_properties = self.__order_property_names.copy()
+        cursor_entity = datastore_pb.EntityProto()
+        cursor_entity.mutable_key().CopyFrom(position.key())
+        for indexvalue in position.indexvalue_list():
+            property = cursor_entity.add_property()
+            property.set_name(indexvalue.property())
+            property.mutable_value().CopyFrom(indexvalue.value())
+            remaining_properties.remove(indexvalue.property())
+
+        Check(not remaining_properties,
+              'Cursor does not match query: missing values for %r' %
+              remaining_properties)
+
+        return (cursor_entity, position.start_inclusive())
+
+    def Count(self):
+        """Counts results, up to the query's limit.
+
+        Note this method does not deduplicate results, so the query it was generated
+        from should have the 'distinct' clause applied.
+
+        Returns:
+          int: Result count.
+        """
+        return self.__count

--- a/AppDB/appscale/datastore/fdb/sdk.py
+++ b/AppDB/appscale/datastore/fdb/sdk.py
@@ -1,3 +1,7 @@
+"""
+This module contains code copied from the Python SDK to facilitate query
+operations.
+"""
 import logging
 import sys
 import threading

--- a/AppDB/appscale/datastore/fdb/transactions.py
+++ b/AppDB/appscale/datastore/fdb/transactions.py
@@ -1,0 +1,290 @@
+"""
+This module stores and retrieves datastore transaction metadata. The
+TransactionManager is the main interface that clients can use to interact with
+the transaction layer. See its documentation for implementation details.
+"""
+import logging
+import math
+import sys
+from collections import defaultdict
+
+import six
+import six.moves as sm
+from tornado import gen
+
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+from appscale.datastore.dbconstants import BadRequest, InternalError
+from appscale.datastore.fdb.cache import SectionCache
+from appscale.datastore.fdb.codecs import (
+  decode_path, decode_sortable_int, decode_str, encode_path, encode_read_vs,
+  encode_sortable_int, encode_vs_index)
+from appscale.datastore.fdb.utils import (
+  DS_ROOT, fdb, KVIterator, MAX_ENTITY_SIZE, VS_SIZE)
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.datastore import entity_pb
+
+logger = logging.getLogger(__name__)
+
+
+class TransactionMetadata(object):
+  """
+  A TransactionMetadata directory handles the encoding and decoding details for
+  transaction metadata for a specific project.
+
+  The directory path looks like (<project-dir>, 'transactions').
+  Within this directory, keys are encoded as
+  <scatter-byte> + <txid> + <rpc-type (optional)> + <rpc-details (optional)>.
+
+  The <scatter-byte> is a single byte derived from the txid. Its purpose is to
+  spread writes more evenly across the cluster and minimize hotspots. This is
+  especially important for this index because each write is given a new, larger
+  <txid> value than the last.
+
+  The <txid> is an 8-byte integer that serves as a handle for the client to
+  identify a transaction. It also serves as a read versionstamp for FDB
+  transactions used within the datastore transaction.
+
+  The initial creation of the datastore transaction does not specify any RPC
+  details. The purpose of that KV is to verify that the datastore transaction
+  exists (and the garbage collector hasn't cleaned it up) before committing it.
+
+  The <rpc-type> is a single byte that indicates what kind of RPC is being
+  logged as having occurred inside the transaction.
+
+  The <rpc-details> encodes the necessary details in order for the datastore
+  to reconstruct the RPCs that occurreed during the transaction when it comes
+  time to commit the mutations.
+
+  # TODO: Go into more detail about how different RPC types are encoded.
+  """
+  DIR_NAME = u'transactions'
+
+  LOOKUPS = b'\x00'
+  QUERIES = b'\x01'
+  PUTS = b'\x02'
+  DELETES = b'\x03'
+
+  # The max number of bytes for each FDB value.
+  _CHUNK_SIZE = 10000
+
+  _ENTITY_LEN_SIZE = 3
+
+  def __init__(self, directory):
+    self.directory = directory
+
+  @property
+  def project_id(self):
+    return self.directory.get_path()[len(DS_ROOT)]
+
+  def encode_start_key(self, txid):
+    return self._txid_prefix(txid)
+
+  def encode_lookups(self, txid, keys):
+    section_prefix = self._txid_prefix(txid) + self.LOOKUPS
+    return self._encode_chunks(section_prefix, self._encode_keys(keys))
+
+  def encode_query_key(self, txid, namespace, ancestor):
+    if not isinstance(ancestor, tuple):
+      ancestor = encode_path(ancestor)
+
+    section_prefix = self._txid_prefix(txid) + self.QUERIES
+    ns_path = fdb.tuple.pack((namespace,) + ancestor[:2])
+    return section_prefix + ns_path
+
+  def encode_puts(self, txid, entities):
+    section_prefix = self._txid_prefix(txid) + self.PUTS
+    encoded_entities = [entity.Encode() for entity in entities]
+    value = b''.join([b''.join([self._encode_entity_len(entity), entity])
+                      for entity in encoded_entities])
+    return self._encode_chunks(section_prefix, value)
+
+  def encode_deletes(self, txid, keys):
+    section_prefix = self._txid_prefix(txid) + self.DELETES
+    return self._encode_chunks(section_prefix, self._encode_keys(keys))
+
+  def decode_metadata(self, txid, kvs):
+    lookup_rpcs = defaultdict(list)
+    queried_groups = set()
+    mutation_rpcs = []
+
+    rpc_type_index = len(self._txid_prefix(txid))
+    current_vs = None
+    for kv in kvs:
+      rpc_type = kv.key[rpc_type_index]
+      if rpc_type == self.QUERIES:
+        ns_path = fdb.tuple.unpack(kv.key[rpc_type_index + 1:])
+        queried_groups.add((ns_path[0], ns_path[1:]))
+        continue
+
+      vs_index = rpc_type_index + 1
+      rpc_vs = kv.key[vs_index:vs_index + VS_SIZE]
+      if rpc_type == self.LOOKUPS:
+        lookup_rpcs[rpc_vs].append(kv.value)
+      elif rpc_type in (self.PUTS, self.DELETES):
+        if current_vs == rpc_vs:
+          mutation_rpcs[-1].append(kv.value)
+        else:
+          current_vs = rpc_vs
+          mutation_rpcs.append([rpc_type, kv.value])
+      else:
+        raise InternalError(u'Unrecognized RPC type')
+
+    lookups = set()
+    mutations = []
+    for chunks in six.itervalues(lookup_rpcs):
+      lookups.update(self._unpack_keys(b''.join(chunks)))
+
+    for rpc_info in mutation_rpcs:
+      rpc_type = rpc_info[0]
+      blob = b''.join(rpc_info[1:])
+      if rpc_type == self.PUTS:
+        mutations.extend(self._unpack_entities(blob))
+      else:
+        mutations.extend(self._unpack_keys(blob))
+
+    return lookups, queried_groups, mutations
+
+  def get_txid_slice(self, txid):
+    prefix = self._txid_prefix(txid)
+    return slice(fdb.KeySelector.first_greater_or_equal(prefix),
+                 fdb.KeySelector.first_greater_than(prefix + b'\xff'))
+
+  def get_expired_slice(self, scatter_byte, safe_vs):
+    prefix = self.directory.rawPrefix + scatter_byte
+    return slice(fdb.KeySelector.first_greater_or_equal(prefix),
+                 fdb.KeySelector.first_greater_than(prefix + safe_vs))
+
+  def _encode_ns_key(self, key):
+    namespace = decode_str(key.name_space())
+    return fdb.tuple.pack((namespace,) + encode_path(key.path()))
+
+  def _txid_prefix(self, txid):
+    scatter_byte = bytes(bytearray([txid % 256]))
+    return self.directory.rawPrefix + scatter_byte + encode_read_vs(txid)
+
+  def _encode_keys(self, keys):
+    return b''.join(
+      [b''.join([self._encode_key_len(key), self._encode_ns_key(key)])
+       for key in keys])
+
+  def _unpack_keys(self, blob):
+    keys = []
+    position = 0
+    while position < len(blob):
+      element_count = ord(blob[position])
+      position += 1
+      namespace, position = fdb.tuple._decode(blob, position)
+
+      elements = []
+      for _ in sm.range(element_count):
+        element, position = fdb.tuple._decode(blob, position)
+        elements.append(element)
+
+      key = entity_pb.Reference()
+      key.set_app(self.project_id)
+      key.set_name_space(namespace)
+      key.mutable_path().MergeFrom(decode_path(elements))
+      keys.append(key)
+
+    return keys
+
+  def _unpack_entities(self, blob):
+    pos = 0
+    entities = []
+    while pos < len(blob):
+      entity_len = decode_sortable_int(blob[pos:pos + self._ENTITY_LEN_SIZE])
+      pos += self._ENTITY_LEN_SIZE
+      entities.append(entity_pb.EntityProto(blob[pos:pos + entity_len]))
+      pos += entity_len
+
+    return entities
+
+  def _encode_key_len(self, key):
+    return bytes(bytearray([key.path().element_size()]))
+
+  def _encode_entity_len(self, encoded_entity):
+    if len(encoded_entity) > MAX_ENTITY_SIZE:
+      raise BadRequest(u'Entity exceeds maximum size')
+
+    return encode_sortable_int(len(encoded_entity), self._ENTITY_LEN_SIZE)
+
+  def _encode_chunks(self, section_prefix, value):
+    full_prefix = section_prefix + b'\x00' * VS_SIZE
+    vs_index = encode_vs_index(len(section_prefix))
+    chunk_count = int(math.ceil(len(value) / self._CHUNK_SIZE))
+    return tuple(
+      (full_prefix + bytes(bytearray((index,))) + vs_index,
+       value[index * self._CHUNK_SIZE:(index + 1) * self._CHUNK_SIZE])
+      for index in sm.range(chunk_count))
+
+
+class TransactionManager(object):
+  """
+  The TransactionManager is the main interface that clients can use to interact
+  with the transaction layer. It makes use of TransactionMetadata directories
+  to handle the encoding and decoding details when satisfying requests.
+  """
+  def __init__(self, tornado_fdb, project_cache):
+    self._tornado_fdb = tornado_fdb
+    self._tx_metadata_cache = SectionCache(
+      self._tornado_fdb, project_cache, TransactionMetadata)
+
+  @gen.coroutine
+  def create(self, tr, project_id):
+    txid, tx_dir = yield [self._tornado_fdb.get_read_version(tr),
+                          self._tx_metadata_cache.get(tr, project_id)]
+    tr[tx_dir.encode_start_key(txid)] = b''
+    raise gen.Return(txid)
+
+  @gen.coroutine
+  def log_lookups(self, tr, project_id, get_request):
+    txid = get_request.transaction().handle()
+    tx_dir = yield self._tx_metadata_cache.get(tr, project_id)
+    for key, value in tx_dir.encode_lookups(txid, get_request.key_list()):
+      tr.set_versionstamped_key(key, value)
+
+  @gen.coroutine
+  def log_query(self, tr, project_id, query):
+    txid = query.transaction().handle()
+    namespace = decode_str(query.name_space())
+    if not query.has_ancestor():
+      raise BadRequest(u'Queries in a transaction must specify an ancestor')
+
+    tx_dir = yield self._tx_metadata_cache.get(tr, project_id)
+    tr[tx_dir.encode_query_key(txid, namespace, query.ancestor())] = b''
+
+  @gen.coroutine
+  def log_puts(self, tr, project_id, put_request):
+    txid = put_request.transaction().handle()
+    tx_dir = yield self._tx_metadata_cache.get(tr, project_id)
+    for key, value in tx_dir.encode_puts(txid, put_request.entity_list()):
+      tr.set_versionstamped_key(key, value)
+
+  @gen.coroutine
+  def log_deletes(self, tr, project_id, delete_request):
+    txid = delete_request.transaction().handle()
+    tx_dir = yield self._tx_metadata_cache.get(tr, project_id)
+    for key, value in tx_dir.encode_deletes(txid, delete_request.key_list()):
+      tr.set_versionstamped_key(key, value)
+
+  @gen.coroutine
+  def delete(self, tr, project_id, txid):
+    tx_dir = yield self._tx_metadata_cache.get(tr, project_id)
+    del tr[tx_dir.get_txid_slice(txid)]
+
+  @gen.coroutine
+  def get_metadata(self, tr, project_id, txid):
+    tx_dir = yield self._tx_metadata_cache.get(tr, project_id)
+    kvs = yield KVIterator(tr, self._tornado_fdb,
+                           tx_dir.get_txid_slice(txid)).list()
+
+    if not kvs or kvs[0].key != tx_dir.encode_start_key(txid):
+      raise BadRequest(u'Transaction not found')
+
+    raise gen.Return(tx_dir.decode_metadata(txid, kvs[1:]))
+
+  @gen.coroutine
+  def clear_range(self, tr, project_id, scatter_byte, safe_vs):
+    tx_dir = yield self._tx_metadata_cache.get(tr, project_id)
+    del tr[tx_dir.get_expired_slice(scatter_byte, safe_vs)]

--- a/AppDB/appscale/datastore/fdb/utils.py
+++ b/AppDB/appscale/datastore/fdb/utils.py
@@ -242,11 +242,20 @@ def get_scatter_val(path):
   return val
 
 
-def hash_tuple(value):
-  hashable_value = u''.join([six.text_type(element) for element in value])
+def hash_tuple(path):
+  """
+  Generates a consistent byte value for an entity path or fragment. The return
+  value is only suitable to evenly scatter the path's encoding order. It is not
+  suitable for a unique identifier.
+
+  Args:
+    path: A tuple containing values that can be interpreted as unicode strings.
+  Returns:
+    An integer ranging from 0 to 255.
+  """
+  hashable_value = u''.join([six.text_type(element) for element in path])
   val = mmh3.hash(hashable_value.encode('utf-8'), signed=False)
-  byte_array = bytearray((val % 256,))
-  return bytes(byte_array)
+  return six.int2byte(val % 256)
 
 
 def format_prop_val(prop_value):

--- a/AppDB/appscale/datastore/fdb/utils.py
+++ b/AppDB/appscale/datastore/fdb/utils.py
@@ -1,0 +1,311 @@
+import logging
+import random
+import time
+
+import fdb
+import mmh3
+import six
+from tornado import gen
+from tornado.concurrent import Future as TornadoFuture
+
+from appscale.datastore.dbconstants import SCATTER_CHANCE
+
+fdb.api_version(610)
+logger = logging.getLogger(__name__)
+
+MAX_FDB_TX_DURATION = 5
+
+_MAX_SEQUENTIAL_BIT = 52
+_MAX_SEQUENTIAL_ID = (1 << _MAX_SEQUENTIAL_BIT) - 1
+_MAX_SCATTERED_COUNTER = (1 << (_MAX_SEQUENTIAL_BIT - 1)) - 1
+_MAX_SCATTERED_ID = _MAX_SEQUENTIAL_ID + 1 + _MAX_SCATTERED_COUNTER
+_SCATTER_SHIFT = 64 - _MAX_SEQUENTIAL_BIT + 1
+
+# The Cloud Datastore API uses microseconds as version IDs. When the entity
+# doesn't exist, it reports the version as "1".
+ABSENT_VERSION = 1
+
+# The max number of bytes for each FDB value.
+CHUNK_SIZE = 10000
+
+SCATTER_PROP = u'__scatter__'
+
+MAX_32 = 256 ** 4
+
+SCATTER_PROPORTION = int(MAX_32 * SCATTER_CHANCE)
+
+# The number of bytes used to store a commit versionstamp.
+VS_SIZE = 10
+
+MAX_ENTITY_SIZE = 1048572
+
+# The FDB directory used for the datastore.
+DS_ROOT = (u'appscale', u'datastore')
+
+
+class EncodedTypes(object):
+  ENTITY_V3 = b'\x00'
+  KEY_V3 = b'\x01'
+
+
+def ReverseBitsInt64(v):
+  v = ((v >> 1) & 0x5555555555555555) | ((v & 0x5555555555555555) << 1)
+  v = ((v >> 2) & 0x3333333333333333) | ((v & 0x3333333333333333) << 2)
+  v = ((v >> 4) & 0x0F0F0F0F0F0F0F0F) | ((v & 0x0F0F0F0F0F0F0F0F) << 4)
+  v = ((v >> 8) & 0x00FF00FF00FF00FF) | ((v & 0x00FF00FF00FF00FF) << 8)
+  v = ((v >> 16) & 0x0000FFFF0000FFFF) | ((v & 0x0000FFFF0000FFFF) << 16)
+  v = int((v >> 32) | (v << 32) & 0xFFFFFFFFFFFFFFFF)
+  return v
+
+
+class ScatteredAllocator(object):
+  def __init__(self):
+    self._counter = random.randint(1, _MAX_SCATTERED_COUNTER)
+
+  def invalidate(self):
+    self._counter = random.randint(1, _MAX_SCATTERED_COUNTER)
+
+  def get_id(self):
+    id_ = (_MAX_SEQUENTIAL_ID + 1 +
+           long(ReverseBitsInt64(self._counter << _SCATTER_SHIFT)))
+
+    self._counter += 1
+    if self._counter > _MAX_SCATTERED_COUNTER:
+      self._counter = 1
+
+    return id_
+
+
+class DirectoryCache(object):
+  """ Manages a cache of recently opened directories. """
+
+  # The number of items the cache can hold.
+  SIZE = 512
+
+  def __init__(self, db, root):
+    """ Creates a new DirectoryCache. """
+    self.root = root
+    self._db = db
+    self._directory_list = []
+    self._directory_dict = {}
+
+  def get(self, path, base=None, create_if_necessary=True):
+    if base is not None:
+      root_elements = len(self.root.get_path())
+      if base.get_path()[:root_elements] != self.root.get_path():
+        raise Exception('Invalid base')
+
+      base_path = base.get_path()[root_elements:]
+      path = base_path + path
+
+    try:
+      return self._directory_dict[path]
+    except KeyError:
+      method = self.root.open
+      if create_if_necessary:
+        method = self.root.create_or_open
+
+      self[path] = method(self._db, path)
+      return self[path]
+
+  def __setitem__(self, key, value):
+    """ Adds a new directory to the cache.
+
+    Args:
+      key: A tuple identifying the directory path.
+      value: A directory object.
+    """
+    if key in self._directory_dict:
+      return
+
+    self._directory_dict[key] = value
+    self._directory_list.append(key)
+    if len(self._directory_list) > self.SIZE:
+      old_key = self._directory_list.pop(0)
+      del self._directory_dict[old_key]
+
+  def __getitem__(self, key):
+    """ Retrieves a directory from the cache.
+
+    Args:
+      key: A tuple identifying the directory path.
+    """
+    return self._directory_dict[key]
+
+
+class TornadoFDB(object):
+  def __init__(self, io_loop):
+    self._io_loop = io_loop
+
+  def commit(self, tr):
+    tornado_future = TornadoFuture()
+    callback = lambda fdb_future: self._handle_fdb_result(
+      fdb_future, tornado_future)
+    commit_future = tr.commit()
+    commit_future.on_ready(callback)
+    return tornado_future
+
+  def get(self, tr, key, snapshot=False):
+    tx_reader = tr
+    if snapshot:
+      tx_reader = tr.snapshot
+
+    tornado_future = TornadoFuture()
+    callback = lambda fdb_future: self._handle_fdb_result(
+      fdb_future, tornado_future)
+    get_future = tx_reader.get(key)
+    get_future.on_ready(callback)
+    return tornado_future
+
+  def get_range(self, tr, key_slice, limit=0,
+                streaming_mode=fdb.StreamingMode.iterator, iteration=1,
+                reverse=False, snapshot=False):
+    tx_reader = tr
+    if snapshot:
+      tx_reader = tr.snapshot
+
+    begin = key_slice.start
+    if not isinstance(begin, fdb.KeySelector):
+      begin = fdb.KeySelector.first_greater_or_equal(begin)
+
+    end = key_slice.stop
+    if not isinstance(end, fdb.KeySelector):
+      end = fdb.KeySelector.first_greater_or_equal(end)
+
+    tornado_future = TornadoFuture()
+    callback = lambda fdb_future: self._handle_fdb_result(
+      fdb_future, tornado_future)
+
+    get_future = tx_reader._get_range(begin, end, limit, streaming_mode,
+                                      iteration, reverse)
+
+    get_future.on_ready(callback)
+    return tornado_future
+
+  def get_read_version(self, tr):
+    tornado_future = TornadoFuture()
+    callback = lambda fdb_future: self._handle_fdb_result(
+      fdb_future, tornado_future)
+    get_future = tr.get_read_version()
+    get_future.on_ready(callback)
+    return tornado_future
+
+  def _handle_fdb_result(self, fdb_future, tornado_future):
+    try:
+      result = fdb_future.wait()
+    except Exception as fdb_error:
+      self._io_loop.add_callback(tornado_future.set_exception, fdb_error)
+      return
+
+    self._io_loop.add_callback(tornado_future.set_result, result)
+
+
+class KVIterator(object):
+  def __init__(self, tr, tornado_fdb, key_slice, limit=0, reverse=False,
+               streaming_mode=fdb.StreamingMode.iterator, snapshot=False):
+    self.slice = key_slice
+    self.done_with_range = False
+    self._tr = tr
+    self._tornado_fdb = tornado_fdb
+
+    self._limit = limit
+    self._reverse = reverse
+    self._mode = streaming_mode
+    self._snapshot = snapshot
+
+    self._bsel = key_slice.start
+    if not isinstance(self._bsel, fdb.KeySelector):
+      self._bsel = fdb.KeySelector.first_greater_or_equal(self._bsel)
+
+    self._esel = key_slice.stop
+    if not isinstance(self._esel, fdb.KeySelector):
+      self._esel = fdb.KeySelector.first_greater_or_equal(self._esel)
+
+    self._fetched = 0
+    self._iteration = 1
+    self._index = 0
+    self._done = False
+
+  def __repr__(self):
+    return (u'KVIterator(key_slice={!r}, limit={!r}, reverse={!r}, '
+            u'streaming_mode={!r}, snapshot={!r})').format(
+      self.slice, self._limit, self._reverse, self._mode, self._snapshot)
+
+  def increase_limit(self, difference=1):
+    if not self.done_with_range:
+      self._limit += difference
+      self._done = False
+
+  @gen.coroutine
+  def next_page(self, mode=None):
+    mode = mode or self._mode
+    if self._done:
+      raise gen.Return(([], False))
+
+    tmp_limit = 0
+    if self._limit > 0:
+      tmp_limit = self._limit - self._fetched
+
+    kvs, count, more = yield self._tornado_fdb.get_range(
+      self._tr, slice(self._bsel, self._esel), tmp_limit, mode,
+      self._iteration, self._reverse, self._snapshot)
+    self._fetched += count
+    self._iteration += 1
+
+    if kvs:
+      if self._reverse:
+        self._esel = fdb.KeySelector.first_greater_or_equal(kvs[-1].key)
+      else:
+        self._bsel = fdb.KeySelector.first_greater_than(kvs[-1].key)
+
+    reached_limit = self._limit > 0 and self._fetched == self._limit
+    self._done = not more or reached_limit
+    self.done_with_range = not more and not reached_limit
+
+    raise gen.Return((kvs, not self._done))
+
+  @gen.coroutine
+  def list(self):
+    all_kvs = []
+    while True:
+      kvs, more_results = yield self.next_page(fdb.StreamingMode.want_all)
+      all_kvs.extend(kvs)
+      if not more_results:
+        break
+
+    raise gen.Return(all_kvs)
+
+
+def next_entity_version(old_version):
+  # Since client timestamps are unreliable, ensure the new version is greater
+  # than the old one.
+  return max(int(time.time() * 1000 * 1000), old_version + 1)
+
+
+def put_chunks(tr, chunk, subspace, add_vs, chunk_size=CHUNK_SIZE):
+  chunk_indexes = [(n, n + chunk_size)
+                   for n in xrange(0, len(chunk), chunk_size)]
+  for start, end in chunk_indexes:
+    value = chunk[start:end]
+    if add_vs:
+      key = subspace.pack_with_versionstamp((fdb.tuple.Versionstamp(), start))
+      tr.set_versionstamped_key(key, value)
+    else:
+      key = subspace.pack((start,))
+      tr[key] = value
+
+
+def get_scatter_val(path):
+  hashable_path = u''.join([six.text_type(element) for element in path])
+  val = mmh3.hash(hashable_path.encode('utf-8'), signed=False)
+  if val >= SCATTER_PROPORTION:
+    return None
+
+  return val
+
+
+def hash_tuple(value):
+  hashable_value = u''.join([six.text_type(element) for element in value])
+  val = mmh3.hash(hashable_value.encode('utf-8'), signed=False)
+  byte_array = bytearray((val % 256,))
+  return bytes(byte_array)

--- a/AppDB/appscale/datastore/fdb/utils.py
+++ b/AppDB/appscale/datastore/fdb/utils.py
@@ -1,3 +1,7 @@
+"""
+This module contains common utility functions used across the FDB
+implementation.
+"""
 import json
 import logging
 import random
@@ -60,6 +64,7 @@ def ReverseBitsInt64(v):
 
 
 class ScatteredAllocator(object):
+  """ Generates large ID values that are somewhat evenly distributed. """
   def __init__(self):
     self._counter = random.randint(1, _MAX_SCATTERED_COUNTER)
 
@@ -78,6 +83,10 @@ class ScatteredAllocator(object):
 
 
 class TornadoFDB(object):
+  """
+  Presents FoundationDB operations in an interface that is friendly to Tornado
+  coroutines.
+  """
   def __init__(self, io_loop):
     self._io_loop = io_loop
 
@@ -152,6 +161,7 @@ class TornadoFDB(object):
 
 
 class ResultIterator(object):
+  """ Allows clients to page through a range of Key-Values. """
   def __init__(self, tr, tornado_fdb, key_slice, limit=0, reverse=False,
                streaming_mode=fdb.StreamingMode.iterator, snapshot=False):
     self.slice = key_slice

--- a/AppDB/appscale/datastore/fdb/utils.py
+++ b/AppDB/appscale/datastore/fdb/utils.py
@@ -76,63 +76,6 @@ class ScatteredAllocator(object):
     return id_
 
 
-class DirectoryCache(object):
-  """ Manages a cache of recently opened directories. """
-
-  # The number of items the cache can hold.
-  SIZE = 512
-
-  def __init__(self, db, root):
-    """ Creates a new DirectoryCache. """
-    self.root = root
-    self._db = db
-    self._directory_list = []
-    self._directory_dict = {}
-
-  def get(self, path, base=None, create_if_necessary=True):
-    if base is not None:
-      root_elements = len(self.root.get_path())
-      if base.get_path()[:root_elements] != self.root.get_path():
-        raise Exception('Invalid base')
-
-      base_path = base.get_path()[root_elements:]
-      path = base_path + path
-
-    try:
-      return self._directory_dict[path]
-    except KeyError:
-      method = self.root.open
-      if create_if_necessary:
-        method = self.root.create_or_open
-
-      self[path] = method(self._db, path)
-      return self[path]
-
-  def __setitem__(self, key, value):
-    """ Adds a new directory to the cache.
-
-    Args:
-      key: A tuple identifying the directory path.
-      value: A directory object.
-    """
-    if key in self._directory_dict:
-      return
-
-    self._directory_dict[key] = value
-    self._directory_list.append(key)
-    if len(self._directory_list) > self.SIZE:
-      old_key = self._directory_list.pop(0)
-      del self._directory_dict[old_key]
-
-  def __getitem__(self, key):
-    """ Retrieves a directory from the cache.
-
-    Args:
-      key: A tuple identifying the directory path.
-    """
-    return self._directory_dict[key]
-
-
 class TornadoFDB(object):
   def __init__(self, io_loop):
     self._io_loop = io_loop

--- a/AppDB/appscale/datastore/scripts/datastore.py
+++ b/AppDB/appscale/datastore/scripts/datastore.py
@@ -901,7 +901,7 @@ def main():
       log_level=logger.getEffectiveLevel(),
       taskqueue_locations=taskqueue_locations)
   else:
-    from appscale.datastore.fdb import FDBDatastore
+    from appscale.datastore.fdb.fdb_datastore import FDBDatastore
     datastore_access = FDBDatastore()
     datastore_access.start()
 

--- a/AppDB/appscale/datastore/scripts/datastore.py
+++ b/AppDB/appscale/datastore/scripts/datastore.py
@@ -904,6 +904,8 @@ def main():
     from appscale.datastore.fdb.fdb_datastore import FDBDatastore
     datastore_access = FDBDatastore()
     datastore_access.start()
+    zookeeper = zktransaction.ZKTransaction(
+      host=zookeeper_locations, log_level=logger.getEffectiveLevel())
 
   zookeeper.handle.add_listener(zk_state_listener)
   zookeeper.handle.ensure_path(DATASTORE_SERVERS_NODE)

--- a/AppDB/setup.py
+++ b/AppDB/setup.py
@@ -30,6 +30,7 @@ setup(
             'appscale.datastore',
             'appscale.datastore.cassandra_env',
             'appscale.datastore.backup',
+            'appscale.datastore.fdb',
             'appscale.datastore.scripts',
             'appscale.datastore.zkappscale'],
   entry_points={'console_scripts': [

--- a/AppDB/setup.py
+++ b/AppDB/setup.py
@@ -14,6 +14,7 @@ setup(
     'cassandra-driver<3.18.0',
     'kazoo',
     'M2Crypto',
+    'monotonic',
     'mmh3',
     'SOAPpy',
     'tornado'

--- a/AppDB/test/unit/test_codecs.py
+++ b/AppDB/test/unit/test_codecs.py
@@ -1,0 +1,302 @@
+import sys
+import unittest
+
+from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
+from appscale.datastore.fdb import codecs
+
+sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.datastore import entity_pb
+
+
+class TestCodecs(unittest.TestCase):
+  def test_reverse_bits(self):
+    original = b'guestbook'
+    reversed = codecs.reverse_bits(original)
+    self.assertEqual(original, codecs.reverse_bits(reversed))
+
+  def test_int64(self):
+    test_vals = [-9223372036854775807, -1099511627776, -1, 0, 1, 255, 256,
+                 16777216]
+    # Ensure original value survives an encoding and decoding transform.
+    for test_val in test_vals:
+      encoded = codecs.Int64.encode(test_val)
+      decoded = codecs.Int64.decode(encoded[0], encoded, 1)[0]
+      self.assertEqual(test_val, decoded)
+
+      reverse_encoded = codecs.Int64.encode(test_val, reverse=True)
+      reverse_decoded = codecs.Int64.decode(
+        reverse_encoded[0], reverse_encoded, 1, reverse=True)[0]
+      self.assertEqual(test_val, reverse_decoded)
+
+    # Ensure encoded values are sorted properly.
+    for index, test_val in enumerate(test_vals):
+      if index == len(test_vals) - 1:
+        break
+
+      greater_val = test_vals[index + 1]
+      encoded = codecs.Int64.encode(test_val)
+      greater_encoded = codecs.Int64.encode(greater_val)
+      self.assertLess(encoded, greater_encoded)
+
+      reverse_encoded = codecs.Int64.encode(test_val, reverse=True)
+      reverse_greater_encoded = codecs.Int64.encode(greater_val, reverse=True)
+      self.assertGreater(reverse_encoded, reverse_greater_encoded)
+
+    test_vals = [(0, 1), (255, 1), (256, 2)]
+    for test_val, byte_count in test_vals:
+      bare_encoded = codecs.Int64.encode_bare(test_val, byte_count)
+      bare_decoded = codecs.Int64.decode_bare(bare_encoded)
+      self.assertEqual(test_val, bare_decoded)
+
+  def test_bytes(self):
+    test_vals = [b'\x00', b'\x00\x00', b'\x00\xFF', b'guestbook', b'\xFF',
+                 b'\xFF\xFF']
+    # Ensure original value survives an encoding and decoding transform.
+    for test_val in test_vals:
+      encoded = codecs.Bytes.encode(test_val)
+      decoded = codecs.Bytes.decode(encoded, 1)[0]
+      self.assertEqual(test_val, decoded)
+
+      reverse_encoded = codecs.Bytes.encode(test_val, reverse=True)
+      reverse_decoded = codecs.Bytes.decode(
+        reverse_encoded, 1, reverse=True)[0]
+      self.assertEqual(test_val, reverse_decoded)
+
+    # Ensure encoded values are sorted properly.
+    for index, test_val in enumerate(test_vals):
+      if index == len(test_vals) - 1:
+        break
+
+      greater_val = test_vals[index + 1]
+      encoded = codecs.Bytes.encode(test_val)
+      greater_encoded = codecs.Bytes.encode(greater_val)
+      self.assertLess(encoded, greater_encoded)
+
+      reverse_encoded = codecs.Bytes.encode(test_val, reverse=True)
+      reverse_greater_encoded = codecs.Bytes.encode(greater_val, reverse=True)
+      self.assertGreater(reverse_encoded, reverse_greater_encoded)
+
+  def test_double(self):
+    test_vals = [-4294967296.0, -3.14, -.6, -0.0, 0.0, .5, 3.14, 16777216.0]
+    # Ensure original value survives an encoding and decoding transform.
+    for test_val in test_vals:
+      encoded = codecs.Double.encode(test_val)
+      decoded = codecs.Double.decode(encoded, 1)[0]
+      self.assertEqual(test_val, decoded)
+
+      reverse_encoded = codecs.Double.encode(test_val, reverse=True)
+      reverse_decoded = codecs.Double.decode(
+        reverse_encoded, 1, reverse=True)[0]
+      self.assertEqual(test_val, reverse_decoded)
+
+    # Ensure encoded values are sorted properly.
+    for index, test_val in enumerate(test_vals):
+      if index == len(test_vals) - 1:
+        break
+
+      greater_val = test_vals[index + 1]
+      encoded = codecs.Double.encode(test_val)
+      greater_encoded = codecs.Double.encode(greater_val)
+      self.assertLess(encoded, greater_encoded)
+
+      reverse_encoded = codecs.Double.encode(test_val, reverse=True)
+      reverse_greater_encoded = codecs.Double.encode(greater_val, reverse=True)
+      self.assertGreater(reverse_encoded, reverse_greater_encoded)
+
+  def test_point(self):
+    test_vals = []
+    test_tuples = [(-3.5, -1), (-3.5, -0.0), (-3.5, 0.0), (-3.5, 1), (-0.0, 1),
+                   (0.0, 1.0), (3.5, 5)]
+    for x, y in test_tuples:
+      test_val = entity_pb.PropertyValue_PointValue()
+      test_val.set_x(x)
+      test_val.set_y(y)
+      test_vals.append(test_val)
+
+    # Ensure original value survives an encoding and decoding transform.
+    for test_val in test_vals:
+      encoded = codecs.Point.encode(test_val)
+      decoded = codecs.Point.decode(encoded, 1)[0]
+      self.assertTrue(test_val.Equals(decoded))
+
+      reverse_encoded = codecs.Point.encode(test_val, reverse=True)
+      reverse_decoded = codecs.Point.decode(
+        reverse_encoded, 1, reverse=True)[0]
+      self.assertTrue(test_val.Equals(reverse_decoded))
+
+    # Ensure encoded values are sorted properly.
+    for index, test_val in enumerate(test_vals):
+      if index == len(test_vals) - 1:
+        break
+
+      greater_val = test_vals[index + 1]
+      encoded = codecs.Point.encode(test_val)
+      greater_encoded = codecs.Point.encode(greater_val)
+      self.assertLess(encoded, greater_encoded)
+
+      reverse_encoded = codecs.Point.encode(test_val, reverse=True)
+      reverse_greater_encoded = codecs.Point.encode(greater_val, reverse=True)
+      self.assertGreater(reverse_encoded, reverse_greater_encoded)
+
+  def test_text(self):
+    test_vals = [u'\x00', u'\x00\x00', u'guestbook', u'z', u'\u03b1']
+    # Ensure original value survives an encoding and decoding transform.
+    for test_val in test_vals:
+      encoded = codecs.Text.encode(test_val)
+      decoded = codecs.Text.decode(encoded, 0)[0]
+      self.assertEqual(test_val, decoded)
+
+      reverse_encoded = codecs.Text.encode(test_val, reverse=True)
+      reverse_decoded = codecs.Text.decode(
+        reverse_encoded, 0, reverse=True)[0]
+      self.assertEqual(test_val, reverse_decoded)
+
+    # Ensure encoded values are sorted properly.
+    for index, test_val in enumerate(test_vals):
+      if index == len(test_vals) - 1:
+        break
+
+      greater_val = test_vals[index + 1]
+      encoded = codecs.Text.encode(test_val)
+      greater_encoded = codecs.Text.encode(greater_val)
+      self.assertLess(encoded, greater_encoded)
+
+      reverse_encoded = codecs.Text.encode(test_val, reverse=True)
+      reverse_greater_encoded = codecs.Text.encode(greater_val, reverse=True)
+      self.assertGreater(reverse_encoded, reverse_greater_encoded)
+
+  def test_user(self):
+    test_vals = []
+    test_tuples = [(u'a@a.com', u'a.com'),
+                   (u'test@appscale.com', u'appscale.com'),
+                   (u'test@appscale.com', u'example.com')]
+    for email, auth_domain in test_tuples:
+      test_val = entity_pb.PropertyValue_UserValue()
+      test_val.set_email(email)
+      test_val.set_auth_domain(auth_domain)
+      test_vals.append(test_val)
+
+    # Ensure original value survives an encoding and decoding transform.
+    for test_val in test_vals:
+      encoded = codecs.User.encode(test_val)
+      decoded = codecs.User.decode(encoded, 1)[0]
+      self.assertTrue(test_val.Equals(decoded))
+
+      reverse_encoded = codecs.User.encode(test_val, reverse=True)
+      reverse_decoded = codecs.User.decode(
+        reverse_encoded, 1, reverse=True)[0]
+      self.assertTrue(test_val.Equals(reverse_decoded))
+
+    # Ensure encoded values are sorted properly.
+    for index, test_val in enumerate(test_vals):
+      if index == len(test_vals) - 1:
+        break
+
+      greater_val = test_vals[index + 1]
+      encoded = codecs.User.encode(test_val)
+      greater_encoded = codecs.User.encode(greater_val)
+      self.assertLess(encoded, greater_encoded)
+
+      reverse_encoded = codecs.User.encode(test_val, reverse=True)
+      reverse_greater_encoded = codecs.User.encode(greater_val, reverse=True)
+      self.assertGreater(reverse_encoded, reverse_greater_encoded)
+
+  def test_path(self):
+    test_tuples = [(u'Greet', u'test', u'Greeting', u'test'),
+                   (u'Greeting', 1),
+                   (u'Greeting', 2),
+                   (u'Greeting', u'test'),
+                   (u'Greeting', u'test', u'Author', 1),
+                   (u'Greeting', u'test', u'Greeting', u'test'),
+                   (u'Greeting2', u'test'),
+                   (u'Greeting2', u'test', u'Greeting', u'test')]
+
+    # Ensure original value survives an encoding and decoding transform.
+    for path_tuple in test_tuples:
+      encoded = codecs.Path.pack(path_tuple)
+      decoded = codecs.Path.unpack(encoded, 0)[0]
+      self.assertEqual(path_tuple, decoded)
+
+      reverse_encoded = codecs.Path.pack(path_tuple, reverse=True)
+      reverse_decoded = codecs.Path.unpack(
+        reverse_encoded, 0, reverse=True)[0]
+      self.assertEqual(path_tuple, reverse_decoded)
+
+    # Ensure encoded values are sorted properly.
+    for index, path_tuple in enumerate(test_tuples):
+      if index == len(test_tuples) - 1:
+        break
+
+      greater_val = test_tuples[index + 1]
+      encoded = codecs.Path.pack(path_tuple)
+      greater_encoded = codecs.Path.pack(greater_val)
+      self.assertLess(encoded, greater_encoded)
+
+      reverse_encoded = codecs.Path.pack(path_tuple, reverse=True)
+      reverse_greater_encoded = codecs.Path.pack(greater_val, reverse=True)
+      self.assertGreater(reverse_encoded, reverse_greater_encoded)
+
+  def test_reference(self):
+    test_vals = []
+    test_tuples = [
+      (u'guest', u'', u'Greet', u'test', u'Greeting', u'test'),
+      (u'guestbook', u'', u'Greet', u'test', u'Greeting', u'test'),
+      (u'guestbook', u'', u'Greeting', 1),
+      (u'guestbook', u'', u'Greeting', 2),
+      (u'guestbook', u'', u'Greeting', u'test'),
+      (u'guestbook', u'', u'Greeting', u'test', u'Author', 1),
+      (u'guestbook', u'', u'Greeting', u'test', u'Greeting', u'test'),
+      (u'guestbook', u'', u'Greeting2', u'test'),
+      (u'guestbook', u'', u'Greeting2', u'test', u'Greeting', u'test'),
+      (u'guestbook', u'ns1', u'Greeting2', u'test', u'Greeting', u'test'),
+      (u'guestbook2', u'', u'Greet', u'test', u'Greeting', u'test')
+    ]
+    for test_tuple in test_tuples:
+      ref_val = entity_pb.PropertyValue_ReferenceValue()
+      ref_val.set_app(test_tuple[0])
+      ref_val.set_name_space(test_tuple[1])
+      flat_path = test_tuple[2:]
+      for index in range(0, len(flat_path), 2):
+        element = ref_val.add_pathelement()
+        element.set_type(flat_path[index])
+        id_or_name = flat_path[index + 1]
+        if isinstance(id_or_name, int):
+          element.set_id(id_or_name)
+        else:
+          element.set_name(id_or_name)
+
+      test_vals.append(ref_val)
+
+    # Ensure original value survives an encoding and decoding transform.
+    for test_val in test_vals:
+      encoded = codecs.Reference.encode(test_val)
+      decoded = codecs.Reference.decode(encoded, 1)[0]
+      self.assertTrue(test_val.Equals(decoded))
+
+      reverse_encoded = codecs.Reference.encode(test_val, reverse=True)
+      reverse_decoded = codecs.Reference.decode(
+        reverse_encoded, 1, reverse=True)[0]
+      self.assertTrue(test_val.Equals(reverse_decoded))
+
+    # Ensure encoded values are sorted properly.
+    for index, test_val in enumerate(test_vals):
+      if index == len(test_vals) - 1:
+        break
+
+      greater_val = test_vals[index + 1]
+      encoded = codecs.Reference.encode(test_val)
+      greater_encoded = codecs.Reference.encode(greater_val)
+      self.assertLess(encoded, greater_encoded)
+
+      reverse_encoded = codecs.Reference.encode(test_val, reverse=True)
+      reverse_greater_encoded = codecs.Reference.encode(
+        greater_val, reverse=True)
+      self.assertGreater(reverse_encoded, reverse_greater_encoded)
+
+  def test_txid(self):
+    scatter_val = 5
+    commit_vs = b'\x00\x00\x00\xa4\x10\xaf\xd3\x0a\x00\x01'
+    encoded = codecs.TransactionID.encode(scatter_val, commit_vs)
+    decoded_scatter, decoded_commit_vs = codecs.TransactionID.decode(encoded)
+    self.assertEqual(scatter_val, decoded_scatter)
+    self.assertEqual(commit_vs, decoded_commit_vs)


### PR DESCRIPTION
There are several areas that still need work before we should consider using this as the default backend.
- ~The way index entries are encoded needs some adjusting. At the moment, there is some unnecessary tuple nesting and versionstamp padding that makes keys longer than they need to be.~
- FDB errors should be handled and retried when possible or translated to the appropriate datastore error code.
- Kind statistics have not been implemented yet.

In addition, the following areas could use some work but do not necessarily block the usage of this module.
- ~The query handling logic could use some refactoring. There is some repetition that makes it tedious to read and more difficult to maintain.~
- Composite index definitions should be stored in FDB so they can be updated consistently.
- A lot of the methods need more documentation.
- Unit tests for the encoding and decoding methods would be useful.
- The SDK imports can be removed.
- Sequential key allocation has not been implemented yet.
- Transactional tasks have not been implemented in a way that guarantees atomicity.