### PR TITLE
Datastore missing entity_pb import

### DIFF
--- a/AppDB/appscale/datastore/fdb/indexes.py
+++ b/AppDB/appscale/datastore/fdb/indexes.py
@@ -25,6 +25,7 @@ from appscale.datastore.fdb.utils import (
 from appscale.datastore.dbconstants import BadRequest, InternalError
 
 sys.path.append(APPSCALE_PYTHON_APPSERVER)
+from google.appengine.datastore import entity_pb
 from google.appengine.datastore.datastore_pb import Query_Filter, Query_Order
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Add missing entity_pb import to address issue shown in hawkeye test log output:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 1415, in _execute
    result = yield result
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/scripts/datastore.py", line 196, in post
    version_id=request.headers.get('Version'))
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/scripts/datastore.py", line 248, in remote_request
    response, errcode, errdetail = yield self.run_query(http_request_data)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/scripts/datastore.py", line 430, in run_query
    yield datastore_access._dynamic_run_query(query, clone_qr_pb)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/fdb/fdb_datastore.py", line 277, in _dynamic_run_query
    entries, more_iterator_results = yield iterator.next_page()
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 879, in run
    yielded = self.gen.send(value)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/fdb/indexes.py", line 326, in next_page
    prop_value = entity_pb.PropertyValue()
NameError: global name 'entity_pb' is not defined
```