### PR TITLE
Firewall configuration wrapper script using iptables-restore to apply rules

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -2777,7 +2777,7 @@ class Djinn
     # list of nodes in the firewall.
     write_locations
     if FIREWALL_IS_ON
-      Djinn.log_run("bash #{APPSCALE_HOME}/firewall.conf")
+      Djinn.log_run("bash #{APPSCALE_HOME}/scripts/firewall-update.sh #{APPSCALE_HOME}/firewall.conf")
     end
   end
 

--- a/firewall.conf
+++ b/firewall.conf
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Run using scripts/firewall-update.sh firewall.conf for atomic updates.
+# update script redefines "iptables" to collect rules and apply on exit.
 
 # Flush any current firewall settings
 iptables -F

--- a/scripts/firewall-update.sh
+++ b/scripts/firewall-update.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Remove temporary files on exit
+cleanup() {
+  [ ! -f "${IPTABLES_FILE:-}" ] || rm -f "${IPTABLES_FILE}"
+}
+
+trap cleanup EXIT
+
+# Output rules to file
+iptables() {
+  if [ "-F" == "${1}" ] ; then
+    return # drop flush, we will replace all rules
+  fi
+  if [ -z "${IPTABLES_FILE:-}" ] ; then
+    IPTABLES_FILE="$(mktemp --tmpdir=/run/appscale/ iptables.XXXXXXXXXX)"
+    echo "*filter"               >  "${IPTABLES_FILE}"
+    echo ":INPUT ACCEPT [0:0]"   >> "${IPTABLES_FILE}"
+    echo ":FORWARD ACCEPT [0:0]" >> "${IPTABLES_FILE}"
+    echo ":OUTPUT ACCEPT [0:0]"  >> "${IPTABLES_FILE}"
+  fi
+  echo "$*" >> "${IPTABLES_FILE}"
+}
+
+# Update firewall atomically
+update_firewall() {
+  echo "COMMIT" >> "${IPTABLES_FILE}"
+
+  if [ -f "/run/appscale/iptables.applied" ] ; then
+    if diff --brief "/run/appscale/iptables.applied" "${IPTABLES_FILE}" &>/dev/null; then
+      rm "${IPTABLES_FILE}"
+    fi
+  fi
+
+  if [ -f "${IPTABLES_FILE}" ] ; then
+    if iptables-restore --table filter "${IPTABLES_FILE}"; then
+      mv -f "${IPTABLES_FILE}" "/run/appscale/iptables.applied"
+    else
+      mv -f "${IPTABLES_FILE}" "/run/appscale/iptables.failed"
+    fi
+  fi
+}
+
+# Source and process firewall configuration
+if [ -f "${1:-}" ] ; then
+  source ${1}
+  update_firewall
+fi
+


### PR DESCRIPTION
This pull request adds a `firewall-update.sh` script for wrapping the existing `firewall.conf`. 

The wrapper script collects the rules for application on completion of the wrapper. The wrapper checks for changes before using `iptables-restore` to apply, so will result in the `FILTER` table being flushed less frequently. Due to the reduced flush any packed/byte counters would not be frequently reset, which is a change in behaviour (but seems preferable)

When the wrapper is used we no longer flush tables other than the `FILTER` table so it would be up to the user to ensure these were correct for use with an AppScale deployment.