### PR TITLE
Retry unknown commit result for simple mutations

### DIFF
--- a/AppDB/appscale/datastore/fdb/fdb_datastore.py
+++ b/AppDB/appscale/datastore/fdb/fdb_datastore.py
@@ -101,7 +101,11 @@ class FDBDatastore(object):
     try:
       yield self._tornado_fdb.commit(tr, convert_exceptions=False)
     except fdb.FDBError as fdb_error:
-      if fdb_error.code != FDBErrorCodes.NOT_COMMITTED:
+      if fdb_error.code == FDBErrorCodes.NOT_COMMITTED:
+        pass
+      elif fdb_error.code == FDBErrorCodes.COMMIT_RESULT_UNKNOWN:
+        logger.error('Unable to determine commit result. Retrying.')
+      else:
         raise InternalError(fdb_error.description)
 
       retries -= 1
@@ -187,7 +191,11 @@ class FDBDatastore(object):
     try:
       yield self._tornado_fdb.commit(tr, convert_exceptions=False)
     except fdb.FDBError as fdb_error:
-      if fdb_error.code != FDBErrorCodes.NOT_COMMITTED:
+      if fdb_error.code == FDBErrorCodes.NOT_COMMITTED:
+        pass
+      elif fdb_error.code == FDBErrorCodes.COMMIT_RESULT_UNKNOWN:
+        logger.error('Unable to determine commit result. Retrying.')
+      else:
         raise InternalError(fdb_error.description)
 
       retries -= 1

--- a/AppDB/appscale/datastore/fdb/utils.py
+++ b/AppDB/appscale/datastore/fdb/utils.py
@@ -51,6 +51,7 @@ DS_ROOT = (u'appscale', u'datastore')
 
 class FDBErrorCodes(object):
   NOT_COMMITTED = 1020
+  COMMIT_RESULT_UNKNOWN = 1021
 
 
 def ReverseBitsInt64(v):


### PR DESCRIPTION
This can reduce error messages for idempotent operations.