### PR TITLE
Add a rough interface for managing service accounts

### DIFF
--- a/AdminServer/appscale/admin/__init__.py
+++ b/AdminServer/appscale/admin/__init__.py
@@ -62,6 +62,7 @@ from .constants import (
   VersionNotChanged
 )
 from .controller_state import ControllerState
+from .iam import ServiceAccountsHandler
 from .operation import (
   DeleteServiceOperation,
   CreateVersionOperation,
@@ -1398,6 +1399,8 @@ def main():
     ('/api/datastore/index/add', UpdateIndexesHandler,
      {'zk_client': zk_client, 'ua_client': ua_client}),
     ('/api/queue/update', UpdateQueuesHandler,
+     {'zk_client': zk_client, 'ua_client': ua_client}),
+    ('/v1/projects/([^/]*)/serviceAccounts', ServiceAccountsHandler,
      {'zk_client': zk_client, 'ua_client': ua_client})
   ])
   logger.info('Starting AdminServer')

--- a/AdminServer/appscale/admin/iam.py
+++ b/AdminServer/appscale/admin/iam.py
@@ -1,0 +1,106 @@
+""" Implements some IAM API operations. """
+import json
+
+from kazoo.exceptions import NodeExistsError, NoNodeError
+
+from .base_handler import BaseHandler
+from .constants import CustomHTTPError
+from appscale.common.constants import HTTPCodes
+
+
+class ServiceAccount(object):
+  def __init__(self, project_id, email, id_=None, display_name=None,
+               description=None, private_key=None, token_uri=None):
+    self.project_id = project_id
+    self.email = email
+    self.id = id_
+    self.display_name = display_name
+    self.description = description
+    self.private_key = private_key
+    self.token_uri = token_uri
+
+  def json_repr(self):
+    optional_fields = (('uniqueId', self.id),
+                       ('displayName', self.display_name),
+                       ('description', self.description),
+                       ('oauth2ClientId', self.id))
+    details = {'name': '/'.join(['projects', self.project_id,
+                                 'serviceAccounts', self.email]),
+               'projectId': self.project_id,
+               'email': self.email}
+    for field, val in optional_fields:
+      if val is not None:
+        details[field] = val
+
+    return details
+
+  def zk_serialize(self):
+    zk_fields = (('email', self.email),
+                 ('uniqueId', self.id),
+                 ('displayName', self.display_name),
+                 ('description', self.description),
+                 ('privateKey', self.private_key),
+                 ('tokenUri', self.token_uri))
+    return json.dumps({field: val for field, val in zk_fields
+                       if val is not None})
+
+  @classmethod
+  def from_json(cls, project_id, data):
+    required = ('privateKey', 'email', 'uniqueId', 'tokenUri')
+    details = json.loads(data)
+    for field in required:
+      if field not in details:
+        raise CustomHTTPError(HTTPCodes.BAD_REQUEST,
+                              message='{} is a required field'.format(field))
+
+    return cls(project_id, details['email'], details['uniqueId'],
+               private_key=details['privateKey'],
+               token_uri=details['tokenUri'])
+
+
+class ServiceAccountsHandler(BaseHandler):
+  PROJECT_NODE = '/appscale/projects/{}'
+
+  def initialize(self, zk_client, ua_client):
+    self.zk_client = zk_client
+    self.ua_client = ua_client
+
+  def get(self, project_id):
+    self.authenticate(project_id, self.ua_client)
+    service_accounts = []
+    project_node = self.PROJECT_NODE.format(project_id)
+    try:
+      default_data = self.zk_client.get(project_node + '/private_key')[0]
+    except NoNodeError:
+      default_data = None
+
+    if default_data is not None:
+      details = json.loads(default_data)
+      service_accounts.append(ServiceAccount(project_id, details['key_name']))
+
+    accounts_node = self.PROJECT_NODE.format(project_id) + '/service_accounts'
+    try:
+      account_names = self.zk_client.get_children(accounts_node)
+    except NoNodeError:
+      account_names = []
+
+    for account_name in account_names:
+      account_node = '/'.join([accounts_node, account_name])
+      account_data = self.zk_client.get(account_node)[0]
+      service_account = ServiceAccount.from_json(project_id, account_data)
+      service_accounts.append(service_account)
+
+    self.write(json.dumps([account.json_repr()
+                           for account in service_accounts]))
+
+  def post(self, project_id):
+    self.authenticate(project_id, self.ua_client)
+    account = ServiceAccount.from_json(project_id, self.request.body)
+    account_path = '/'.join([self.PROJECT_NODE.format(project_id),
+                             'service_accounts', account.email])
+    try:
+      self.zk_client.create(account_path, account.zk_serialize(),
+                            makepath=True)
+    except NodeExistsError:
+      raise CustomHTTPError(HTTPCodes.BAD_REQUEST,
+                            message='{} already exists'.format(account.email))

