### PR TITLE
UAServer do not use user_schema with postgres backend

### DIFF
--- a/AppDB/appscale/datastore/scripts/ua_server.py
+++ b/AppDB/appscale/datastore/scripts/ua_server.py
@@ -331,10 +331,10 @@ def get_user_data(username, secret):
 
     if not result:
       raise gen.Return('Error: User {} does not exist'.format(username))
-    if len(user_schema) != len(result):
+    if len(USERS_SCHEMA) != len(result):
       raise gen.Return(
         "Error: Bad length of user schema vs user result "
-        "user schema: " + str(user_schema) + " result: " + str(result)
+        "user schema: " + str(USERS_SCHEMA) + " result: " + str(result)
       )
 
     user = Users("a", "b", "c")


### PR DESCRIPTION
Use `USERS_SCHEMA` constant rather than `user_schema` which is not initialized when using postgres.

This was causing `get_user_data` to fail as per the `/var/log/ejabberd/extauth.log` log:

```
2019-12-12 07:41:05,749 INFO ejabberd_auth.py:67 trying to authenticate user [hawkeyepython27@192.168.100.80] 
2019-12-12 07:41:05,756 INFO ejabberd_auth.py:79 userdata for [hawkeyepython27@192.168.100.80] is [Error: Bad length of user schema vs user result user schema: [] result: ['hawkeyepython27@
192.168.100.80', '7b77af2d8879af55d6ea594c947d2b0050cb576d', 1576135252.0, 1576135252.0, 1576135252.0, [], 'notSet', 0L, 0, 'notSet', '0.0.0.0', 0, 0, True, 'app', False, '']] 
2019-12-12 07:41:05,756 INFO ejabberd_auth.py:83 matchdata for [hawkeyepython27@192.168.100.80] was none 
2019-12-12 07:41:05,756 INFO ejabberd_auth.py:101 auth unsuccessful for hawkeyepython27 
```