### PR TITLE
Scaled nodes changes

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2324,7 +2324,7 @@ class Djinn
     Djinn.log_debug("Changed nodes to #{@nodes}")
 
     update_firewall
-    initialize_nodes_in_parallel([], new_nodes)
+    initialize_nodes_in_parallel(new_nodes, [])
   end
 
   # Cleans out temporary files that may have been written by a previous

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -877,8 +877,8 @@ class Djinn
           Djinn.log_warn("max_machines is less than the number of nodes!")
           @options['max_machines'] = @nodes.length.to_s
         end
-        if Integer(@options['min_machines']) < @nodes.length
-          Djinn.log_warn("min_machines is less than the number of nodes!")
+        if Integer(@options['min_machines']) > @nodes.length
+          Djinn.log_warn("min_machines is bigger than the number of nodes!")
           @options['min_machines'] = @nodes.length.to_s
         end
         if Integer(@options['max_machines']) < Integer(@options['min_machines'])

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3142,7 +3142,7 @@ class Djinn
         end
         if node.public_ip == public_ip
           HelperFunctions.log_and_crash("Found my public ip (#{public_ip}) " \
-            "in @nodes but my private ip is not matching! @nodes=#{@nodes}.")
+            "in @nodes but my private ip (#{all_local_ips}) is not matching! @nodes=#{@nodes}.")
         end
       }
     }

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3763,6 +3763,8 @@ class Djinn
       Djinn.log_run("ssh-keygen -R #{dest_node.public_ip}")
     end
 
+    is_it_cloud = nil
+    infrastructure = nil
     @state_change_lock.synchronize {
       is_it_cloud = is_cloud?
       infrastructure = @options['infrastructure']
@@ -4202,7 +4204,7 @@ class Djinn
       begin
         commands = JSON.load(user_commands)
       rescue JSON::ParserError
-        commands = user_commands]
+        commands = user_commands
       end
 
       if commands.class == String
@@ -4287,6 +4289,8 @@ class Djinn
     end
     Djinn.log_debug("Sending data to #{ip}.")
 
+    layout = nil
+    options = nil
     @state_change_lock.synchronize {
       layout = Djinn.convert_location_class_to_json(@nodes)
       options = JSON.dump(@options)

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1721,7 +1721,6 @@ class Djinn
     start_infrastructure_manager
     mount_persistent_storage
 
-    find_me_in_locations
     write_database_info
     update_firewall
 

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -937,37 +937,39 @@ class Djinn
     }
     enforce_options
 
-    # From here on we do more logical checks on the values we received.
-    # The first one is to check that max and min are set appropriately.
-    # Max and min needs to be at least the number of started nodes, it
-    # needs to be positive. Max needs to be no smaller than min.
-    @state_change_lock.synchronize {
-      if Integer(@options['max_machines']) < @nodes.length
-        Djinn.log_warn("max_machines is less than the number of nodes!")
-        @options['max_machines'] = @nodes.length.to_s
-      end
-      if Integer(@options['min_machines']) < @nodes.length
-        Djinn.log_warn("min_machines is less than the number of nodes!")
-        @options['min_machines'] = @nodes.length.to_s
-      end
-      if Integer(@options['max_machines']) < Integer(@options['min_machines'])
-        Djinn.log_warn("min_machines is bigger than max_machines!")
-        @options['max_machines'] = @options['min_machines']
-      end
-    }
-
     # We need to make sure this node is listed in the started nodes.
     find_me_in_locations
     return "Error: Couldn't find me in the node map" if @my_index.nil?
 
-    @state_change_lock.synchronize {
-      ENV['EC2_URL'] = @options['ec2_url']
-      if @options['ec2_access_key'].nil?
-        @options['ec2_access_key'] = @options['EC2_ACCESS_KEY']
-        @options['ec2_secret_key'] = @options['EC2_SECRET_KEY']
-        @options['ec2_url'] = @options['EC2_URL']
-      end
-    }
+    # From here on we do more logical checks on the values we received.
+    # The first one is to check that max and min are set appropriately.
+    # Max and min needs to be at least the number of started nodes, it
+    # needs to be positive. Max needs to be no smaller than min.
+    if my_node.is_shadow?
+      @state_change_lock.synchronize {
+        if Integer(@options['max_machines']) < @nodes.length
+          Djinn.log_warn("max_machines is less than the number of nodes!")
+          @options['max_machines'] = @nodes.length.to_s
+        end
+        if Integer(@options['min_machines']) < @nodes.length
+          Djinn.log_warn("min_machines is less than the number of nodes!")
+          @options['min_machines'] = @nodes.length.to_s
+        end
+        if Integer(@options['max_machines']) < Integer(@options['min_machines'])
+          Djinn.log_warn("min_machines is bigger than max_machines!")
+          @options['max_machines'] = @options['min_machines']
+        end
+      }
+
+      @state_change_lock.synchronize {
+        ENV['EC2_URL'] = @options['ec2_url']
+        if @options['ec2_access_key'].nil?
+          @options['ec2_access_key'] = @options['EC2_ACCESS_KEY']
+          @options['ec2_secret_key'] = @options['EC2_SECRET_KEY']
+          @options['ec2_url'] = @options['EC2_URL']
+        end
+      }
+    end
 
     'OK'
   end

--- a/AppController/lib/infrastructure_manager_client.rb
+++ b/AppController/lib/infrastructure_manager_client.rb
@@ -77,10 +77,14 @@ class InfrastructureManagerClient
     return run_result
   end
 
