### PR TITLE
AppController firewall configuration disabled via APPSCALE_FIREWALL env

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -290,7 +290,7 @@ class Djinn
   # A boolean that indicates whether or not we should turn the firewall on,
   # and continuously keep it on. Should definitely be on for releases, and
   # on whenever possible.
-  FIREWALL_IS_ON = true
+  FIREWALL_IS_ON = 'true' == (ENV['APPSCALE_FIREWALL'] || 'true')
 
   # The location on the local filesystem where AppScale-related configuration
   # files are written to.


### PR DESCRIPTION
Allow the controllers firewall update functionality to be disabled via `APPSCALE_FIREWALL` environment variable. 

This environment variable could be set manually on hosts, be included in images, etc, to disable firewall modification if this is otherwise provided for the deployment (e.g. security groups and network acls in ec2)

The built-in firewall rules can be overly restrictive if we want to allow access to zookeeper state (e.g. external datastore with fdb backend) or datastores (e.g. cloud datastore proxy) and are more difficult to automate.