### PR TITLE
Slow stop services

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4492,6 +4492,7 @@ class Djinn
   def start_admin_server
     Djinn.log_info('Starting AdminServer')
     script = `which appscale-admin`.chomp
+    HelperFunctions.log_and_crash("Cannod find appscale-admin!") if script.empty?
     nginx_port = 17441
     service_port = 17442
     start_cmd = "#{script} serve -p #{service_port}"

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -3304,7 +3304,7 @@ class Djinn
     # we got this far, it must be primed.
     am_i_autoscaled = false
     get_autoscaled_nodes.each { |node|
-      if slave.private_ip == my_node.private_ip
+      if node.private_ip == my_node.private_ip
         am_i_autoscaled = true
         Djinn.log_info("Skipping database layout check on scaled node.")
         break

--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -4504,7 +4504,7 @@ class Djinn
   def start_admin_server
     Djinn.log_info('Starting AdminServer')
     script = `which appscale-admin`.chomp
-    HelperFunctions.log_and_crash("Cannod find appscale-admin!") if script.empty?
+    HelperFunctions.log_and_crash("Cannot find appscale-admin!") if script.empty?
     nginx_port = 17441
     service_port = 17442
     start_cmd = "#{script} serve -p #{service_port}"

--- a/AppController/lib/helperfunctions.rb
+++ b/AppController/lib/helperfunctions.rb
@@ -914,7 +914,7 @@ module HelperFunctions
     write_file(APPCONTROLLER_CRASHLOG_LOCATION, Time.new.to_s + ': ' +
       message)
     # Try to also log to the normal log file.
-    Djinn.log_error("FATAL: #{message}")
+    Djinn.log_fatal("#{message}")
 
     # If asked for, wait for a while before crashing. This will help the
     # tools to collect the status report or crashlog.

--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -120,6 +120,12 @@ CONFIG
   # This function unmonitors and optionally stops the service, and removes
   # the monit configuration file.
   def self.stop(watch, stop = true)
+    # No need to do anything if the service is not running.
+    unless is_running?(watch)
+      Djinn.log_debug("Asked to stop #{watch} but it is not running.")
+      return
+    end
+
     # To make sure the service is stopped, we query monit till the service
     # is not any longer running.
     running = true
@@ -203,8 +209,9 @@ BOO
   end
 
   def self.is_running?(watch)
-    output = run_cmd("#{MONIT} summary | grep \"'#{watch}'\" | grep -E "\
-                     '"(Running|Initializing|OK)"')
+    script = `which appscale-admin`.chomp
+    HelperFunctions.log_and_crash("Cannod find appscale-admin!") if script.empty?
+    output = run_cmd("#{script} summary | grep \"'#{watch}'\"")
     (output != '')
   end
 

--- a/AppController/lib/monit_interface.rb
+++ b/AppController/lib/monit_interface.rb
@@ -210,7 +210,7 @@ BOO
 
   def self.is_running?(watch)
     script = `which appscale-admin`.chomp
-    HelperFunctions.log_and_crash("Cannod find appscale-admin!") if script.empty?
+    HelperFunctions.log_and_crash("Cannot find appscale-admin!") if script.empty?
     output = run_cmd("#{script} summary | grep \"'#{watch}'\"")
     (output != '')
   end

--- a/AppController/lib/taskqueue.rb
+++ b/AppController/lib/taskqueue.rb
@@ -216,10 +216,7 @@ module TaskQueue
         Djinn.log_run("ps ax | grep rabbit | grep -v grep | awk '{print $1}' | xargs kill -9")
         erase_local_files if clear_data
       end
-      if tries_left.zero?
-        Djinn.log_fatal('CRITICAL ERROR: RabbitMQ slave failed to come up')
-        abort
-      end
+      HelperFunctions.log_and_crash('RabbitMQ slave failed to come up') if tries_left.zero?
     }
   end
 


### PR DESCRIPTION
This PR is to address the issues we have seen in slow start of autoscaled nodes.There are 2 parts in this PR (and I can split it if preferred):

- don't try to stop a non-running service: since we go to monit, at time the process can take much longer to actually do nothing;

- autoscaled node don't check for DB tables: this shave off about 1minute to the ready time for autoscaled nodes.