### PR TITLE
Don't trap SIGTERM and let the process stops

### DIFF
--- a/AppController/djinnServer.rb
+++ b/AppController/djinnServer.rb
@@ -145,11 +145,6 @@ server = DjinnServer.new(
   :SSLCertName => nil
 )
 
-trap('TERM') {
-  Djinn.log_debug("Received TERM signal: stopping AppController.")
-  server.shutdown
-}
-
 new_thread = Thread.new { run_server(server) }
 server.djinn.job_start(secret)
 new_thread.join()


### PR DESCRIPTION
Since the AC is not doing any prticular action on normal stop (that is
SIGTERM reception) we don't need to trap it anymore, and let service
appscale-controller stop do its magic.