### PR TITLE
Retry applying transaction mutations

### DIFF
--- a/AppDB/appscale/datastore/fdb/fdb_datastore.py
+++ b/AppDB/appscale/datastore/fdb/fdb_datastore.py
@@ -327,7 +327,7 @@ class FDBDatastore(object):
       versionstamp_future = tr.get_versionstamp()
 
     try:
-      yield self._tornado_fdb.commit(tr)
+      yield self._tornado_fdb.commit(tr, convert_exceptions=False)
     except fdb.FDBError as fdb_error:
       if fdb_error.code != FDBErrorCodes.NOT_COMMITTED:
         raise InternalError(fdb_error.description)


### PR DESCRIPTION
FDB transactions that fail due to conflicts with other FDB transactions can be retried in this case.