### PR TITLE
Escape property values when outputting table

### DIFF
--- a/AppDashboard/templates/datastore/viewer.html
+++ b/AppDashboard/templates/datastore/viewer.html
@@ -138,7 +138,7 @@
               {% endif %}
             </td>
             {% for attribute in entity.attributes %}
-              <td>{{ attribute.short_value }}</td>
+              <td>{{ attribute.short_value|escape }}</td>
             {% endfor %}
             {% if property_overflow %}
               <td></td>


### PR DESCRIPTION
This prevents entity data from being interpreted as HTML markup.