### PR TITLE
AppController terminate update for newer ifconfig/monit output

### DIFF
--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -134,7 +134,7 @@ module TerminateHelper
   def self.disable_database_writes
     # First, tell Cassandra that no more writes should be accepted on this node.
     ifconfig = `ifconfig`
-    bound_addrs = ifconfig.scan(/inet addr:(\d+.\d+.\d+.\d+)/).flatten
+    bound_addrs = ifconfig.scan(/inet .*?(\d+.\d+.\d+.\d+) /).flatten
     bound_addrs.delete("127.0.0.1")
     ip = bound_addrs[0]
 

--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -140,7 +140,7 @@ module TerminateHelper
 
     # Make sure we have cassandra running, otherwise nodetool may get
     # stuck.
-    if system("monit summary | grep cassandra | grep Running > /dev/null")
+    if system("monit summary | grep cassandra | grep 'Running\\|OK' > /dev/null")
       `/opt/cassandra/cassandra/bin/nodetool -h #{ip} -p 7199 drain`
     end
 


### PR DESCRIPTION
Update ` AppController/terminate.rb` to allow the newer `ifconfig` and `monit summary` output as per bionic.

Daily build no. 6742