### PR TITLE
Install wheel for hermes and search2

### DIFF
--- a/SearchService2/build-scripts/ensure_searchservice2.sh
+++ b/SearchService2/build-scripts/ensure_searchservice2.sh
@@ -25,6 +25,7 @@ if ! "${PIP}" --version | grep 'python 3\.' ; then
 fi
 
 echo "Upgrading appscale-common.."
+"${PIP}" install wheel
 "${PIP}" install --upgrade --no-deps "${COMMON_DIR}"
 echo "Installing appscale-common dependencies if any missing.."
 "${PIP}" install "${COMMON_DIR}"

--- a/debian/appscale_install_functions.sh
+++ b/debian/appscale_install_functions.sh
@@ -611,6 +611,7 @@ installhermes()
     python3 -m venv /opt/appscale_venvs/hermes/
     # Install Hermes and its dependencies in it
     HERMES_PIP=/opt/appscale_venvs/hermes/bin/pip
+    ${HERMES_PIP} install wheel
     ${HERMES_PIP} install --upgrade --no-deps ${APPSCALE_HOME}/common
     ${HERMES_PIP} install ${APPSCALE_HOME}/common
     ${HERMES_PIP} install --upgrade --no-deps ${APPSCALE_HOME}/AdminServer


### PR DESCRIPTION
Install wheel via pip for hermes and search2 virtual environments to fix (non fatal) build errors:

```
Building wheels for collected packages: PyYAML
  Running setup.py bdist_wheel for PyYAML: started
  Running setup.py bdist_wheel for PyYAML: finished with status 'error'
  Complete output from command /opt/appscale_venvs/search2/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-1ss2a3ji/PyYAML/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmprthwswm_pip-wheel- --python-tag cp36:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Running setup.py clean for PyYAML
  Failed building wheel for PyYAML
Failed to build PyYAML
```

as present in image build output.

This results in the installed:

`/opt/appscale_venvs/hermes/lib/python3.6/site-packages/PyYAML-5.1.2.egg-info`

rather than the expected (as per task queue):

`/opt/appscale_venvs/appscale_taskqueue/lib/python3.6/site-packages/PyYAML-5.1.2.dist-info`