### PR TITLE
Do not request KVs when query limit is zero

### DIFF
--- a/AppDB/appscale/datastore/fdb/utils.py
+++ b/AppDB/appscale/datastore/fdb/utils.py
@@ -162,7 +162,7 @@ class TornadoFDB(object):
 
 class ResultIterator(object):
   """ Allows clients to page through a range of Key-Values. """
-  def __init__(self, tr, tornado_fdb, key_slice, limit=0, reverse=False,
+  def __init__(self, tr, tornado_fdb, key_slice, limit=None, reverse=False,
                streaming_mode=fdb.StreamingMode.iterator, snapshot=False):
     self.slice = key_slice
     self.done_with_range = False
@@ -193,7 +193,7 @@ class ResultIterator(object):
       self.slice, self._limit, self._reverse, self._mode, self._snapshot)
 
   def increase_limit(self, difference=1):
-    if not self.done_with_range:
+    if self._limit is not None and not self.done_with_range:
       self._limit += difference
       self._done = False
 
@@ -203,12 +203,15 @@ class ResultIterator(object):
     if self._done:
       raise gen.Return(([], False))
 
-    tmp_limit = 0
-    if self._limit > 0:
-      tmp_limit = self._limit - self._fetched
+    if self._limit is None:
+      fdb_limit = 0
+    else:
+      fdb_limit = self._limit - self._fetched
+      if fdb_limit < 1:
+        raise gen.Return(([], False))
 
     results, count, more = yield self._tornado_fdb.get_range(
-      self._tr, slice(self._bsel, self._esel), tmp_limit, mode,
+      self._tr, slice(self._bsel, self._esel), fdb_limit, mode,
       self._iteration, self._reverse, self._snapshot)
     self._fetched += count
     self._iteration += 1
@@ -219,7 +222,7 @@ class ResultIterator(object):
       else:
         self._bsel = fdb.KeySelector.first_greater_than(results[-1].key)
 
-    reached_limit = self._limit > 0 and self._fetched == self._limit
+    reached_limit = self._limit is not None and self._fetched >= self._limit
     self._done = not more or reached_limit
     self.done_with_range = not more and not reached_limit
 


### PR DESCRIPTION
The datastore API treats a limit of "0" as a request for 0 results rather than a request for all the entities that match the query.