### PR TITLE
Allow custom service accounts for restore operations

### DIFF
--- a/AppServer/google/appengine/ext/datastore_admin/main.py
+++ b/AppServer/google/appengine/ext/datastore_admin/main.py
@@ -182,7 +182,8 @@ class RouteByActionHandler(webapp.RequestHandler):
         'active_operations': self.GetOperations(active=True),
         'pending_backups': self.GetPendingBackups(),
         'backups': self.GetBackups(),
-        'map_reduce_path': config.MAPREDUCE_PATH + '/detail'
+        'map_reduce_path': config.MAPREDUCE_PATH + '/detail',
+        'service_accounts': utils.get_service_account_names()
     }
     utils.RenderToResponse(self, 'list_actions.html', template_params)
 

--- a/AppServer/google/appengine/ext/datastore_admin/templates/confirm_backup_import.html
+++ b/AppServer/google/appengine/ext/datastore_admin/templates/confirm_backup_import.html
@@ -33,6 +33,7 @@
         {% if run_as_a_service %}
           <input type="hidden" name="run_as_a_service" value="{{ run_as_a_service|escape }}">
         {% endif %}
+        <input type="hidden" name="service_account_name" value="{{ service_account_name }}">
         <input type="Submit" name="Import" value="Add to backup list">
         <input type="Submit" name="Restore" value="Restore from backup">
         <a href="{{ datastore_admin_home }}">Cancel</a>

--- a/AppServer/google/appengine/ext/datastore_admin/templates/confirm_restore_from_backup.html
+++ b/AppServer/google/appengine/ext/datastore_admin/templates/confirm_restore_from_backup.html
@@ -64,6 +64,19 @@
         <input type="text" name="queue" value="default"/>
         {% endif %}
       </p>
+      <p>
+        <label for="service_account_name">
+          Service account name
+          <img class="ae-help-icon" src="{{ base_path }}/static/img/help.gif" height="14" width="14" alt="help"
+               title="You can define additional service accounts using the dashboard.">
+        </label>
+        <select id="service_account_name" name="service_account_name">
+          <option value="">--Choose an option--</option>
+          {% for account_name in service_accounts %}
+          <option value="{{ account_name }}">{{ account_name }}</option>
+          {% endfor %}
+        </select>
+      </p>
       <input type="submit" value="Restore">
       <a href="{{ datastore_admin_home }}">Cancel</a>
     </form>

--- a/AppServer/google/appengine/ext/datastore_admin/templates/list_actions.html
+++ b/AppServer/google/appengine/ext/datastore_admin/templates/list_actions.html
@@ -240,8 +240,22 @@
       {% if run_as_a_service %}
         <input type="hidden" name="run_as_a_service" value="{{ run_as_a_service|escape }}">
       {% endif %}
+      <div style="display: block">
+        <label for="service_account_name">
+          Service account name
+          <img class="ae-help-icon" src="{{ base_path }}/static/img/help.gif" height="14" width="14" alt="help"
+               title="You can define additional service accounts using the dashboard.">
+        </label>
+        <select id="service_account_name" name="service_account_name">
+          <option value="">--Choose an option--</option>
+          {% for account_name in service_accounts %}
+          <option value="{{ account_name }}">{{ account_name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <input type="text" name="gs_handle" value="" size="50" placeholder="Bucket or info file"
+             title="Google Cloud Storage path of a backup info file or a bucket name"/>
       <input type="submit" name="action" value="Import Backup Information" title="Import Backup Information or restore from Google Cloud Storage"/>
-      <input type="text" name="gs_handle" value="" size="50" title="Google Cloud Storage path of a backup info file or a bucket name"/>
     </form>
   </div>
   {% if active_operations %}


### PR DESCRIPTION
This extends the datastore admin interface to allow custom service accounts for restore operations.