### PR TITLE
AppController haproxy reload via monit

### DIFF
--- a/AppController/lib/haproxy.rb
+++ b/AppController/lib/haproxy.rb
@@ -88,8 +88,9 @@ module HAProxy
     start_cmd = "#{HAPROXY_BIN} -f #{SERVICE_MAIN_FILE} -D " \
       "-p #{SERVICE_PIDFILE}"
     stop_cmd = "#{BASH_BIN} -c 'kill $(cat #{SERVICE_PIDFILE})'"
+    restart_cmd = "#{BASH_BIN} -c '#{start_cmd} -sf $(cat #{SERVICE_PIDFILE})'"
     MonitInterface.start_daemon(
-      :service_haproxy, start_cmd, stop_cmd, SERVICE_PIDFILE)
+      :service_haproxy, start_cmd, stop_cmd, SERVICE_PIDFILE, nil, restart_cmd)
   end
 
   # Create the config file for UserAppServer.
@@ -227,8 +228,7 @@ module HAProxy
       }
 
       # Reload with the new configuration file.
-      Djinn.log_run("#{HAPROXY_BIN} -f #{SERVICE_MAIN_FILE} -p #{SERVICE_PIDFILE}" \
-                    " -D -sf `cat #{SERVICE_PIDFILE}`")
+      MonitInterface.restart(:service_haproxy)
     end
   end
 


### PR DESCRIPTION
Modify the controllers service haproxy configuration reload so it is always via monit. This means performing a direct monit restart works as expected:

```
# ps ax | grep service-haproxy
19786 ?        Ss     0:00 /usr/sbin/haproxy -f /etc/haproxy/service-haproxy.cfg -D -p /var/run/appscale/service-haproxy.pid -sf 7555
# monit restart service_haproxy
# ps ax | grep service-haproxy
24623 ?        Ss     0:00 /usr/sbin/haproxy -f /etc/haproxy/service-haproxy.cfg -D -p /var/run/appscale/service-haproxy.pid -sf 19786
```

With the fix:

```
# systemctl status
● euca-10-10-9-106
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Thu 2019-08-01 16:21:44 UTC; 7h ago
   CGroup: /
           ├─init.scope
           │ └─1 /sbin/init
           ├─system.slice
           │ ├─monit.service
           │ │ ├─27478 /usr/bin/monit -c /etc/monit/monitrc
           │ │ ├─30880 /usr/sbin/haproxy -f /etc/haproxy/service-haproxy.cfg -D -p /var/run/appscale/service-haproxy.pid -sf 30476
           │ │ └─32335 haproxy -f /etc/haproxy/app-haproxy.cfg -D -p /var/run/appscale/app-haproxy.pid -sf 32317
           │ ├─appscale-controller.service
           │ │ └─27568 /usr/bin/ruby -w /root/appscale/AppController/djinnServer.rb
```

Before the fix:

```
# systemctl status
● euca-10-10-7-27
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Fri 2019-07-19 14:15:23 UTC; 1 weeks 6 days ago
   CGroup: /
           ├─init.scope
           │ └─1 /sbin/init
           ├─system.slice
           │ ├─monit.service
           │ │ ├─23234 haproxy -f /etc/haproxy/app-haproxy.cfg -D -p /var/run/appscale/app-haproxy.pid -sf 21932
           │ │ ├─25833 /usr/bin/monit -c /etc/monit/monitrc
           │ ├─appscale-controller.service
           │ │ ├─10586 /usr/sbin/haproxy -f /etc/haproxy/service-haproxy.cfg -p /var/run/appscale/service-haproxy.pid -D -sf 32533
           │ │ └─25927 /usr/bin/ruby -w /root/appscale/AppController/djinnServer.rb
```

Note that the service haproxy is under `appscale-controller.service` instead of `monit.service`.