### PR TITLE
Add preliminary support for metadata queries

### DIFF
--- a/AppDB/appscale/datastore/fdb/data.py
+++ b/AppDB/appscale/datastore/fdb/data.py
@@ -419,6 +419,15 @@ class DataManager(object):
     Returns:
       A VersionEntry or None.
     """
+    if index_entry.kind == u'__kind__':
+      entity = entity_pb.EntityProto()
+      entity.mutable_key().MergeFrom(index_entry.key)
+      entity.mutable_entity_group().MergeFrom(index_entry.group)
+      version_entry = VersionEntry(
+        index_entry.project_id, index_entry.namespace, index_entry.path,
+        encoded_entity=entity.Encode())
+      raise gen.Return(version_entry)
+
     version_entry = yield self.get_version_from_path(
       tr, index_entry.project_id, index_entry.namespace, index_entry.path,
       index_entry.commit_versionstamp, snapshot)

--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -155,6 +155,10 @@ class IndexEntry(object):
     self.deleted_versionstamp = deleted_versionstamp
 
   @property
+  def kind(self):
+    return self.path[-2]
+
+  @property
   def key(self):
     key = entity_pb.Reference()
     key.set_app(self.project_id)
@@ -329,6 +333,30 @@ class IndexIterator(object):
       return entry.commit_versionstamp < self._read_versionstamp
     else:
       return entry.deleted_versionstamp is None
+
+
+class KindIterator(object):
+  def __init__(self, tr, project_dir, namespace):
+    self._tr = tr
+    self._project_dir = project_dir
+    self._namespace = namespace
+    self._done = False
+
+  @gen.coroutine
+  def next_page(self):
+    if self._done:
+      raise gen.Return(([], False))
+
+    # TODO: This can be made async.
+    ns_dir = self._project_dir.open(
+      self._tr, (KindIndex.DIR_NAME, self._namespace))
+    kinds = ns_dir.list(self._tr)
+    results = [IndexEntry(self._project_dir.get_path()[-1], self._namespace,
+                          (u'__kind__', kind), None, None)
+               for kind in kinds]
+
+    self._done = True
+    raise gen.Return((results, False))
 
 
 class MergeJoinIterator(object):
@@ -1084,6 +1112,10 @@ class IndexManager(object):
     fetch_limit = rpc_limit
     if check_more_results:
       fetch_limit += 1
+
+    if query.has_kind() and query.kind() == u'__kind__':
+      project_dir = yield self._directory_cache.get(tr, (project_id,))
+      raise gen.Return(KindIterator(tr, project_dir, namespace))
 
     index = yield self._get_perfect_index(tr, query)
     reverse = get_scan_direction(query, index) == Query_Order.DESCENDING


### PR DESCRIPTION
This allows clients to get a consistent list of kinds in a namespace. Many tools, including the datastore viewer, use this type of query.