### PR TITLE
AppController fix warning on application relocate to privileged port

### DIFF
--- a/system/units/appscale-controller.service
+++ b/system/units/appscale-controller.service
@@ -11,7 +11,9 @@ Environment=HOME=/root
 ExecStart=/usr/bin/ruby -w /root/appscale/AppController/djinnServer.rb
 SyslogIdentifier=%p
 # Security
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SETGID CAP_SETUID CAP_CHOWN CAP_SYS_MODULE CAP_AUDIT_WRITE CAP_NET_ADMIN CAP_NET_RAW CAP_KILL
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_SETGID CAP_SETUID CAP_CHOWN \
+  CAP_SYS_MODULE CAP_AUDIT_WRITE CAP_NET_ADMIN CAP_NET_BIND_SERVICE    \
+  CAP_NET_RAW CAP_KILL
 
 [Install]
 WantedBy=appscale-control.target multi-user.target


### PR DESCRIPTION
Add `CAP_NET_BIND_SERVICE` capability for `appscale-controller.service` to address warning on relocate to privileged port:

```
Nov  4 22:03:58 3c3b3556cba0  W, [58.467811#13609]  WARN -- : Shell commmand /usr/sbin/nginx -t -c /etc/nginx/nginx.conf failed with error output nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
Nov  4 22:03:58 3c3b3556cba0  nginx: [emerg] bind() to 0.0.0.0:80 failed (13: Permission denied)
Nov  4 22:03:58 3c3b3556cba0  nginx: configuration file /etc/nginx/nginx.conf test failed
Nov  4 22:03:58 3c3b3556cba0  I, [58.468010#13609]  INFO -- : Reloading nginx service.
```