### PR TITLE
AppController remove unused environment/home configuration

### DIFF
--- a/AppController/djinn.rb
+++ b/AppController/djinn.rb
@@ -890,7 +890,6 @@ class Djinn
         end
 
         # Ensure we have the correct EC2 credentials available.
-        ENV['EC2_URL'] = @options['ec2_url']
         if @options['ec2_access_key'].nil?
           @options['ec2_access_key'] = @options['EC2_ACCESS_KEY']
           @options['ec2_secret_key'] = @options['EC2_SECRET_KEY']
@@ -3043,13 +3042,6 @@ class Djinn
     FileUtils.mkdir_p(my_key_dir)
     Djinn.log_run("chmod 600 #{APPSCALE_CONFIG_DIR}/ssh.key")
     Djinn.log_run("cp -p #{APPSCALE_CONFIG_DIR}/ssh.key #{my_key_loc}")
-
-    # AWS and Euca need some evironmental variables.
-    if ["ec2", "euca"].include?(@options['infrastructure'])
-      ENV['EC2_ACCESS_KEY'] = @options['ec2_access_key']
-      ENV['EC2_SECRET_KEY'] = @options['ec2_secret_key']
-      ENV['EC2_URL'] = @options['ec2_url']
-    end
   end
 
   def got_all_data

--- a/AppController/djinnServer.rb
+++ b/AppController/djinnServer.rb
@@ -20,10 +20,6 @@ class Net::HTTP
   end
 end
 
-
-environment = YAML.load_file('/etc/appscale/environment.yaml')
-environment.each { |k,v| ENV[k] = v }
-
 APPSCALE_HOME = ENV['APPSCALE_HOME']
 
 # Import for AppController

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -155,18 +155,6 @@ EOF
     # This create link to appscale settings.
     mkdir -pv ${DESTDIR}${CONFIG_DIR}
 
-    cat <<EOF | tee ${CONFIG_DIR}/home || exit
-${APPSCALE_HOME_RUNTIME}
-EOF
-    # Create the global AppScale environment file.
-    DESTFILE=${DESTDIR}${CONFIG_DIR}/environment.yaml
-    mkdir -pv $(dirname $DESTFILE)
-    echo "Generating $DESTFILE"
-    cat <<EOF | tee $DESTFILE
-APPSCALE_HOME: ${APPSCALE_HOME_RUNTIME}
-EC2_HOME: /usr/local/ec2-api-tools
-JAVA_HOME: ${JAVA_HOME_DIRECTORY}
-EOF
     mkdir -pv /var/log/appscale
     # Allow rsyslog to write to appscale log directory.
     chgrp adm /var/log/appscale


### PR DESCRIPTION
Remove use of `environment.yaml` and setting of ec2 environment variables. Remove `/etc/appscale/home` configuration file.