### PR TITLE
AppController command output to standard error / logging verbosity

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -6,6 +6,7 @@ require 'logger'
 require 'monitor'
 require 'net/http'
 require 'net/https'
+require 'open3'
 require 'openssl'
 require 'securerandom'
 require 'set'
@@ -2424,10 +2425,12 @@ class Djinn
   # the command that was executed.
   def self.log_run(command)
     Djinn.log_debug("Running #{command}")
-    output = `#{command}`
-    if $?.exitstatus != 0
-      Djinn.log_debug("Command #{command} failed with #{$?.exitstatus}" \
-          " and output: #{output}.")
+    output, err_output, status = Open3.capture3(command)
+    if status.exitstatus != 0
+      Djinn.log_debug("Command #{command} failed with #{status.exitstatus}" \
+          " and output: #{output}")
+      Djinn.log_debug("Command #{command} error output: " \
+          "#{err_output}") if err_output
     end
     return output
   end

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -1211,7 +1211,7 @@ class Djinn
       end
     end
 
-    Djinn.log_info("Received request to get properties matching #{property_regex}.")
+    Djinn.log_debug("Received request to get properties matching #{property_regex}.")
     properties = {}
     PARAMETERS_AND_CLASS.each { |key, val|
       begin

--- a/AppController/lib/helperfunctions.rb
+++ b/AppController/lib/helperfunctions.rb
@@ -6,6 +6,7 @@ require 'digest'
 require 'fileutils'
 require 'find'
 require 'net/http'
+require 'open3'
 require 'openssl'
 require 'socket'
 require 'timeout'
@@ -100,7 +101,11 @@ module HelperFunctions
   NUM_ENTRIES_TO_PRINT = 10
 
   def self.shell(cmd)
-    `#{cmd}`
+    output, err_output, status = Open3.capture3(cmd)
+    if status.exitstatus != 0 and err_output
+      Djinn.log_warn("Shell commmand #{cmd} failed with error output #{err_output}")
+    end
+    return output
   end
 
   def self.write_file(location, contents)


### PR DESCRIPTION
This pull request cleans up a couple of logging items:

* Logging of "Received request to get properties matching login" frequently at info level
* Output from os commands being sent to the services stderr

There are other places which send command output to stderr (and sometimes stdin/stdout) that we may want to clean up later.

Daily build no. 6503