### PR TITLE
Flatten path before extracting the entity group

### DIFF
--- a/AppDB/appscale/datastore/fdb/gc.py
+++ b/AppDB/appscale/datastore/fdb/gc.py
@@ -14,7 +14,7 @@ import six.moves as sm
 from tornado import gen
 from tornado.ioloop import IOLoop
 
-from appscale.datastore.dbconstants import MAX_TX_DURATION
+from appscale.datastore.dbconstants import InternalError, MAX_TX_DURATION
 from appscale.datastore.fdb.codecs import (
   decode_str, encode_read_version, encode_versionstamp_index, Path)
 from appscale.datastore.fdb.polling_lock import PollingLock
@@ -273,6 +273,9 @@ class GarbageCollector(object):
     for entry in entries:
       # TODO: Strip raw properties and enforce a max queue size to keep memory
       # usage reasonable.
+      if entry.commit_versionstamp is None:
+        raise InternalError(u'Deleted entry must have a commit versionstamp')
+
       self._queue.append((safe_time, entry, new_versionstamp))
 
   @gen.coroutine

--- a/AppDB/appscale/datastore/fdb/transactions.py
+++ b/AppDB/appscale/datastore/fdb/transactions.py
@@ -95,6 +95,9 @@ class TransactionMetadata(object):
     return self._encode_chunks(section_prefix, self._encode_keys(keys))
 
   def encode_query_key(self, txid, namespace, ancestor_path):
+    if not isinstance(ancestor_path, tuple):
+      ancestor_path = Path.flatten(ancestor_path)
+
     section_prefix = self._txid_prefix(txid) + self.QUERIES
     encoded_ancestor = Text.encode(namespace) + Path.pack(ancestor_path[:2])
     return section_prefix + encoded_ancestor


### PR DESCRIPTION
This fixes an issue with the FDB backend when making a query inside a transaction.

This also:
- Fixes a bug where incomplete entities were not auto-assigned IDs when created in a transaction
- Applies mutations concurrently on transaction commit
- Fixes an issue where index entries could be left behind if an entity is mutated multiple times in a transaction
- Adds an additional check when passing old entries to the garbage collector to be deleted later