### PR TITLE
AppController reload systemd configuration on terminate

### DIFF
--- a/AppController/terminate.rb
+++ b/AppController/terminate.rb
@@ -71,6 +71,8 @@ module TerminateHelper
     # TODO: Use the constant in djinn.rb (ZK_LOCATIONS_JSON_FILE)
     `rm -f #{APPSCALE_CONFIG_DIR}/zookeeper_locations.json`
     `rm -f #{APPSCALE_CONFIG_DIR}/zookeeper_locations`
+
+    `systemctl daemon-reload`
     print "OK"
   end
 


### PR DESCRIPTION
On `appscale down --clean` we remove runtime systemd configuration but were not reloading to apply the changes.

Fixes appscale/appscale#3203