### PR TITLE
Limit version of cassandra-driver

### DIFF
--- a/AppDB/setup.py
+++ b/AppDB/setup.py
@@ -11,7 +11,7 @@ setup(
   platforms='Posix',
   install_requires=[
     'appscale-common',
-    'cassandra-driver',
+    'cassandra-driver<3.18.0',
     'kazoo',
     'M2Crypto',
     'mmh3',

--- a/AppTaskQueue/setup.py
+++ b/AppTaskQueue/setup.py
@@ -12,7 +12,7 @@ setup(
   platforms='Posix',
   install_requires=[
     'appscale-common',
-    'cassandra-driver',
+    'cassandra-driver<3.18.0',
     'celery>=3.1,<4.0.0',
     'eventlet==0.22',
     'kazoo',


### PR DESCRIPTION
This avoids using version 3.18.0, which does not seem to be able to connect to the cluster properly.