### PR TITLE
Catch unexpected errors when checking process line

### DIFF
--- a/AppController/lib/ejabberd.rb
+++ b/AppController/lib/ejabberd.rb
@@ -63,7 +63,10 @@ module Ejabberd
           begin
             next unless process.name == 'epmd'
             process.terminate if process.cmdline.include?('-daemon')
-          rescue PosixPsutil::NoSuchProcess
+          # The PosixPsutil library does not always raise NoSuchProcess when
+          # the given process no longer has a name. StandardError is meant
+          # as a fallback when it doesn't behave properly.
+          rescue PosixPsutil::NoSuchProcess, StandardError
             next
           end
         }


### PR DESCRIPTION
The PosixPsutil raises a `NoMethodError` when the process name no longer exists. This is meant to catch that and similar exceptions that the library has not dealt with.