### PR TITLE
AppServer generate internal admin login secret where needed

### DIFF
--- a/AppServer/google/appengine/tools/devappserver2/blob_upload.py
+++ b/AppServer/google/appengine/tools/devappserver2/blob_upload.py
@@ -46,6 +46,8 @@ from google.appengine.api import datastore_errors
 from google.appengine.api.blobstore import blobstore
 from google.appengine.ext.cloudstorage import cloudstorage_stub
 from google.appengine.tools.devappserver2 import constants
+from google.appengine.tools.devappserver2 import login
+
 
 # Upload URL path.
 UPLOAD_URL_PATH = '_ah/upload/'
@@ -576,7 +578,7 @@ class Application(object):
       environ['QUERY_STRING'] = parsed_url.query
 
     # The user is always an administrator for the forwarded request.
-    environ[constants.FAKE_IS_ADMIN_HEADER] = '1'
+    environ[constants.FAKE_IS_ADMIN_HEADER] = login.fake_admin()
 
     # Set the wsgi variables
     environ['wsgi.input'] = cStringIO.StringIO(content_text)

--- a/AppServer/google/appengine/tools/devappserver2/login.py
+++ b/AppServer/google/appengine/tools/devappserver2/login.py
@@ -37,6 +37,7 @@ import os
 import sha
 import sys
 import urllib
+import uuid
 
 import webapp2
 
@@ -284,6 +285,17 @@ def login_redirect(application_url, continue_url, start_response):
   start_response('302 Requires login',
                  [('Location', redirect_url)])
   return []
+
+
+def fake_admin():
+  """ Generate the fake admin login secret
+
+  Returns:
+    A string containing the fake login secret
+  """
+  return hashlib.sha1('{}/{}'.format(
+      os.environ.get('APPNAME', str(uuid.uuid4())),
+      os.environ.get('COOKIE_SECRET', str(uuid.uuid4())))).hexdigest()
 
 
 class Handler(webapp2.RequestHandler):

--- a/AppServer/google/appengine/tools/devappserver2/module.py
+++ b/AppServer/google/appengine/tools/devappserver2/module.py
@@ -833,6 +833,7 @@ class Module(object):
                'wsgi.input': cStringIO.StringIO(body)}
     util.put_headers_in_environ(headers, environ)
     if fake_login:
+      environ[constants.FAKE_IS_ADMIN_HEADER] = login.fake_admin()
       environ[constants.FAKE_LOGGED_IN_HEADER] = '1'
     elif constants.FAKE_LOGGED_IN_HEADER in environ:
       del environ[constants.FAKE_LOGGED_IN_HEADER]

--- a/AppServer/google/appengine/tools/devappserver2/url_handler.py
+++ b/AppServer/google/appengine/tools/devappserver2/url_handler.py
@@ -16,10 +16,8 @@
 #
 """Base functionality for handling HTTP requests."""
 
-import hashlib
+
 import logging
-import os
-import uuid
 import wsgiref.util
 
 from google.appengine.api import appinfo
@@ -105,9 +103,7 @@ class UserConfiguredURLHandler(URLHandler):
     """
     super(UserConfiguredURLHandler, self).__init__(url_pattern)
     self._url_map = url_map
-    self._secret_hash = hashlib.sha1('{}/{}'.format(
-        os.environ.get('APPNAME', str(uuid.uuid4())),
-        os.environ.get('COOKIE_SECRET', str(uuid.uuid4())))).hexdigest()
+    self._secret_hash = login.fake_admin()
 
   def handle_authorization(self, environ, start_response):
     """Handles the response if the user is not authorized to access this URL.


### PR DESCRIPTION
In master `_ah` handlers using `login: admin` should use a valid login secret. This fixes functionality such as warm up and blobstore uploads where handlers require login.