### PR TITLE
Fix composite index backfilling on FDB

### DIFF
--- a/AppDB/appscale/datastore/fdb/data.py
+++ b/AppDB/appscale/datastore/fdb/data.py
@@ -43,6 +43,17 @@ class VersionEntry(object):
     self._encoded_entity = encoded_entity
     self._decoded_entity = None
 
+  def __repr__(self):
+    # Since the encoded entity can be large, it probably does not make sense to
+    # include it in the string representation.
+    blob_repr = self._encoded_entity
+    if blob_repr is not None:
+      blob_repr = u'<bytes object with length={}>'.format(len(blob_repr))
+
+    return u'VersionEntry({!r}, {!r}, {!r}, {!r}, {!r}, {})'.format(
+      self.project_id, self.namespace, self.path, self.commit_versionstamp,
+      self.version, blob_repr)
+
   @property
   def present(self):
     return self.commit_versionstamp is not None

--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -1358,7 +1358,7 @@ class IndexManager(object):
       while True:
         results, more_results = yield result_iterator.next_page()
         index_entries = [kind_index.decode(result) for result in results]
-        version_entries = yield [self._data_manager.get_entry(self, tr, entry)
+        version_entries = yield [self._data_manager.get_entry(tr, entry)
                                  for entry in index_entries]
         for index_entry, version_entry in zip(index_entries, version_entries):
           new_keys = composite_index.encode_keys(


### PR DESCRIPTION
This fixes a bug that prevented the datastore from backfilling composite indexes.