### PR TITLE
Remove docker special handling for cron/sshd

### DIFF
--- a/debian/appscale_build.sh
+++ b/debian/appscale_build.sh
@@ -59,9 +59,6 @@ if grep docker /proc/1/cgroup > /dev/null ; then
     # Make sure we have default locale.
     ${PKG_CMD} install --assume-yes locales
     locale-gen en_US en_US.UTF-8
-    # Docker images miss the following.
-    mkdir -p /var/run/sshd
-    chmod 755 /var/run/sshd
 fi
 
 export APPSCALE_HOME_RUNTIME=`pwd`

--- a/scripts/fast-start.sh
+++ b/scripts/fast-start.sh
@@ -111,10 +111,6 @@ PRIVATE_IP=""
 
 if [ -z "${PROVIDER}" ]; then
     if grep docker /proc/1/cgroup > /dev/null ; then
-        # We need to start sshd by hand.
-        /usr/sbin/sshd
-        # Force Start cron
-        /usr/sbin/cron
         PROVIDER="Docker"
     elif lspci | grep VirtualBox > /dev/null ; then
         PROVIDER="VirtualBox"
@@ -212,7 +208,7 @@ if [ ! -e AppScalefile ]; then
     [ -z "$PRIVATE_IP" ] && { echo "Cannot get private IP of instance!" ; exit 1 ; }
 
     # Tell the user what we detected.
-    echo "Detected enviroment: ${PROVIDER}"
+    echo "Detected environment: ${PROVIDER}"
     echo "Private IP found: ${PRIVATE_IP}"
     echo "Public IP found:  ${LOGIN}"
 


### PR DESCRIPTION
The appscale docker image now uses systemd so special handling for cron and sshd should be removed. 

When running faststart with current master the following error is logged:

```
# docker run --name appscale --detach --env container=docker --tmpfs /tmp:exec --tmpfs /run --tmpfs /run/lock --volume /sys/fs/cgroup:/sys/fs/cgroup:ro appscale/appscale:dev /sbin/init
b0a960b7e8b5671912c72bef88e8647c8d6e1d955cc85beeda0cafbabb85249a
# docker exec -it appscale /bin/bash
root@b0a960b7e8b5:/# cd root
root@b0a960b7e8b5:~# bash appscale/scripts/fast-start.sh --no-demo-app
cron: can't lock /var/run/crond.pid, otherpid may be 27: Resource temporarily unavailable
Detected enviroment: Docker
Private IP found: 172.17.0.2
Public IP found:  172.17.0.2
Creating AppScalefile...done.
...
...
...
AppScale successfully started!
View status information about your AppScale deployment at http://172.17.0.2:1080
```

Note `cron: can't lock /var/run/crond.pid, otherpid may be 27: Resource temporarily unavailable`