### PR TITLE
Install FoundationDB client libraries

### DIFF
--- a/AppDB/setup.py
+++ b/AppDB/setup.py
@@ -17,7 +17,8 @@ setup(
     'monotonic',
     'mmh3',
     'SOAPpy',
-    'tornado'
+    'tornado',
+    'foundationdb==6.1.11'
   ],
   classifiers=[
     'Development Status :: 5 - Production/Stable',

--- a/AppDB/setup.py
+++ b/AppDB/setup.py
@@ -18,7 +18,7 @@ setup(
     'mmh3',
     'SOAPpy',
     'tornado',
-    'foundationdb==6.1.11'
+    'foundationdb~=6.1.8'
   ],
   classifiers=[
     'Development Status :: 5 - Production/Stable',

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -671,6 +671,10 @@ installtaskqueue()
 
 installdatastore()
 {
+    FDB_CLIENTS_DEB="foundationdb-clients_6.1.8-1_amd64.deb"
+    FDB_CLIENTS_MD5="3792e695a1de5444dbeebcdda7bdf932"
+    cachepackage ${FDB_CLIENTS_DEB} ${FDB_CLIENTS_MD5}
+    dpkg --install ${PACKAGE_CACHE}/foundationdb-clients_6.1.8-1_amd64.deb
     pip install --upgrade --no-deps ${APPSCALE_HOME}/AppDB
     pip install ${APPSCALE_HOME}/AppDB
 }

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -672,7 +672,7 @@ installtaskqueue()
 installdatastore()
 {
     FDB_CLIENTS_DEB="foundationdb-clients_6.1.8-1_amd64.deb"
-    FDB_CLIENTS_MD5="3792e695a1de5444dbeebcdda7bdf932"
+    FDB_CLIENTS_MD5="f701c23c144cdee2a2bf68647f0e108e"
     cachepackage ${FDB_CLIENTS_DEB} ${FDB_CLIENTS_MD5}
     dpkg --install ${PACKAGE_CACHE}/foundationdb-clients_6.1.8-1_amd64.deb
     pip install --upgrade --no-deps ${APPSCALE_HOME}/AppDB


### PR DESCRIPTION
 - Download foundationdb-clients_6.1.8-1_amd64.deb from S3 and install it.
 - Add foundationdb package as a requirement for datastore.