-  def terminate_instances(options, instance_ids)
+  def terminate_instances(opts, instance_ids)
     headers = {}
     headers['Content-Type'] = 'application/json'
     headers['AppScale-Secret'] = @secret
+
+    # Make a copy (the options are a simple hash so shallow copy does the
+    # trick) to not modify the original.
+    options = opts.clone
     options['instance_ids'] = [instance_ids] if instance_ids.class != Array
 
     uri = URI("http://#{@ip}:#{SERVER_PORT}/instances")
@@ -117,7 +121,7 @@ class InfrastructureManagerClient
   #
   # Args:
   #   num_vms: the number of VMs to create.
-  #   options: a hash containing information needed by the agent
+  #   opts: a hash containing information needed by the agent
   #     (credentials etc ...).
   #   roles: an Array containing the roles for each VM to be created.
   #   disks: an Array specifying the disks to be associated with the VMs
@@ -126,9 +130,11 @@ class InfrastructureManagerClient
   # Returns
   #   An Array containing the nodes information, suitable to be converted
   #   into Node.
-  def run_instances(num_vms, options, roles, disks)
+  def run_instances(num_vms, opts, roles, disks)
+    # Make a copy (the options are a simple hash so shallow copy does the
+    # trick) to not modify the original.
+    options = opts.clone
     options['num_vms'] = num_vms.to_s
-    options['cloud'] = 'cloud1'
 
     uri = URI("http://#{@ip}:#{SERVER_PORT}/instances")
     headers = {'Content-Type' => 'application/json',
@@ -184,7 +190,7 @@ class InfrastructureManagerClient
   # Asks the InfrastructureManager to attach a persistent disk to this machine.
   #
   # Args:
-  #   parameters: A Hash that contains the credentials necessary to interact
+  #   opts: A Hash that contains the credentials necessary to interact
   #     with the underlying cloud infrastructure.
   #   disk_name: A String that names the persistent disk to attach to this
   #     machine.
@@ -194,11 +200,14 @@ class InfrastructureManagerClient
   # Returns:
   #   The location on the local filesystem where the persistent disk was
   #   attached to.
-  def attach_disk(options, disk_name, instance_id)
+  def attach_disk(opts, disk_name, instance_id)
     Djinn.log_debug('Calling attach_disk with parameters ' \
-      "#{options.inspect}, with disk name #{disk_name} and instance id " +
+      "#{opts.inspect}, with disk name #{disk_name} and instance id " +
       instance_id.to_s)
 
+    # Make a copy (the options are a simple hash so shallow copy does the
+    # trick) to not modify the original.
+    options = opts.clone
     options['instance_id'] = instance_id
     options['disk_name'] = disk_name
 

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -132,10 +132,9 @@ class TestDjinn < Test::Unit::TestCase
 
     better_credentials = JSON.dump({'keyname' => '0123', 'login' =>
       '1.1.1.1', 'table' => 'cassandra'})
-    result_2 = djinn.set_parameters("", better_credentials,  @secret)
-    # Depending on the JSON library used, "" can either throw an exception
-    # or be interpreted as nil.
-    assert_equal(true, result_2.include?("Error"))
+    assert_raises(AppScaleException) {
+      result_2 = djinn.set_parameters("", better_credentials,  @secret)
+    }
 
     # Now try credentials with an even number of items, but not all the
     # required parameters
@@ -150,8 +149,9 @@ class TestDjinn < Test::Unit::TestCase
       'keyname' => 'appscale'
     })
     bad_node_info = "[1]"
-    result_6 = djinn.set_parameters(bad_node_info, credentials, @secret)
-    assert_equal(true, result_6.include?("Error: node structure is not"))
+    assert_raises(AppScaleException) {
+      result_6 = djinn.set_parameters(bad_node_info, credentials, @secret)
+    }
 
     # Finally, try credentials with info in the right format, but where it
     # refers to nodes that aren't in our deployment

--- a/AppController/test/tc_djinn.rb
+++ b/AppController/test/tc_djinn.rb
@@ -437,7 +437,7 @@ class TestDjinn < Test::Unit::TestCase
       instance.should_receive(:valid_secret?).and_return(true)
     }
 
-    djinn = Djinn.new()
+    djinn = get_djinn_mock
     expected = Djinn::BAD_INPUT_MSG
     actual = djinn.start_roles_on_nodes("", @secret)
     assert_equal(expected, actual)
@@ -676,7 +676,7 @@ class TestDjinn < Test::Unit::TestCase
     deployment_id_exists = true
     bad_secret = 'boo'
     good_secret = 'blarg'
-    djinn = flexmock(Djinn.new())
+    djinn = get_djinn_mock
     flexmock(ZKInterface).should_receive(:exists?).
       and_return(deployment_id_exists)
 
@@ -694,7 +694,7 @@ class TestDjinn < Test::Unit::TestCase
     good_secret = 'boo'
     bad_secret = 'blarg'
     deployment_id = 'baz'
-    djinn = flexmock(Djinn.new())
+    djinn = get_djinn_mock
     flexmock(ZKInterface).should_receive(:get).
         and_return(deployment_id)
 


### PR DESCRIPTION
This PR originated from relatively rare random issues we could see during autoscaling tests. Here are the list of things done:

- limited the time and actions done in set_parameters, ensure we set both @options and @nodes only then the check are fully completed, and pushed the further action/check to enforce_options;

- ensure that no other calls can be fulfilled if @nodes is empty: this prevent bogus/spurious errors in the logs;

- prevent temporary IAAS options are accidentally propagated to the AC;

- limit locks around initialize_nodes_in_parallel.
