### PR TITLE
Datastore transaction metadata decoding fix

### DIFF
--- a/AppDB/appscale/datastore/fdb/transactions.py
+++ b/AppDB/appscale/datastore/fdb/transactions.py
@@ -141,10 +141,11 @@ class TransactionMetadata(object):
       else:
         raise InternalError(u'Unrecognized RPC type')
 
-    lookups = set()
+    lookups = dict()
     mutations = []
     for chunks in six.itervalues(lookup_rpcs):
-      lookups.update(self._unpack_keys(b''.join(chunks)))
+      lookups.update([(key.SerializeToString(), key)
+                      for key in self._unpack_keys(b''.join(chunks))])
 
     for rpc_info in mutation_rpcs:
       rpc_type = rpc_info[0]
@@ -154,7 +155,7 @@ class TransactionMetadata(object):
       else:
         mutations.extend(self._unpack_keys(blob))
 
-    return lookups, queried_groups, mutations
+    return list(six.itervalues(lookups)), queried_groups, mutations
 
   def get_txid_slice(self, txid):
     prefix = self._txid_prefix(txid)


### PR DESCRIPTION
Fix decoding of transaction metadata for fdb datastore due to unhashable key. We now use the serialized key for uniqueness of lookups.

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 1415, in _execute
    result = yield result
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/scripts/datastore.py", line 196, in post
    version_id=request.headers.get('Version'))
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/scripts/datastore.py", line 254, in remote_request
    app_id, http_request_data)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/scripts/datastore.py", line 366, in commit_transaction_request
    yield datastore_access.apply_txn_changes(app_id, txid)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 876, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/fdb/fdb_datastore.py", line 350, in apply_txn_changes
    tr, project_id, txid)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 870, in run
    value = future.result()
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 215, in result
    raise_exc_info(self._exc_info)
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 879, in run
    yielded = self.gen.send(value)
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/fdb/transactions.py", line 296, in get_metadata
    raise gen.Return(tx_dir.decode_metadata(txid, results[1:]))
  File "/usr/local/lib/python2.7/dist-packages/appscale/datastore/fdb/transactions.py", line 147, in decode_metadata
    lookups.update(self._unpack_keys(b''.join(chunks)))
TypeError: unhashable instance
```