### PR TITLE
Datastore missing codecs import

### DIFF
--- a/AppDB/appscale/datastore/fdb/index_directories.py
+++ b/AppDB/appscale/datastore/fdb/index_directories.py
@@ -5,6 +5,7 @@ import six
 
 from appscale.common.unpackaged import APPSCALE_PYTHON_APPSERVER
 from appscale.datastore.dbconstants import BadRequest, InternalError
+from appscale.datastore.fdb import codecs
 from appscale.datastore.fdb.codecs import (
   decode_value, encode_value, encode_versionstamp_index, Path)
 from appscale.datastore.fdb.utils import (


### PR DESCRIPTION
Add missing codecs import to address issue shown in hawkeye test log output:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 656, in callback
    result_list.append(f.result())
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 230, in wrapper
    yielded = next(result)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/fdb/indexes.py", line 342, in _populated
    index_slice = prop_index.type_range(type_name)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/fdb/index_directories.py", line 579, in type_range
    start = six.int2byte(codecs.MIN_INT64_CODE)
NameError: global name 'codecs' is not defined
```