--- a/AppDashboard/dashboard.py
+++ b/AppDashboard/dashboard.py
@@ -38,6 +38,8 @@ from dashboard_logs import RequestLogLine
 from datastore_viewer import DatastoreEditRequestHandler
 from datastore_viewer import DatastoreViewer
 from datastore_viewer import DatastoreViewerSelector
+from service_accounts import (ServiceAccountsProjectSelector,
+                              ProjectServiceAccounts)
 from pull_queue_viewer import (PQProjectSelector, PQQueueSelector,
                                PQTaskSelector)
 
@@ -1192,6 +1194,8 @@ dashboard_pages = [
   ('/apps/json/?', AppsAsJSONPage),
   ('/apps/json/(.+)', AppsAsJSONPage),
   ('/apps/stats', StatsPage),
+  ('/service_accounts', ServiceAccountsProjectSelector),
+  ('/service_accounts/(.+)', ProjectServiceAccounts),
   ('/logs', LogMainPage),
   ('/logs/(.+)/(.+)', LogServiceHostPage),
   ('/logs/(.+)', LogServicePage),

--- a/AppDashboard/lib/app_dashboard_data.py
+++ b/AppDashboard/lib/app_dashboard_data.py
@@ -130,6 +130,8 @@ class AppDashboardData():
         "relocate_app": {"title": "Relocate Application",
                          "link": "/apps/relocate",
                          "template": "apps/relocate.html"},
+        "service_accounts": {"title": "Service Accounts",
+                             "link": "/service_accounts"},
         "manage_users": {"title": "Manage Users",
                          "link": "/authorize",
                          "is_admin_panel": True,
@@ -159,7 +161,9 @@ class AppDashboardData():
                                           {"delete_app": lookup_dict[
                                               "delete_app"]},
                                           {"relocate_app": lookup_dict[
-                                              "relocate_app"]}]}
+                                              "relocate_app"]},
+                                          {"service_accounts": lookup_dict[
+                                              "service_accounts"]}]}
       if user_info.is_user_cloud_admin:
         lookup_dict["appscale_management"] = {"AppScale Management":
                                               [{"cloud_stats": lookup_dict[

--- a/AppDashboard/lib/service_accounts.py
+++ b/AppDashboard/lib/service_accounts.py
@@ -1,0 +1,100 @@
+import json
+
+from google.appengine.api import urlfetch
+
+from admin_server_location import ADMIN_SERVER_LOCATION
+from app_dashboard import AppDashboard
+from app_dashboard_helper import AppDashboardHelper, AppHelperException
+from secret_key import GLOBAL_SECRET_KEY
+
+
+class ServiceAccountsProjectSelector(AppDashboard):
+  TEMPLATE = 'service_accounts/project_selector.html'
+
+  def get(self):
+    if self.helper.is_user_cloud_admin():
+      version_keys = self.helper.get_version_info().keys()
+      owned_projects = list({version.split('_')[0] for version in version_keys
+                             if version.split('_')[0] != self.PROJECT_ID})
+    else:
+      owned_projects = self.helper.get_owned_apps()
+
+    context = {
+      'page_content': self.TEMPLATE,
+      'owned_projects': owned_projects,
+    }
+    self.render_app_page(page='service_accounts_project_selector',
+                         values=context)
+
+
+class ProjectServiceAccounts(AppDashboard):
+  TEMPLATE = 'service_accounts/editor.html'
+
+  def ensure_user_has_admin(self, project_id):
+    """ Returns an error page if user does not have project permissions.
+
+    Args:
+      project_id: A string specifying a project ID.
+    """
+    if self.helper.is_user_cloud_admin():
+      version_keys = self.helper.get_version_info().keys()
+      owned_projects = list({version.split('_')[0]
+                             for version in version_keys})
+    else:
+      owned_projects = self.helper.get_owned_apps()
+
+    if project_id not in owned_projects:
+      message = ('You do not have permission to view or edit service accounts '
+                 'for this project. Please log in as a user with sufficient '
+                 'permissions.')
+      self.response.write(message)
+      self.abort(403)
+
+  def get(self, project_id):
+    self.ensure_user_has_admin(project_id)
+    admin_server = 'https://{}:{}'.format(ADMIN_SERVER_LOCATION,
+                                          AppDashboardHelper.ADMIN_SERVER_PORT)
+    accounts_url = '{}/v1/projects/{}/serviceAccounts'.format(
+      admin_server, project_id)
+    result = urlfetch.fetch(accounts_url,
+                            headers={'AppScale-Secret': GLOBAL_SECRET_KEY},
+                            validate_certificate=False)
+    if result.status_code != 200:
+      raise AppHelperException(result.content)
+
+    try:
+      accounts = json.loads(result.content)
+    except ValueError:
+      raise AppHelperException('Invalid response: {}'.format(result.content))
+
+    context = {
+      'page_content': self.TEMPLATE,
+      'project_id': project_id,
+      'accounts': accounts
+    }
+    self.render_app_page(page='service_accounts', values=context)
+
+  def post(self, project_id):
+    self.ensure_user_has_admin(project_id)
+    account_data = self.request.POST['service_account_json'].file.read()
+    account_details = json.loads(account_data)
+    required = ('client_email', 'client_id', 'private_key', 'token_uri')
+    for field in required:
+      if field not in account_details:
+        raise AppHelperException('Missing required field: {}'.format(field))
+
+    payload = {'email': account_details['client_email'],
+               'uniqueId': account_details['client_id'],
+               'privateKey': account_details['private_key'],
+               'tokenUri': account_details['token_uri']}
+    admin_server = 'https://{}:{}'.format(ADMIN_SERVER_LOCATION,
+                                          AppDashboardHelper.ADMIN_SERVER_PORT)
+    accounts_url = '{}/v1/projects/{}/serviceAccounts'.format(
+      admin_server, project_id)
+    result = urlfetch.fetch(accounts_url, json.dumps(payload), urlfetch.POST,
+                            headers={'AppScale-Secret': GLOBAL_SECRET_KEY},
+                            validate_certificate=False)
+    if result.status_code != 200:
+      raise AppHelperException(result.content)
+
+    self.redirect('/service_accounts/{}'.format(project_id))

--- a/AppDashboard/templates/service_accounts/editor.html
+++ b/AppDashboard/templates/service_accounts/editor.html
@@ -1,0 +1,16 @@
+<div class="page-header"><h1>Service Accounts for {{ project_id }}</h1></div>
+{% if accounts %}
+  <h3>Current Accounts</h3>
+  <ul>
+  {% for account in accounts %}
+    <li>{{ account.email }}</li>
+  {% endfor %}
+  </ul>
+{% else %}
+  <p>There are no service accounts defined for this project.</p>
+{% endif %}
+<form method="post" enctype="multipart/form-data">
+    <h3>Upload new service account JSON</h3>
+    <input type="file" name="service_account_json" required>
+    <input type="submit" value="Upload">
+</form>

--- a/AppDashboard/templates/service_accounts/project_selector.html
+++ b/AppDashboard/templates/service_accounts/project_selector.html
@@ -1,0 +1,11 @@
+<div class="page-header"><h1>Service Accounts</h1></div>
+{% if owned_projects %}
+  <ul>
+  {% for project_id in owned_projects %}
+    <li><a href="/service_accounts/{{ project_id }}">{{ project_id }}</a></li>
+  {% endfor %}
+  </ul>
+{% else %}
+  <p>There are either no deployed projects, or you do not have ownership of any
+      of them.</p>
+{% endif %}


### PR DESCRIPTION
This adds a page to the dashboard that allows users to list a project's service accounts and upload custom ones.