### PR TITLE
Update bootstrap.sh usage text for agents

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,13 +17,15 @@ UNIT_TEST="n"
 GIT_TAG=""
 
 usage() {
-    echo "Usage: ${0} [--repo <repo>][--tools-repo <repo>][-t]"
+    echo "Usage: ${0} [--repo <repo>][--tools-repo <repo>][--agents-repo <repo>][-t]"
     echo
     echo "Options:"
     echo "   --repo <repo>            Specify appscale repo (default $APPSCALE_REPO)"
     echo "   --branch <branch>        Specify appscale branch (default $APPSCALE_BRANCH)"
     echo "   --tools-repo <repo>      Specify appscale-tools repo (default $APPSCALE_TOOLS_REPO"
     echo "   --tools-branch <branch>  Specify appscale-tools branch (default $APPSCALE_TOOLS_BRANCH)"
+    echo "   --agents-repo <repo>     Specify appscale-agents repo (default $AGENTS_REPO)"
+    echo "   --agents-branch <branch> Specify appscale-agents branch (default $AGENTS_BRANCH)"
     echo "   --force-upgrade          Force upgrade even if some check fails."
     echo "   --tag <git-tag>          Use git tag (ie 2.2.0) or 'last' to use the latest release or 'dev' for HEAD"
     echo "   -t                       Run unit tests"


### PR DESCRIPTION
Add new agent options to the usage text for `bootstrap.sh`

This change conflicts with appscale#3140 but I think that is not for 3.8 so this may be good to have until that draft is completed (assuming that is for a later release)

Example output:

```
# ./bootstrap.sh --invalid-arg
Checking to make sure you are root...Success
Checking to make sure $HOME is /root...Success
Usage: ./bootstrap.sh [--repo <repo>][--tools-repo <repo>][--agents-repo <repo>][-t]

Options:
   --repo <repo>            Specify appscale repo (default git://github.com/AppScale/appscale.git)
   --branch <branch>        Specify appscale branch (default master)
   --tools-repo <repo>      Specify appscale-tools repo (default git://github.com/AppScale/appscale-tools.git
   --tools-branch <branch>  Specify appscale-tools branch (default master)
   --agents-repo <repo>     Specify appscale-agents repo (default git://github.com/AppScale/appscale-agents.git)
   --agents-branch <branch> Specify appscale-agents branch (default master)
   --force-upgrade          Force upgrade even if some check fails.
   --tag <git-tag>          Use git tag (ie 2.2.0) or 'last' to use the latest release or 'dev' for HEAD
   -t                       Run unit tests
```

We should close this pull request if not wanted for 3.8.