### PR TITLE
Docker image build updated to allow systemctl command failure

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -110,7 +110,7 @@ while [ $# -gt 0 ]; do
     if [ "${1}" = "--tag" ]; then
         shift; if [ -z "${1}" ]; then usage; fi
         GIT_TAG="${1}";
-        if [${GIT_TAG} != "dev" ]; then TAG_PARAM_SPECIFIED="Y"; fi
+        if [ "${GIT_TAG}" != "dev" ]; then TAG_PARAM_SPECIFIED="Y"; fi
         shift; continue
     fi
     if [ "${1}" = "-t" ]; then

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -396,11 +396,11 @@ installservice()
       echo "Linking appscale common systemd drop-in"
       for APPSCALE_SYSTEMD_SERVICE in ${DESTDIR}/lib/systemd/system/appscale-*.service; do
         [ -d "${APPSCALE_SYSTEMD_SERVICE}.d" ] || mkdir "${APPSCALE_SYSTEMD_SERVICE}.d"
-        ln -t "${APPSCALE_SYSTEMD_SERVICE}.d" ${DESTDIR}/lib/systemd/system/appscale-.d/10-appscale-common.conf
+        ln -ft "${APPSCALE_SYSTEMD_SERVICE}.d" ${DESTDIR}/lib/systemd/system/appscale-.d/10-appscale-common.conf
       done
     fi
 
-    systemctl daemon-reload
+    systemctl daemon-reload || true
 
     # Enable AppController on system reboots.
     systemctl enable appscale-controller || true


### PR DESCRIPTION
Fix the docker image build by allowing `systemctl daemon-reload` to fail.

With this fix the image build will complete but the resulting image is not functional.