### PR TITLE
Tasks should use http to avoid scheme redirects since they use HAProxy

### DIFF
--- a/AppServer/google/appengine/tools/devappserver2/module.py
+++ b/AppServer/google/appengine/tools/devappserver2/module.py
@@ -581,7 +581,7 @@ class Module(object):
     try:
       environ['SERVER_PORT'] = environ['HTTP_HOST'].split(':')[1]
     except IndexError:
-      scheme = environ['HTTP_X_FORWARDED_PROTO']
+      scheme = environ.get('HTTP_X_FORWARDED_PROTO', 'http')
       if scheme == 'http':
         environ['SERVER_PORT'] = 80
       else:

--- a/AppTaskQueue/appscale/taskqueue/push_worker.py
+++ b/AppTaskQueue/appscale/taskqueue/push_worker.py
@@ -154,16 +154,8 @@ def execute_task(task, headers, args):
         update_task(task_name, TASK_STATES.FAILED)
         return
 
-      # Targets do not get X-Forwarded-Proto from nginx, they use haproxy port.
-      headers['X-Forwarded-Proto'] = url.scheme
-      if url.scheme == 'http':
-        connection = httplib.HTTPConnection(remote_host, url.port)
-      elif url.scheme == 'https':
-        connection = httplib.HTTPSConnection(remote_host, url.port)
-      else:
-        logger.error("Task %s tried to use url scheme %s, "
-                     "which is not supported." % (
-                     args['task_name'], url.scheme))
+      # Tasks should use HTTP to bypass scheme redirects since they use HAProxy.
+      connection = httplib.HTTPConnection(remote_host, url.port)
 
       skip_host = False
       if b'host' in headers or b'Host' in headers:


### PR DESCRIPTION
Addresses an issue where tasks attempt to go to https for tasks and headers are missing for a proper redirect. Since tasks send requests through HAProxy, there is no need for scheme to be involved and this will bypass the part of the AppServer that does the scheme redirection.