### PR TITLE
Install newer psutils to handle kernel 5.X output of /proc/diskstats

### DIFF
--- a/Hermes/setup.py
+++ b/Hermes/setup.py
@@ -14,7 +14,7 @@ setup(
     'appscale-common',
     'kazoo',
     'tornado',
-    'psutil==5.1.3',
+    'psutil==5.6.3',
     'attrs>=18.1.0',
     'mock',
   ],

--- a/InfrastructureManager/setup.py
+++ b/InfrastructureManager/setup.py
@@ -4,7 +4,7 @@ install_requires = [
   'appscale-common',
   # TODO: add 'appscale-agents' to required packages.
   'mock',
-  'psutil==5.1.3',
+  'psutil==5.6.3',
   'tornado'
 ]
 


### PR DESCRIPTION
on Azure the base ubuntu image seems to be using the 5.0 kernel, whereas GCP and EC2 are running 4.x. The issue here is that the number of fields in diskstats is different on the newer kernel which causes an issue with psutils 5.1.3.